### PR TITLE
Add support for contrib flags, featuring --comet

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -35,6 +35,7 @@ import pandas as pd
 import yaml
 from pprint import pformat
 
+import ludwig.contrib
 from ludwig.data.dataset import Dataset
 from ludwig.data.postprocessing import postprocess_df, postprocess
 from ludwig.data.preprocessing import build_data

--- a/ludwig/contrib.py
+++ b/ludwig/contrib.py
@@ -1,0 +1,55 @@
+# coding=utf-8
+# Copyright (c) 2019 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""
+Module for handling contributed support. Loaded first
+to handle items that need to be setup before core
+modules, like tensorflow.
+"""
+
+import sys
+import logging
+
+## Contributors, add functions here:
+
+def enable_comet_support():
+    """
+    Enable Third-party support from comet.ml
+    Allows experiment tracking, visualization, and
+    management.
+    """
+    try:
+        import comet_ml
+        comet_ml.Experiment()
+    except:
+        logging.error("Ignored --comet " +
+                      "See: https://www.comet.ml/" +
+                      "docs/python-sdk/getting-started/ " +
+                      "for more information")
+
+
+## Contributors, call functions here:
+
+## NOTE: Other contribs may need more sophisticated
+##       arg parsing.
+for arg in list(sys.argv):
+    ## First, check for your flag(s):
+    if arg == "--comet":
+        ## Second, call your function:
+        enable_comet_support()
+        ## Third, clean up and remove your flag(s)
+        sys.argv.remove("--comet")
+    ## elif ... other flags


### PR DESCRIPTION
Ludwig is an excellent tool! We would love to be able to track, visualize, and manage Ludwig experiments in comet.ml.

We need a method of injecting imports for approved, third-party libraries into the Ludwig pipeline.

This PR adds a general method for third-parties to integrate their projects, at least as imports before the core libraries are imported. More sophisticated third-party connections could be made through hooks and callbacks. Such complexities are not implemented here. 

This PR also adds the flag `--comet` as a working example of such a third-party module. To use:

```shell
ludwig --comet 
``` 

This is useful while training. For example, the following code:

```shell
export COMET_PROJECT_NAME=ludwig 
ludwig experiment --comet \
  --data_csv reuters-allcats.csv \
  --model_definition_file model_definition.yaml
```
created the following: 

https://www.comet.ml/dsblank/ludwig/

If you can think of a less intrusive manner of inserting such code into the pipeline, please let us know.