### PR TITLE
Fix unwanted creation of hdf5 files when running ludwig.predict on images

### DIFF
--- a/ludwig/data/dataset.py
+++ b/ludwig/data/dataset.py
@@ -40,9 +40,10 @@ class Dataset:
         if idx is None:
             idx = range(self.size)
         if (self.data_hdf5_fp is None or
-                'in_memory' not in self.features[feature_name]):
+                'preprocessing' not in self.features[feature_name] or
+                'in_memory' not in self.features[feature_name]['preprocessing']):
             return self.dataset[feature_name][idx]
-        if self.features[feature_name]['in_memory']:
+        if self.features[feature_name]['preprocessing']['in_memory']:
             return self.dataset[feature_name][idx]
 
         sub_batch = self.dataset[feature_name][idx]

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -630,7 +630,6 @@ def preprocess_for_prediction(
         if 'preprocessing' in input_feature:
             if 'in_memory' in input_feature['preprocessing']:
                 if not input_feature['preprocessing']['in_memory']:
-                    print('==== OVERRIDING IN MEMORY FLAG ====')
                     input_feature['preprocessing']['in_memory'] = True
     preprocessing_params = merge_dict(
         default_preprocessing_parameters,

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -630,6 +630,11 @@ def preprocess_for_prediction(
         if 'preprocessing' in input_feature:
             if 'in_memory' in input_feature['preprocessing']:
                 if not input_feature['preprocessing']['in_memory']:
+                    logging.warning(
+                        'WARNING: When running predict in_memory flag should '
+                        'be true. Overriding and setting it to true for '
+                        'feature <{}>'.format(input_feature['name'])
+                    )
                     input_feature['preprocessing']['in_memory'] = True
     preprocessing_params = merge_dict(
         default_preprocessing_parameters,

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -626,6 +626,12 @@ def preprocess_for_prediction(
     model_definition = load_json(
         os.path.join(model_path, MODEL_HYPERPARAMETERS_FILE_NAME)
     )
+    for input_feature in model_definition['input_features']:
+        if 'preprocessing' in input_feature:
+            if 'in_memory' in input_feature['preprocessing']:
+                if not input_feature['preprocessing']['in_memory']:
+                    print('==== OVERRIDING IN MEMORY FLAG ====')
+                    input_feature['preprocessing']['in_memory'] = True
     preprocessing_params = merge_dict(
         default_preprocessing_parameters,
         model_definition['preprocessing']

--- a/ludwig/experiment.py
+++ b/ludwig/experiment.py
@@ -252,6 +252,7 @@ def experiment(
             'preprocessing'],
         random_seed=random_seed
     )
+    print("=== train ===")
     if is_on_master():
         logging.info('Training set: {0}'.format(training_set.size))
         if validation_set is not None:

--- a/ludwig/experiment.py
+++ b/ludwig/experiment.py
@@ -252,7 +252,6 @@ def experiment(
             'preprocessing'],
         random_seed=random_seed
     )
-    print("=== train ===")
     if is_on_master():
         logging.info('Training set: {0}'.format(training_set.size))
         if validation_set is not None:

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -58,9 +58,6 @@ class ImageBaseFeature(BaseFeature):
             metadata,
             preprocessing_parameters
     ):
-        print("=== add feature data ===")
-        # if 'preprocessing' not in feature:
-        #     feature['preprocessing'] = {}
         set_default_value(
             feature['preprocessing'],
             'in_memory',
@@ -131,7 +128,6 @@ class ImageBaseFeature(BaseFeature):
             'num_channels'] = num_channels
 
         if feature['preprocessing']['in_memory']:
-            print('=== in memory ===')
             data[feature['name']] = np.empty(
                 (num_images, height, width, num_channels),
                 dtype=np.int8
@@ -156,7 +152,6 @@ class ImageBaseFeature(BaseFeature):
                     img = img[:, :, :num_channels]
                 data[feature['name']][i, :, :, :] = img
         else:
-            print('=== not in memory ===')
             data_fp = os.path.splitext(dataset_df.csv)[0] + '.hdf5'
             mode = 'w'
             if os.path.isfile(data_fp):

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -58,8 +58,11 @@ class ImageBaseFeature(BaseFeature):
             metadata,
             preprocessing_parameters
     ):
+        print("=== add feature data ===")
+        # if 'preprocessing' not in feature:
+        #     feature['preprocessing'] = {}
         set_default_value(
-            feature,
+            feature['preprocessing'],
             'in_memory',
             preprocessing_parameters['in_memory']
         )
@@ -127,7 +130,8 @@ class ImageBaseFeature(BaseFeature):
         metadata[feature['name']]['preprocessing'][
             'num_channels'] = num_channels
 
-        if feature['in_memory']:
+        if feature['preprocessing']['in_memory']:
+            print('=== in memory ===')
             data[feature['name']] = np.empty(
                 (num_images, height, width, num_channels),
                 dtype=np.int8
@@ -152,6 +156,7 @@ class ImageBaseFeature(BaseFeature):
                     img = img[:, :, :num_channels]
                 data[feature['name']][i, :, :, :] = img
         else:
+            print('=== not in memory ===')
             data_fp = os.path.splitext(dataset_df.csv)[0] + '.hdf5'
             mode = 'w'
             if os.path.isfile(data_fp):
@@ -190,8 +195,6 @@ class ImageInputFeature(ImageBaseFeature, InputFeature):
         self.height = 0
         self.width = 0
         self.num_channels = 0
-
-        self.in_memory = True
 
         self.encoder = 'stacked_cnn'
 
@@ -255,6 +258,7 @@ class ImageInputFeature(ImageBaseFeature, InputFeature):
     @staticmethod
     def populate_defaults(input_feature):
         set_default_value(input_feature, 'tied_weights', None)
+        set_default_value(input_feature, 'preprocessing', {})
 
 
 image_encoder_registry = {


### PR DESCRIPTION
Also refactoring to keep 'in_memory' flag in preprocessing parameters everywhere for consistency.

Test plan:

python -m ludwig.predict --only_predictions --data_csv signs_dataset_vali.csv --model_path results/experiment_run_635/model

Made sure hdf5 files are not created.

+ integration tests: python -m pytest
