### PR TITLE
fixed preprocessing_defaults error in bag_feature.py

### DIFF
--- a/ludwig/features/bag_feature.py
+++ b/ludwig/features/bag_feature.py
@@ -36,8 +36,8 @@ class BagBaseFeature(BaseFeature):
 
     preprocessing_defaults = {
         'format': 'space',
-        'most_common': False,
-        'lowercase': 10000,
+        'most_common': 10000,
+        'lowercase': False,
         'missing_value_strategy': FILL_WITH_CONST,
         'fill_value': ''
     }


### PR DESCRIPTION
'preprocessing_defaults' in bag_feature.py has error.

'most_common' should be **10000** and 'lowercase' should be **False**