### PR TITLE
Remove outdated note that TensorFlow does not work with Python 3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ sudo apt install python3  # on ubuntu
 brew install python3      # on mac
 ```
 
-At the time of writing this document, TensorFlow is not compatible with Python 3.7, so the recommended version of Python for Ludwig is 3.6.
 You may want to use a virtual environment to maintain an isolated [Python environment](https://docs.python-guide.org/dev/virtualenvs/).
 
 In order to install Ludwig just run:

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you don’t have Python 3 installed, install it by running:
 sudo apt install python3  # on ubuntu
 brew install python3      # on mac
 ```
-
+If you are using Python 3.7, you have to use `tensorflow>=1.13.1` as previous versions do not support it.
 You may want to use a virtual environment to maintain an isolated [Python environment](https://docs.python-guide.org/dev/virtualenvs/).
 
 In order to install Ludwig just run:


### PR DESCRIPTION
Since [version 1.13.1](
https://github.com/tensorflow/tensorflow/releases/tag/v1.13.1), TensorFlow now supports Python 3.7 on all operating systems. Consequently, the note to use Python 3.6 as the recommended version can be removed.