### PR TITLE
Fix KeyError when running via initialize_model() for image features.

### DIFF
--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -235,7 +235,7 @@ class ImageInputFeature(ImageBaseFeature, InputFeature):
         for dim in ['height', 'width', 'num_channels']:
             input_feature[dim] = feature_metadata['preprocessing'][dim]
         input_feature['data_hdf5_fp'] = (
-            kwargs['model_definition']['data_hdf5_fp']
+            kwargs['model_definition'].get('data_hdf5_fp', None)
         )
 
     @staticmethod


### PR DESCRIPTION
Training a model using `model.initialize_model(); model.train_online();` fails for image inputs.

As far as I understand, that field (`model_definition['data_hdf5_fp']`) is only created in `preprocess_for_training`, which only is called from `model.train()`. This change fixes the resulting KeyError, however it feels symptomatic. It would require a deeper knowledge of the code base than what I have at this time to ensure preprocessing is done the same in `model.train()` and `model.initialize_model()`