### PR TITLE
Fixes for typos and example inconsistencies in the documentation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,8 +8,8 @@ Please provide the following:
 
 # Documentation Pull Requests
 
-Note that the documentation HTML files are a in `docs/` while the Markdown sources are in `mkdocs/docs`.
+Note that the documentation HTML files are in `docs/` while the Markdown sources are in `mkdocs/docs`.
 
-If you are proposing a modification to the documentation you should change only the Markdown files, then recreate the documentation as examplained in the `mkdocs/README.md` file with `mkdocs build`, which will create the HTML files automatically, and only after this create a commit.
+If you are proposing a modification to the documentation you should change only the Markdown files, then recreate the documentation as explained in the `mkdocs/README.md` file with `mkdocs build`, which will create the HTML files automatically, and only after this create a commit.
 
-`API.md` is automatically generated from the docstrings in the code, so if you want to change something in that file, first modify `ludwig/api.py` docstring, then run `mkdocs/code_docs_autogen.py`, which will create `mkdocs/docs/api.md` and then finally run `mkdocs build` which will generate the HTML in `docs/`.
+`api.md` is automatically generated from the docstrings in the code, so if you want to change something in that file, first modify `ludwig/api.py` docstring, then run `mkdocs/code_docs_autogen.py`, which will create `mkdocs/docs/api.md` and then finally run `mkdocs build` which will generate the HTML in `docs/`.

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -657,6 +657,7 @@ this function if you don't use <code>train_online</code>.</p>
 <hr />
 <h3 id="load">load<a class="headerlink" href="#load" title="Permanent link">&para;</a></h3>
 <div class="codehilite"><pre><span></span><span class="n">load</span><span class="p">(</span>
+  <span class="n">model_dir</span><span class="p">,</span>
   <span class="n">logging_level</span><span class="o">=</span><span class="mi">40</span>
 <span class="p">)</span>
 </pre></div>

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -584,7 +584,7 @@
 </pre></div>
 
 
-<p>If you have already trained a model you cal load it and use it to predict</p>
+<p>If you have already trained a model you can load it and use it to predict</p>
 <div class="codehilite"><pre><span></span><span class="n">ludwig_model</span> <span class="o">=</span> <span class="n">LudwigModel</span><span class="o">.</span><span class="n">load</span><span class="p">(</span><span class="n">model_dir</span><span class="p">)</span>
 </pre></div>
 

--- a/docs/examples/index.html
+++ b/docs/examples/index.html
@@ -1073,8 +1073,8 @@ For each task we show an example dataset and a sample model definition that can 
 <table>
 <thead>
 <tr>
-<th>image_1</th>
-<th>image_2</th>
+<th>image_path_1</th>
+<th>image_path_2</th>
 <th>similarity</th>
 </tr>
 </thead>
@@ -1112,7 +1112,7 @@ For each task we show an example dataset and a sample model definition that can 
                         class="l l-Scalar l-Scalar-Plain">input_features</span><span class="p p-Indicator">:</span>
     <span class="p p-Indicator">-</span>
         <span class="l l-Scalar l-Scalar-Plain">name</span><span class="p p-Indicator">:</span> <span
-                            class="l l-Scalar l-Scalar-Plain">image_1</span>
+                            class="l l-Scalar l-Scalar-Plain">image_path_1</span>
         <span class="l l-Scalar l-Scalar-Plain">type</span><span class="p p-Indicator">:</span> <span
                             class="l l-Scalar l-Scalar-Plain">image</span>
         <span class="l l-Scalar l-Scalar-Plain">encoder</span><span class="p p-Indicator">:</span> <span
@@ -1125,7 +1125,7 @@ For each task we show an example dataset and a sample model definition that can 
                             class="l l-Scalar l-Scalar-Plain">28</span>
     <span class="p p-Indicator">-</span>
         <span class="l l-Scalar l-Scalar-Plain">name</span><span class="p p-Indicator">:</span> <span
-                            class="l l-Scalar l-Scalar-Plain">image_2</span>
+                            class="l l-Scalar l-Scalar-Plain">image_path_2</span>
         <span class="l l-Scalar l-Scalar-Plain">type</span><span class="p p-Indicator">:</span> <span
                             class="l l-Scalar l-Scalar-Plain">image</span>
         <span class="l l-Scalar l-Scalar-Plain">encoder</span><span class="p p-Indicator">:</span> <span

--- a/docs/user_guide/index.html
+++ b/docs/user_guide/index.html
@@ -3669,7 +3669,7 @@ Inputs are of size <code>b</code> while outputs are fo size <code>b x h</code> w
 <h3 id="sequence-features">Sequence Features<a class="headerlink" href="#sequence-features" title="Permanent link">&para;</a></h3>
 <h4 id="sequence-features-preprocessing">Sequence Features Preprocessing<a class="headerlink" href="#sequence-features-preprocessing" title="Permanent link">&para;</a></h4>
 <p>Sequence features are transformed into an integer valued matrix of size <code>n x l</code> (where <code>n</code> is the size of the dataset and <code>l</code> is the minimum of the length of the longest sequence and a <code>sequence_length_limit</code> parameter) and added to HDF5 with a key that reflects the name of column in the CSV.
-The way sets are mapped into integers consists in first using a formatter to map from strings to sequences of tokens (by default this is done by splitting on spaces).
+The way sequences are mapped into integers consists in first using a formatter to map from strings to sequences of tokens (by default this is done by splitting on spaces).
 Then a a dictionary of all the different token strings present in the column of the CSV is collected, then they are ranked by frequency and an increasing integer ID is assigned to them from the most frequent to the most rare (with 0 being assigned to <code>&lt;PAD&gt;</code> used for padding and 1 assigned to <code>&lt;UNK&gt;</code> item).
 The column name is added to the JSON file, with an associated dictionary containing
 1. the mapping from integer to string (<code>idx2str</code>)

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -99,7 +99,7 @@ class LudwigModel:
     train_stats = ludwig_model.train(data_df=dataframe)
     ```
 
-    If you have already trained a model you cal load it and use it to predict
+    If you have already trained a model you can load it and use it to predict
 
     ```python
     ludwig_model = LudwigModel.load(model_dir)

--- a/mkdocs/docs/api.md
+++ b/mkdocs/docs/api.md
@@ -138,6 +138,7 @@ __Inputs__
 
 ```python
 load(
+  model_dir,
   logging_level=40
 )
 ```

--- a/mkdocs/docs/api.md
+++ b/mkdocs/docs/api.md
@@ -47,7 +47,7 @@ or
 train_stats = ludwig_model.train(data_df=dataframe)
 ```
 
-If you have already trained a model you cal load it and use it to predict
+If you have already trained a model you can load it and use it to predict
 
 ```python
 ludwig_model = LudwigModel.load(model_dir)

--- a/mkdocs/docs/examples.md
+++ b/mkdocs/docs/examples.md
@@ -291,7 +291,7 @@ One-shot Learning with Siamese Networks
 
 This example can be considered a simple baseline for one-shot learning on the [Omniglot](https://github.com/brendenlake/omniglot) dataset. The task is, given two images of two handwritten characters, recognize if they are two instances of the same character or not.
 
-| image_1                          |   image_2                        | similarity |
+| image_path_1                     |   image_path_2                   | similarity |
 |----------------------------------|----------------------------------|------------|
 | balinese/character01/0108_13.png | balinese/character01/0108_18.png | 1          |
 | balinese/character01/0108_13.png | balinese/character08/0115_12.png | 0          |
@@ -309,14 +309,14 @@ With `model_definition.yaml`:
 ```yaml
 input_features:
     -
-        name: image_1
+        name: image_path_1
         type: image
         encoder: stacked_cnn
         resize_image: true
         width: 28
         height: 28
     -
-        name: image_2
+        name: image_path_2
         type: image
         encoder: stacked_cnn
         resize_image: true

--- a/mkdocs/docs/user_guide.md
+++ b/mkdocs/docs/user_guide.md
@@ -1357,7 +1357,7 @@ Sequence Features
 ### Sequence Features Preprocessing
 
 Sequence features are transformed into an integer valued matrix of size `n x l` (where `n` is the size of the dataset and `l` is the minimum of the length of the longest sequence and a `sequence_length_limit` parameter) and added to HDF5 with a key that reflects the name of column in the CSV.
-The way sets are mapped into integers consists in first using a formatter to map from strings to sequences of tokens (by default this is done by splitting on spaces).
+The way sequences are mapped into integers consists in first using a formatter to map from strings to sequences of tokens (by default this is done by splitting on spaces).
 Then a a dictionary of all the different token strings present in the column of the CSV is collected, then they are ranked by frequency and an increasing integer ID is assigned to them from the most frequent to the most rare (with 0 being assigned to `<PAD>` used for padding and 1 assigned to `<UNK>` item).
 The column name is added to the JSON file, with an associated dictionary containing
 1. the mapping from integer to string (`idx2str`)


### PR DESCRIPTION
Overview:
- Fixes for typos and example inconsistencies in the documentation
  - Fix typo in API docs
  - Fix incorrect reference to "sets" with "sequences" in the user guide
  - Fix column name references in "One-shot Learning with Siamese Networks" example
  - Fix typos in the pull request template