### PR TITLE
fix: Avoid using signal when not on main thread

### DIFF
--- a/ludwig/models/model.py
+++ b/ludwig/models/model.py
@@ -28,6 +28,7 @@ import re
 import signal
 import sys
 import time
+import threading
 from collections import OrderedDict
 
 import numpy as np
@@ -384,7 +385,9 @@ class Model:
         self.epochs = epochs
         digits_per_epochs = len(str(self.epochs))
         self.received_sigint = False
-        signal.signal(signal.SIGINT, self.set_epochs_to_1_or_quit)
+        # Only use signals when on the main thread to avoid issues with CherryPy: https://github.com/uber/ludwig/issues/286
+        if threading.current_thread() == threading.main_thread():
+            signal.signal(signal.SIGINT, self.set_epochs_to_1_or_quit)
         should_validate = validation_set is not None and validation_set.size > 0
         if eval_batch_size < 1:
             eval_batch_size = batch_size


### PR DESCRIPTION
# Code Pull Requests

Please provide the following:

* a clear explanation of what your code does
    * This change makes sure no signals are fired if the ludwig code isn't called from the main thread. This should avoid errors when using ludwig inside a route inside a webservice like CherryPy
* if applicable, a reference to an issue
    * https://github.com/uber/ludwig/issues/286
- a reproducible test for your PR (code, model definition and data sample)
    * clone this repo: https://gitlab.com/bertyhell/woody-puzzle-solver
    * checkout this commit: https://gitlab.com/bertyhell/woody-puzzle-solver/blob/50f84fde9db8f4aa80c86fb3d7fb8ba026172163/src
    * Run this file in python: https://gitlab.com/bertyhell/woody-puzzle-solver/blob/50f84fde9db8f4aa80c86fb3d7fb8ba026172163/src/server/service.py
    * Make post request: 
    ```
    curl -X POST \
  http://localhost:8080/train \
  -H 'Content-Type: application/json' \
  -H 'Postman-Token: 8a9abce5-f728-4f6e-99f7-99492677e419' \
  -H 'cache-control: no-cache' \
  -d '{"definitions" : {"input_features": [],	"output_features": []}, "training_samples":[]}'
    ```