### PR TITLE
Fixes two bugs introduced while migrating to tensorflow 1.13

### DIFF
--- a/ludwig/models/modules/loss_modules.py
+++ b/ludwig/models/modules/loss_modules.py
@@ -109,8 +109,9 @@ def cross_entropy_sequence_loss(logits, targets, sequence_length):
             logits=logits, labels=targets)
         # Mask out the losses we don't care about
         loss_mask = tf.sequence_mask(
-            tf.cast(sequence_length, tf.int32), tf.cast(tf.shape(targets)[1],
-            tf.int32))
+            tf.cast(sequence_length, tf.int32),
+            tf.cast(tf.shape(targets)[1], tf.int32)
+        )
         losses = losses * tf.cast(loss_mask, tf.float32)
         return losses
 

--- a/ludwig/models/modules/loss_modules.py
+++ b/ludwig/models/modules/loss_modules.py
@@ -109,8 +109,8 @@ def cross_entropy_sequence_loss(logits, targets, sequence_length):
             logits=logits, labels=targets)
         # Mask out the losses we don't care about
         loss_mask = tf.sequence_mask(
-            tf.cast(sequence_length, tf.int32), tf.cast(tf.shape(targets)[1]),
-            tf.int32)
+            tf.cast(sequence_length, tf.int32), tf.cast(tf.shape(targets)[1],
+            tf.int32))
         losses = losses * tf.cast(loss_mask, tf.float32)
         return losses
 

--- a/ludwig/utils/tf_utils.py
+++ b/ludwig/utils/tf_utils.py
@@ -36,7 +36,7 @@ def to_sparse(tensor, lengths, max_length):
     mask = tf.sequence_mask(lengths, max_length)
     indices = tf.cast(tf.where(tf.equal(mask, True)), tf.int64)
     values = tf.cast(tf.boolean_mask(tensor, mask), tf.int32)
-    shape = tf.cast(tf.shape(tensor), tf.int32)
+    shape = tf.cast(tf.shape(tensor), tf.int64)
     return tf.SparseTensor(indices, values, shape)
 
 


### PR DESCRIPTION
- Fixes two bugs introduced while migrating to tensorflow 1.13

1. Typo in loss_modules
2. [tf.SparseTensor](https://www.tensorflow.org/api_docs/python/tf/sparse/SparseTensor) expects the shape to be of type tf.int64 (we were using tf.int32)

<img width="491" alt="Screen Shot 2019-03-26 at 2 41 24 PM" src="https://user-images.githubusercontent.com/17418219/55035486-52f61c80-4fd5-11e9-9d92-680164c04ee0.png">


Tests:
All tests pass