### PR TITLE
Adds some sanity checks for model definition and shows helpful error messages

### DIFF
--- a/ludwig/utils/defaults.py
+++ b/ludwig/utils/defaults.py
@@ -131,7 +131,58 @@ def get_default_optimizer_params(optimizer_type):
         raise ValueError('Incorrect optimizer type: ' + optimizer_type)
 
 
+def _perform_sanity_checks(model_definition):
+    assert 'input_features' in model_definition, (
+        'Model definition does not define any input features'
+    )
+
+    assert 'output_features' in model_definition, (
+        'Model definition does not define any output features'
+    )
+
+    assert isinstance(model_definition['input_features'], list), (
+        'Ludwig expects input features in a list. Check your model '
+        'definition format'
+    )
+
+    assert isinstance(model_definition['output_features'], list), (
+        'Ludwig expects output features in a list. Check your model '
+        'definition format'
+    )
+
+    assert len(model_definition['input_features']) > 0, (
+        'Model definition needs to have at least one input feature'
+    )
+
+    assert len(model_definition['output_features']) > 0, (
+        'Model definition needs to have at least one output feature'
+    )
+
+    if 'training' in model_definition:
+        assert isinstance(model_definition['training'], dict), (
+            'There is an issue while reading the training section of the ' 
+            'model definition. The parameters are expected to be'
+            'read as a dictionary. Please check your model definition format.'
+        )
+
+    if 'preprocessing' in model_definition:
+        assert isinstance(model_definition['preprocessing'], dict), (
+            'There is an issue while reading the preprocessing section of the ' 
+            'model definition. The parameters are expected to be read'
+            'as a dictionary. Please check your model definition format.'
+        )
+
+    if 'combiner' in model_definition:
+        assert isinstance(model_definition['combiner'], dict), (
+            'There is an issue while reading the combiner section of the ' 
+            'model definition. The parameters are expected to be read'
+            'as a dictionary. Please check your model definition format.'
+        )
+
+
 def merge_with_defaults(model_definition):
+    _perform_sanity_checks(model_definition)
+
     # ===== Preprocessing =====
     model_definition['preprocessing'] = merge_dict(
         default_preprocessing_parameters,
@@ -158,9 +209,6 @@ def merge_with_defaults(model_definition):
     for param in default_training_params:
         set_default_value(model_definition['training'], param,
                           default_training_params[param])
-
-    if len(model_definition['output_features']) == 0:
-        raise ValueError('No output features are defined')
 
     set_default_value(
         model_definition['training'],


### PR DESCRIPTION
- Performs some basic sanity checks on the model definition: if it has some input, output features, wether ludwig is able to read the different sections etc. 
- several basic issues related to yaml formatting would be raised before the data processing or model training starts would be avoided.

