### PR TITLE
Move image preprocessing params to preprocessing section

### DIFF
--- a/ludwig/data/dataset_synthesyzer.py
+++ b/ludwig/data/dataset_synthesyzer.py
@@ -169,9 +169,9 @@ def generate_timeseries(feature):
 
 def generate_image(feature):
     # Read num_channels, width, height
-    num_channels = feature['num_channels']
-    width = feature['width']
-    height = feature['height']
+    num_channels = feature['preprocessing']['num_channels']
+    width = feature['preprocessing']['width']
+    height = feature['preprocessing']['height']
     image_dest_folder = feature['destination_folder']
 
     if width <= 0 or height <= 0 or num_channels < 1:

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -81,7 +81,7 @@ class ImageBaseFeature(BaseFeature):
                 )
             feature['should_resize'] = True
             set_default_value(
-                feature['preprocessing'], 
+                preprocessing_parameters, 
                 'resize_method', 
                 'crop_or_pad'
             )
@@ -130,7 +130,7 @@ class ImageBaseFeature(BaseFeature):
                     img = resize_image(
                         img,
                         (im_height, im_width),
-                        feature['preprocessing']['resize_method']
+                        preprocessing_parameters['resize_method']
                     )
                 data[feature['name']][i, :, :, :] = img
         else:
@@ -156,7 +156,7 @@ class ImageBaseFeature(BaseFeature):
                         img = resize_image(
                             img,
                             (im_height, im_width),
-                            feature['preprocessing']['resize_method'],
+                            preprocessing_parameters['resize_method'],
                         )
 
                     image_dataset[i, :im_height, :im_width, :] = img

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -58,12 +58,12 @@ class ImageBaseFeature(BaseFeature):
             preprocessing_parameters
     ):
         set_default_value(
-            feature, 
-            'in_memory', 
+            feature,
+            'in_memory',
             preprocessing_parameters['in_memory']
         )
 
-        if ('height' in preprocessing_parameters or 
+        if ('height' in preprocessing_parameters or
                 'width' in preprocessing_parameters):
             feature['should_resize'] = True
             try:
@@ -74,20 +74,19 @@ class ImageBaseFeature(BaseFeature):
                     'Image height and width must be set and have '
                     'positive integer values: ' + str(e)
                 )
-            if (preprocessing_parameters[HEIGHT] <= 0 or 
+            if (preprocessing_parameters[HEIGHT] <= 0 or
                     preprocessing_parameters[WIDTH] <= 0):
                 raise ValueError(
                     'Image height and width must be positive integers'
                 )
-            feature['should_resize'] = True
-            set_default_value(
-                preprocessing_parameters, 
-                'resize_method', 
-                'crop_or_pad'
-            )
+            if 'resize_method' in preprocessing_parameters:
+                feature['resize_method'] = (
+                    preprocessing_parameters['resize_method']
+                )
+            else:
+                feature['resize_method'] = 'crop_or_pad'
         else:
             feature['should_resize'] = False
-
 
         csv_path = os.path.dirname(os.path.abspath(dataset_df.csv))
 
@@ -130,7 +129,7 @@ class ImageBaseFeature(BaseFeature):
                     img = resize_image(
                         img,
                         (im_height, im_width),
-                        preprocessing_parameters['resize_method']
+                        feature['resize_method']
                     )
                 data[feature['name']][i, :, :, :] = img
         else:
@@ -156,7 +155,7 @@ class ImageBaseFeature(BaseFeature):
                         img = resize_image(
                             img,
                             (im_height, im_width),
-                            preprocessing_parameters['resize_method'],
+                            feature['resize_method'],
                         )
 
                     image_dataset[i, :im_height, :im_width, :] = img

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -157,7 +157,7 @@ class ImageBaseFeature(BaseFeature):
                         img = resize_image(
                             img,
                             (height, width),
-                            feature['resize_method'],
+                            preprocessing_parameters['resize_method'],
                         )
 
                     image_dataset[i, :height, :width, :] = img

--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -99,8 +99,8 @@ def save_hdf5(data_fp, data, metadata=None):
         for key, value in data.items():
             dataset = h5_file.create_dataset(key, data=value)
             if key in metadata:
-                if 'in_memory' in metadata[key]:
-                    if metadata[key]['in_memory']:
+                if 'in_memory' in metadata[key]['preprocessing']:
+                    if metadata[key]['preprocessing']['in_memory']:
                         dataset.attrs['in_memory'] = True
                     else:
                         dataset.attrs['in_memory'] = False

--- a/ludwig/utils/image_utils.py
+++ b/ludwig/utils/image_utils.py
@@ -17,8 +17,8 @@
 from math import floor, ceil
 
 import numpy as np
-from skimage.transform import resize
 from skimage import img_as_ubyte
+from skimage.transform import resize
 
 from ludwig.constants import CROP_OR_PAD, INTERPOLATE
 
@@ -57,8 +57,10 @@ def crop_or_pad(img, new_size_tuple):
 
 
 def resize_image(img, new_size_typle, resize_method):
-    if resize_method == CROP_OR_PAD:
-        return crop_or_pad(img, new_size_typle)
-    elif resize_method == INTERPOLATE:
-        return img_as_ubyte(resize(img, new_size_typle))
-    raise ValueError('Invalid image resize method: {}'.format(resize_method))
+    if tuple(img.shape[:2]) != new_size_typle:
+        if resize_method == CROP_OR_PAD:
+            return crop_or_pad(img, new_size_typle)
+        elif resize_method == INTERPOLATE:
+            return img_as_ubyte(resize(img, new_size_typle))
+        raise ValueError(
+            'Invalid image resize method: {}'.format(resize_method))

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -236,9 +236,9 @@ def test_experiment_image_inputs(csv_filename):
         "[{type: text, name: random_text, vocab_size: 100,"
         " max_len: 10, encoder: stacked_cnn}, {type: numerical,"
         " name: random_number}, "
-        "{type: image, name: random_image, width: 10, in_memory: ${in_memory},"
-        " height: 10, num_channels: 3, encoder: ${encoder},"
-        " resnet_size: 8, destination_folder: ${folder}}]")
+        "{type: image, name: random_image, encoder: ${encoder},"
+        "preprocessing: {in_memory: ${in_memory}, height: 10, width: 10, "
+        "num_channels: 3}, resnet_size: 8, destination_folder: ${folder}}]")
 
     # Resnet encoder
     input_features = input_features_template.substitute(
@@ -431,9 +431,9 @@ def test_movie_rating_prediction(csv_filename):
 def test_example_with_set_output(csv_filename):
     image_dest_folder = os.path.join(os.getcwd(), 'generated_images')
     input_features_template = Template(
-        '[{name: image_path, type: image, encoder: ${encoder}, width: 10, '
-        'height: 10, num_channels: 3, resnet_size: 8, destination_folder: '
-        '${folder}}]')
+        '[{name: image_path, type: image, encoder: ${encoder}, preprocessing: '
+        '{width: 10, height: 10, num_channels: 3}, resnet_size: 8, '
+        'destination_folder: ${folder}}]')
 
     output_features = "[ {name: tags, type: set, max_len: 5, vocab_size: 10}]"
 
@@ -456,10 +456,11 @@ def test_example_with_set_output(csv_filename):
 def test_visual_question_answering(csv_filename):
     image_dest_folder = os.path.join(os.getcwd(), 'generated_images')
     input_features = Template(
-        '[{name: image_path, type: image, encoder: stacked_cnn, width: 10, '
-        'height: 10, num_channels: 3, resnet_size: 8, destination_folder: '
-        '${folder}}, {name: question, type: text, vocab_size: 20, max_len: 10,'
-        'encoder: parallel_cnn, level: word}]').substitute(
+        '[{name: image_path, type: image, encoder: stacked_cnn, preprocessing:'
+        ' {width: 10, height: 10, num_channels: 3}, resnet_size: 8, '
+        'destination_folder: ${folder}}, {name: question, type: text, '
+        'vocab_size: 20, max_len: 10,encoder: parallel_cnn, '
+        'level: word}]').substitute(
         folder=image_dest_folder)
 
     output_features = "[ {name: answer, type: sequence, max_len: 5, " \


### PR DESCRIPTION
Moving preprocessing parameters into preprocessing yaml section.

Test:
python -m ludwig.experiment --data_csv ~/Documents/ludwig/datasets/dog_breeds/dog_breeds.csv --model_definition '{input_features: [{name: image_path, type: image, encoder: stacked_cnn, num_filters: 3, num_conv_layers: 3, preprocessing: {height: 100, width: 100, resize_method: interpolate}}], output_features: [{name: label, type: category}]}'