### PR TITLE
ContribClass instance in registry and generalize commands

### DIFF
--- a/ludwig/cli.py
+++ b/ludwig/cli.py
@@ -23,6 +23,7 @@ from ludwig import predict
 from ludwig import train
 from ludwig import visualize
 
+import ludwig.contrib
 
 class CLI(object):
     """CLI describes a command line interface for interacting with Ludwig, there
@@ -64,21 +65,27 @@ Available sub-commands:
         getattr(self, args.command)()
 
     def experiment(self):
+        ludwig.contrib.contrib_command("experiment")
         experiment.cli(sys.argv[2:])
 
     def train(self):
+        ludwig.contrib.contrib_command("train")
         train.cli(sys.argv[2:])
 
     def predict(self):
+        ludwig.contrib.contrib_command("predict")
         predict.cli(sys.argv[2:])
 
     def visualize(self):
+        ludwig.contrib.contrib_command("visualize")
         visualize.cli(sys.argv[2:])
 
     def collect_weights(self):
+        ludwig.contrib.contrib_command("collect_weights")
         collect.cli_collect_weights(sys.argv[2:])
 
     def collect_activations(self):
+        ludwig.contrib.contrib_command("collect_activations")
         collect.cli_collect_activations(sys.argv[2:])
 
 


### PR DESCRIPTION
This PR:

* creates an instance of the ContribClass from ContribClass.import_call and saves it in registry
* calls methods of instance, like ContribInstance.train(*args, **kwargs)
* For Comet, it uses a local config file to pass experiment_key down the pipeline

TODO: need to call contrib_command("METHOD_NAME") for places to add hooks.