### PR TITLE
Fix image interpolation

### DIFF
--- a/ludwig/utils/image_utils.py
+++ b/ludwig/utils/image_utils.py
@@ -18,6 +18,7 @@ from math import floor, ceil
 
 import numpy as np
 from skimage.transform import resize
+from skimage import img_as_ubyte
 
 from ludwig.constants import CROP_OR_PAD, INTERPOLATE
 
@@ -59,5 +60,5 @@ def resize_image(img, new_size_typle, resize_method):
     if resize_method == CROP_OR_PAD:
         return crop_or_pad(img, new_size_typle)
     elif resize_method == INTERPOLATE:
-        return resize(img, new_size_typle)
+        return img_as_ubyte(resize(img, new_size_typle))
     raise ValueError('Invalid image resize method: {}'.format(resize_method))


### PR DESCRIPTION
Resize method which uses interpolation produces floats. These need to be converted to uint8s before saving hdf5 files.