### PR TITLE
Refactors experiment.py, api.py to use the full_train method from train.py

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -54,7 +54,7 @@ from ludwig.models.model import Model
 from ludwig.models.model import load_model_and_definition
 from ludwig.models.modules.measure_modules import get_best_function
 from ludwig.predict import calculate_overall_stats
-from ludwig.train import get_experiment_dir_name
+from ludwig.train import get_experiment_dir_name, full_train
 from ludwig.train import get_file_names
 from ludwig.train import train
 from ludwig.train import update_model_definition_with_metadata
@@ -283,6 +283,7 @@ class LudwigModel:
             output_directory='results',
             gpus=None,
             gpu_fraction=1.0,
+            use_horovod=False,
             random_seed=42,
             logging_level=logging.ERROR,
             debug=False,
@@ -401,31 +402,12 @@ class LudwigModel:
         if logging_level in {logging.WARNING, logging.ERROR, logging.CRITICAL}:
             set_disable_progressbar(True)
 
-        # setup directories and file names
-        experiment_dir_name = None
-        if model_resume_path is not None:
-            if os.path.exists(model_resume_path):
-                experiment_dir_name = model_resume_path
-            else:
-                logging.info(
-                    'Model resume path does not exists,'
-                    ' starting training from scratch'
-                )
-                model_resume_path = None
-        if model_resume_path is None:
-            experiment_dir_name = get_experiment_dir_name(
-                output_directory,
-                '',
-                model_name
-            )
-        description_fn, training_stats_fn, model_dir = get_file_names(
-            experiment_dir_name
-        )
-
-        # save description
-        description = get_experiment_description(
+        self.model, preprocessed_data, _, train_stats = full_train(
             self.model_definition,
-            dataset_type,
+            data_df=data_df,
+            data_train_df=data_train_df,
+            data_validation_df=data_validation_df,
+            data_test_df=data_test_df,
             data_csv=data_csv,
             data_train_csv=data_train_csv,
             data_validation_csv=data_validation_csv,
@@ -434,152 +416,24 @@ class LudwigModel:
             data_train_hdf5=data_train_hdf5,
             data_validation_hdf5=data_validation_hdf5,
             data_test_hdf5=data_test_hdf5,
-            metadata_json=train_set_metadata_json,
-            random_seed=random_seed)
-
-        save_json(description_fn, description)
-
-        # print description
-        logging.info('Model name: {}'.format(model_name))
-        logging.info('Output path: {}'.format(experiment_dir_name))
-        logging.info('\n')
-        for key, value in description.items():
-            logging.info('{0}: {1}'.format(key, pformat(value, indent=4)))
-        logging.info('\n')
-
-        # preprocess
-        if data_df is not None or data_train_df is not None:
-            (
-                training_set,
-                validation_set,
-                test_set,
-                train_set_metadata
-            ) = preprocess_for_training(
-                self.model_definition,
-                dataset_type,
-                data_df=data_df,
-                data_train_df=data_train_df,
-                data_validation_df=data_validation_df,
-                data_test_df=data_test_df,
-                train_set_metadata_json=train_set_metadata_json,
-                skip_save_processed_input=True,
-                preprocessing_params=
-                self.model_definition['preprocessing'],
-                random_seed=random_seed)
-        else:
-            (
-                training_set,
-                validation_set,
-                test_set,
-                train_set_metadata
-            ) = preprocess_for_training(
-                self.model_definition,
-                dataset_type,
-                data_csv=data_csv,
-                data_train_csv=data_train_csv,
-                data_validation_csv=data_validation_csv,
-                data_test_csv=data_test_csv,
-                data_hdf5=data_hdf5,
-                data_train_hdf5=data_train_hdf5,
-                data_validation_hdf5=data_validation_hdf5,
-                data_test_hdf5=data_test_hdf5,
-                train_set_metadata_json=train_set_metadata_json,
-                skip_save_processed_input=skip_save_processed_input,
-                preprocessing_params=
-                self.model_definition['preprocessing'],
-                random_seed=random_seed)
-
-        logging.info('Training set: {0}'.format(training_set.size))
-        if validation_set is not None:
-            logging.info('Validation set: {0}'.format(validation_set.size))
-        if test_set is not None:
-            logging.info('Test set: {0}'.format(test_set.size))
-
-        # update model definition with metadata properties
-        update_model_definition_with_metadata(
-            self.model_definition,
-            train_set_metadata
-        )
-
-        if not skip_save_model:
-            os.makedirs(model_dir, exist_ok=True)
-            train_set_metadata_path = os.path.join(
-                model_dir,
-                TRAIN_SET_METADATA_FILE_NAME
-            )
-            save_json(train_set_metadata_path, train_set_metadata)
-
-        # run the experiment
-        model, result = train(
-            training_set=training_set,
-            validation_set=validation_set,
-            test_set=test_set,
-            model_definition=self.model_definition,
-            save_path=model_dir,
+            train_set_metadata_json=train_set_metadata_json,
+            experiment_name='api_experiment',
+            model_name=model_name,
             model_load_path=model_load_path,
-            resume=model_resume_path is not None,
+            model_resume_path=model_resume_path,
             skip_save_model=skip_save_model,
             skip_save_progress=skip_save_progress,
             skip_save_log=skip_save_log,
+            skip_save_processed_input=skip_save_processed_input,
+            output_directory=output_directory,
             gpus=gpus,
             gpu_fraction=gpu_fraction,
+            use_horovod=use_horovod,
             random_seed=random_seed,
-            debug=debug
+            debug=debug,
         )
 
-        train_trainset_stats, train_valisest_stats, train_testset_stats = result
-        train_stats = {
-            'train': train_trainset_stats,
-            'validation': train_valisest_stats,
-            'test': train_testset_stats
-        }
-
-        # save training and test statistics
-        save_json(training_stats_fn, train_stats)
-
-        # grab the results of the model with highest validation test performance
-        md_training = self.model_definition['training']
-        validation_field = md_training['validation_field']
-        validation_measure = md_training['validation_measure']
-        validation_field_result = train_valisest_stats[validation_field]
-
-        best_function = get_best_function(validation_measure)
-
-        # print results of the model with highest validation test performance
-        if validation_set is not None:
-            # max or min depending on the measure
-            epoch_best_vali_measure, best_vali_measure = best_function(
-                enumerate(validation_field_result[validation_measure]),
-                key=lambda pair: pair[1]
-            )
-            logging.info('Best validation model epoch: {0}'.format(
-                epoch_best_vali_measure + 1)
-            )
-            logging.info(
-                'Best validation model {0} on validation set {1}: {2}'.format(
-                    validation_measure,
-                    validation_field,
-                    best_vali_measure)
-            )
-
-            if test_set is not None:
-                best_vali_measure_epoch_test_measure = train_testset_stats[
-                    validation_field
-                ][validation_measure][epoch_best_vali_measure]
-                logging.info(
-                    'Best validation model {0} on test set {1}: {2}'.format(
-                        validation_measure,
-                        validation_field,
-                        best_vali_measure_epoch_test_measure
-                    )
-                )
-
-        logging.info('Finished: {0}'.format(model_name))
-        logging.info('Saved to {0}:'.format(experiment_dir_name))
-
-        # set parameters
-        self.model = model
-        self.train_set_metadata = train_set_metadata
+        self.train_set_metadata = preprocessed_data[-1]
 
         return train_stats
 

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -30,7 +30,6 @@ import argparse
 import logging
 import os
 import sys
-from pprint import pformat
 
 import ludwig.contrib
 
@@ -44,7 +43,6 @@ from ludwig.data.postprocessing import postprocess_df, postprocess
 from ludwig.data.preprocessing import build_data
 from ludwig.data.preprocessing import build_dataset
 from ludwig.data.preprocessing import load_metadata
-from ludwig.data.preprocessing import preprocess_for_training
 from ludwig.data.preprocessing import replace_text_feature_level
 from ludwig.globals import MODEL_HYPERPARAMETERS_FILE_NAME
 from ludwig.globals import MODEL_WEIGHTS_FILE_NAME
@@ -52,17 +50,13 @@ from ludwig.globals import TRAIN_SET_METADATA_FILE_NAME
 from ludwig.globals import set_disable_progressbar
 from ludwig.models.model import Model
 from ludwig.models.model import load_model_and_definition
-from ludwig.models.modules.measure_modules import get_best_function
 from ludwig.predict import calculate_overall_stats
-from ludwig.train import get_experiment_dir_name, full_train
-from ludwig.train import get_file_names
-from ludwig.train import train
+from ludwig.train import full_train
 from ludwig.train import update_model_definition_with_metadata
 from ludwig.utils.data_utils import read_csv
 from ludwig.utils.data_utils import save_json
 from ludwig.utils.defaults import default_random_seed
 from ludwig.utils.defaults import merge_with_defaults
-from ludwig.utils.misc import get_experiment_description
 from ludwig.utils.print_utils import logging_level_registry
 
 
@@ -416,6 +410,7 @@ class LudwigModel:
             data_train_hdf5=data_train_hdf5,
             data_validation_hdf5=data_validation_hdf5,
             data_test_hdf5=data_test_hdf5,
+            dataset_type=dataset_type,
             train_set_metadata_json=train_set_metadata_json,
             experiment_name='api_experiment',
             model_name=model_name,

--- a/ludwig/experiment.py
+++ b/ludwig/experiment.py
@@ -156,6 +156,8 @@ def experiment(
     :param gpu_fraction: Fraction of the memory of each GPU to use at
            the beginning of the training. The memory may grow elastically.
     :type gpu_fraction: Integer
+    :param use_horovod: Flag for using horovod
+    :type use_horovod: Boolean
     :param random_seed: Random seed used for weights initialization,
            splits and any other random function.
     :type random_seed: Integer
@@ -163,32 +165,32 @@ def experiment(
     :type debug: Boolean
     """
 
-    model, preprocessed_data, experiment_dir_name = full_train(
+    model, preprocessed_data, experiment_dir_name, _ = full_train(
         model_definition,
-        model_definition_file,
-        data_csv,
-        data_train_csv,
-        data_validation_csv,
-        data_test_csv,
-        data_hdf5,
-        data_train_hdf5,
-        data_validation_hdf5,
-        data_test_hdf5,
-        train_set_metadata_json,
-        experiment_name,
-        model_name,
-        model_load_path,
-        model_resume_path,
-        skip_save_model,
-        skip_save_progress,
-        skip_save_log,
-        skip_save_processed_input,
-        output_directory,
-        gpus,
-        gpu_fraction,
-        use_horovod,
-        random_seed,
-        debug,
+        model_definition_file=model_definition_file,
+        data_csv=data_csv,
+        data_train_csv=data_train_csv,
+        data_validation_csv=data_validation_csv,
+        data_test_csv=data_test_csv,
+        data_hdf5=data_hdf5,
+        data_train_hdf5=data_train_hdf5,
+        data_validation_hdf5=data_validation_hdf5,
+        data_test_hdf5=data_test_hdf5,
+        train_set_metadata_json=train_set_metadata_json,
+        experiment_name=experiment_name,
+        model_name=model_name,
+        model_load_path=model_load_path,
+        model_resume_path=model_resume_path,
+        skip_save_model=skip_save_model,
+        skip_save_progress=skip_save_progress,
+        skip_save_log=skip_save_log,
+        skip_save_processed_input=skip_save_processed_input,
+        output_directory=output_directory,
+        gpus=gpus,
+        gpu_fraction=gpu_fraction,
+        use_horovod=use_horovod,
+        random_seed=random_seed,
+        debug=debug,
         **kwargs
     )
 

--- a/ludwig/experiment.py
+++ b/ludwig/experiment.py
@@ -20,30 +20,19 @@ from __future__ import print_function
 
 import argparse
 import logging
-import os
 import sys
-from pprint import pformat
 
 import yaml
 
 from ludwig.contrib import contrib_command
 from ludwig.data.postprocessing import postprocess
-from ludwig.data.preprocessing import preprocess_for_training
 from ludwig.globals import LUDWIG_VERSION, set_on_master, is_on_master
-from ludwig.globals import TRAIN_SET_METADATA_FILE_NAME
-from ludwig.models.modules.measure_modules import get_best_function
 from ludwig.predict import predict
 from ludwig.predict import print_prediction_results
 from ludwig.predict import save_prediction_outputs
 from ludwig.predict import save_prediction_statistics
-from ludwig.train import get_experiment_dir_name
-from ludwig.train import get_file_names
-from ludwig.train import train
-from ludwig.train import update_model_definition_with_metadata
-from ludwig.utils.data_utils import save_json
+from ludwig.train import full_train
 from ludwig.utils.defaults import default_random_seed
-from ludwig.utils.defaults import merge_with_defaults
-from ludwig.utils.misc import get_experiment_description
 from ludwig.utils.print_utils import logging_level_registry
 from ludwig.utils.print_utils import print_ludwig
 
@@ -173,181 +162,41 @@ def experiment(
     :param debug: If true turns on tfdbg with inf_or_nan checks.
     :type debug: Boolean
     """
-    # set input features defaults
-    if model_definition_file is not None:
-        with open(model_definition_file, 'r') as def_file:
-            model_definition = merge_with_defaults(yaml.load(def_file))
-    else:
-        model_definition = merge_with_defaults(model_definition)
 
-    # setup directories and file names
-    experiment_dir_name = None
-    if model_resume_path is not None:
-        if os.path.exists(model_resume_path):
-            experiment_dir_name = model_resume_path
-        else:
-            if is_on_master():
-                logging.info(
-                    'Model resume path does not exists, '
-                    'starting training from scratch'
-                )
-            model_resume_path = None
-
-    if model_resume_path is None:
-        if is_on_master():
-            experiment_dir_name = get_experiment_dir_name(
-                output_directory,
-                experiment_name,
-                model_name
-            )
-        else:
-            experiment_dir_name = '/'
-    description_fn, training_stats_fn, model_dir = get_file_names(
-        experiment_dir_name
-    )
-
-    # save description
-    description = get_experiment_description(
+    model, preprocessed_data, experiment_dir_name = full_train(
         model_definition,
-        data_csv=data_csv,
-        data_train_csv=data_train_csv,
-        data_validation_csv=data_validation_csv,
-        data_test_csv=data_test_csv,
-        data_hdf5=data_hdf5,
-        data_train_hdf5=data_train_hdf5,
-        data_validation_hdf5=data_validation_hdf5,
-        data_test_hdf5=data_test_hdf5,
-        metadata_json=train_set_metadata_json,
-        random_seed=random_seed
+        model_definition_file,
+        data_csv,
+        data_train_csv,
+        data_validation_csv,
+        data_test_csv,
+        data_hdf5,
+        data_train_hdf5,
+        data_validation_hdf5,
+        data_test_hdf5,
+        train_set_metadata_json,
+        experiment_name,
+        model_name,
+        model_load_path,
+        model_resume_path,
+        skip_save_model,
+        skip_save_progress,
+        skip_save_log,
+        skip_save_processed_input,
+        output_directory,
+        gpus,
+        gpu_fraction,
+        use_horovod,
+        random_seed,
+        debug,
+        **kwargs
     )
-    if is_on_master():
-        save_json(description_fn, description)
-        # print description
-        logging.info('Experiment name: {}'.format(experiment_name))
-        logging.info('Model name: {}'.format(model_name))
-        logging.info('Output path: {}'.format(experiment_dir_name))
-        logging.info('')
-        for key, value in description.items():
-            logging.info('{}: {}'.format(key, pformat(value, indent=4)))
-        logging.info('')
 
-    # preprocess
-    (
-        training_set,
-        validation_set,
-        test_set,
-        train_set_metadata
-    ) = preprocess_for_training(
-        model_definition,
-        data_csv=data_csv,
-        data_train_csv=data_train_csv,
-        data_validation_csv=data_validation_csv,
-        data_test_csv=data_test_csv,
-        data_hdf5=data_hdf5,
-        data_train_hdf5=data_train_hdf5,
-        data_validation_hdf5=data_validation_hdf5,
-        data_test_hdf5=data_test_hdf5,
-        train_set_metadata_json=train_set_metadata_json,
-        skip_save_processed_input=skip_save_processed_input,
-        preprocessing_params=model_definition[
-            'preprocessing'],
-        random_seed=random_seed
-    )
-    if is_on_master():
-        logging.info('Training set: {0}'.format(training_set.size))
-        if validation_set is not None:
-            logging.info('Validation set: {0}'.format(validation_set.size))
-        if test_set is not None:
-            logging.info('Test set: {0}'.format(test_set.size))
+    (training_set,
+     validation_set,
+     test_set,
+     train_set_metadata) = preprocessed_data
 
-    # update model definition with metadata properties
-    update_model_definition_with_metadata(model_definition, train_set_metadata)
-
-    if is_on_master():
-        if not skip_save_model:
-            # save train set metadata
-            os.makedirs(model_dir, exist_ok=True)
-            save_json(
-                os.path.join(
-                    model_dir,
-                    TRAIN_SET_METADATA_FILE_NAME
-                ),
-                train_set_metadata
-            )
-
-    # run the experiment
-    model, training_results = train(
-        training_set=training_set,
-        validation_set=validation_set,
-        test_set=test_set,
-        model_definition=model_definition,
-        save_path=model_dir,
-        model_load_path=model_load_path,
-        resume=model_resume_path is not None,
-        skip_save_model=skip_save_model,
-        skip_save_progress=skip_save_progress,
-        skip_save_log=skip_save_log,
-        gpus=gpus,
-        gpu_fraction=gpu_fraction,
-        use_horovod=use_horovod,
-        random_seed=random_seed,
-        debug=debug
-    )
-    (
-        train_trainset_stats,
-        train_valisest_stats,
-        train_testset_stats
-    ) = training_results
-
-    # grab the results of the model with highest validation test performance
-    validation_field = model_definition['training']['validation_field']
-    validation_measure = model_definition['training']['validation_measure']
-    validation_field_result = train_valisest_stats[validation_field]
-
-    best_function = get_best_function(validation_measure)
-
-    # print results of the model with highest validation test performance
-    if is_on_master():
-        if validation_set is not None:
-            # max or min depending on the measure
-            epoch_best_vali_measure, best_vali_measure = best_function(
-                enumerate(validation_field_result[validation_measure]),
-                key=lambda pair: pair[1]
-            )
-            logging.info('Best validation model epoch: {0}'.format(
-                epoch_best_vali_measure + 1)
-            )
-            logging.info(
-                'Best validation model {0} on validation set {1}: {2}'.format(
-                    validation_measure,
-                    validation_field,
-                    best_vali_measure)
-            )
-        
-            if test_set is not None:
-                best_vali_measure_epoch_test_measure = train_testset_stats[
-                    validation_field
-                ][validation_measure][epoch_best_vali_measure]
-                logging.info(
-                    'Best validation model {0} on test set {1}: {2}'.format(
-                        validation_measure,
-                        validation_field,
-                        best_vali_measure_epoch_test_measure
-                    )
-                )
-
-    # save training statistics
-    if is_on_master():
-        save_json(
-            training_stats_fn,
-            {
-                'train': train_trainset_stats,
-                'validation': train_valisest_stats,
-                'test': train_testset_stats
-            }
-        )
-
-    
     if test_set is not None:
         if model_definition['training']['eval_batch_size'] > 0:
             batch_size = model_definition['training']['eval_batch_size']

--- a/ludwig/train.py
+++ b/ludwig/train.py
@@ -60,6 +60,7 @@ def full_train(
         data_train_hdf5=None,
         data_validation_hdf5=None,
         data_test_hdf5=None,
+        dataset_type='generic',
         train_set_metadata_json=None,
         experiment_name='experiment',
         model_name='run',
@@ -249,7 +250,8 @@ def full_train(
         train_set_metadata_json=train_set_metadata_json,
         skip_save_processed_input=skip_save_processed_input,
         preprocessing_params=model_definition['preprocessing'],
-        random_seed=random_seed
+        random_seed=random_seed,
+        dataset_type=dataset_type
     )
 
     (training_set,

--- a/ludwig/train.py
+++ b/ludwig/train.py
@@ -42,6 +42,7 @@ from ludwig.utils.misc import get_from_registry
 from ludwig.utils.print_utils import logging_level_registry
 from ludwig.utils.print_utils import print_boxed
 from ludwig.utils.print_utils import print_ludwig
+from ludwig.models.modules.measure_modules import get_best_function
 
 
 def full_train(
@@ -223,12 +224,7 @@ def full_train(
         logging.info('\n')
 
     # preprocess
-    (
-        training_set,
-        validation_set,
-        test_set,
-        train_set_metadata
-    ) = preprocess_for_training(
+    preprocessed_data = preprocess_for_training(
         model_definition,
         data_csv=data_csv,
         data_train_csv=data_train_csv,
@@ -243,6 +239,12 @@ def full_train(
         preprocessing_params=model_definition['preprocessing'],
         random_seed=random_seed
     )
+
+    (training_set,
+     validation_set,
+     test_set,
+     train_set_metadata) = preprocessed_data
+
     if is_on_master():
         logging.info('Training set: {0}'.format(training_set.size))
         if validation_set is not None:
@@ -288,6 +290,7 @@ def full_train(
     )
 
     train_trainset_stats, train_valisest_stats, train_testset_stats = result
+
     model.close_session()
 
     if is_on_master():
@@ -305,32 +308,36 @@ def full_train(
     validation_field = model_definition['training']['validation_field']
     validation_measure = model_definition['training']['validation_measure']
     validation_field_result = train_valisest_stats[validation_field]
-    if validation_set is not None:
-        epoch_max_vali_measure, max_vali_measure = max(
+
+    best_function = get_best_function(validation_measure)
+    # results of the model with highest validation test performance
+    if is_on_master() and validation_set is not None:
+        epoch_best_vali_measure, best_vali_measure = best_function(
             enumerate(validation_field_result[validation_measure]),
             key=lambda pair: pair[1]
         )
-        max_vali_measure_epoch_test_measure = train_testset_stats[validation_field][
-            validation_measure][epoch_max_vali_measure]
+        logging.info(
+            'Best validation model epoch:'.format(epoch_best_vali_measure+1)
+        )
+        logging.info(
+           'Best validation model {0} on validation set {1}: {2}'.format(
+               validation_measure, validation_field, best_vali_measure
+           ))
+        if test_set is not None:
+            best_vali_measure_epoch_test_measure = train_testset_stats[
+                validation_field][validation_measure][epoch_best_vali_measure]
 
-    # results of the model with highest validation test performance
-    if is_on_master():
-        if validation_set is not None:
-            logging.info(
-                'Best validation model epoch:'.format(epoch_max_vali_measure + 1)
-            )
-            logging.info(
-                'Best validation model {0} on validation set {1}: {2}'.format(
-                    validation_measure, validation_field, max_vali_measure
-                ))
-            logging.info('Best validation model {0} on test set {1}: {2}'.format(
-                validation_measure, validation_field,
-                max_vali_measure_epoch_test_measure
+            logging.info('Best validation model {0} on test set {1}: '
+                         '{2}'.format(validation_measure,
+                                      validation_field,
+                                      best_vali_measure_epoch_test_measure
             ))
         logging.info('\nFinished: {0}_{1}'.format(experiment_name, model_name))
         logging.info('Saved to: {0}'.format(experiment_dir_name))
 
     contrib_command("train_save", experiment_dir_name)
+
+    return model, preprocessed_data, experiment_dir_name
 
 
 def train(

--- a/tests/fixtures/csv_filename.py
+++ b/tests/fixtures/csv_filename.py
@@ -1,0 +1,35 @@
+import pytest
+import uuid
+import os
+
+
+@pytest.fixture()
+def csv_filename():
+    """
+    This methods returns a random filename for the tests to use for generating
+    temporary data. After the data is used, all the temporary data is deleted.
+    :return: None
+    """
+    csv_filename = uuid.uuid4().hex[:10].upper() + '.csv'
+    yield csv_filename
+
+    delete_temporary_data(csv_filename)
+
+
+def delete_temporary_data(csv_path):
+    """
+    Helper method to delete temporary data created for running tests. Deletes
+    the csv and hdf5/json data (if any)
+    :param csv_path: path to the csv data file
+    :return: None
+    """
+    if os.path.exists(csv_path):
+        os.remove(csv_path)
+
+    json_path = os.path.splitext(csv_path)[0] + '.json'
+    if os.path.exists(json_path):
+        os.remove(json_path)
+
+    hdf5_path = os.path.splitext(csv_path)[0] + '.hdf5'
+    if os.path.exists(hdf5_path):
+        os.remove(hdf5_path)

--- a/tests/integration_tests/test_api.py
+++ b/tests/integration_tests/test_api.py
@@ -1,0 +1,67 @@
+import pytest
+import uuid
+import yaml
+
+from string import Template
+from ludwig.api import LudwigModel
+from ludwig.utils.data_utils import read_csv
+
+from tests.integration_tests.utils import generate_data
+from tests.integration_tests.utils import model_definition_template
+from tests.integration_tests.utils import ENCODERS
+from tests.fixtures.csv_filename import csv_filename
+
+
+def run_api_experiment(input_features, output_features, data_csv):
+    """
+    Helper method to avoid code repetition in running an experiment
+    :param input_features: input schema
+    :param output_features: output schema
+    :param data_csv: path to data
+    :return: None
+    """
+    model_definition = model_definition_template.substitute(
+        input_name=input_features,
+        output_name=output_features
+    )
+
+    model = LudwigModel(yaml.load(model_definition))
+
+    # Training with csv
+    model.train(
+        data_csv=data_csv,
+        skip_save_processed_input=True,
+        skip_save_progress=True,
+        skip_save_unprocessed_output=True
+    )
+    model.predict(data_csv=data_csv)
+
+    # Training with dataframe
+    data_df = read_csv(data_csv)
+    model.train(
+        data_df=data_df,
+        skip_save_processed_input=True,
+        skip_save_progress=True,
+        skip_save_unprocessed_output=True
+    )
+    model.predict(data_df=data_df)
+
+
+def test_api_intent_classification(csv_filename):
+    # Single sequence input, single category output
+    input_features = Template('[{name: utterance, type: sequence,'
+                              'vocab_size: 10, max_len: 10, '
+                              'encoder: ${encoder}, reduce_output: sum}]')
+    output_features = "[{name: intent, type: category, vocab_size: 2," \
+                      " reduce_input: sum}] "
+
+    # Generate test data
+    rel_path = generate_data(
+        input_features.substitute(encoder='rnn'), output_features, csv_filename
+    )
+    for encoder in ENCODERS:
+        run_api_experiment(
+            input_features.substitute(encoder=encoder),
+            output_features,
+            data_csv=rel_path
+        )

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -457,7 +457,8 @@ def test_image_resizing_num_channel_handling(csv_filename):
     output_features = "[{type: binary, name: intent, reduce_input: sum}, " \
                       "{type: numerical, name: random_num_output}]"
 
-    rel_path = generate_data(input_features, output_features, csv_filename)
+    rel_path = generate_data(input_features, output_features, csv_filename,
+                             num_examples=100)
 
     df1 = pd.read_csv(rel_path)
 
@@ -475,7 +476,8 @@ def test_image_resizing_num_channel_handling(csv_filename):
         folder=image_dest_folder,
         in_memory='true',
     )
-    rel_path = generate_data(input_features, output_features, csv_filename)
+    rel_path = generate_data(input_features, output_features, csv_filename,
+                             num_examples=100)
     df2 = pd.read_csv(rel_path)
 
     df = concatenate_df(df1, df2, None)

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -1,0 +1,36 @@
+import pandas as pd
+import os
+import yaml
+
+from string import Template
+from ludwig.data.dataset_synthesyzer import build_synthetic_dataset
+
+ENCODERS = ['embed', 'rnn', 'parallel_cnn', 'cnnrnn', 'stacked_parallel_cnn',
+            'stacked_cnn']
+
+model_definition_template = Template(
+    '{input_features: ${input_name}, output_features: ${output_name}, '
+    'training: {epochs: 2}, combiner: {type: concat, fc_size: 56}}')
+
+
+def generate_data(input_features,
+                  output_features,
+                  filename='test_csv.csv',
+                  num_examples=25):
+    """
+    Helper method to generate synthetic data based on input, output feature
+    specs
+    :param num_examples: number of examples to generate
+    :param input_features: schema
+    :param output_features: schema
+    :param filename: path to the file where data is stored
+    :return:
+    """
+    features = yaml.load(input_features) + yaml.load(output_features)
+    df = build_synthetic_dataset(num_examples, features)
+    data = [next(df) for _ in range(num_examples)]
+
+    dataframe = pd.DataFrame(data[1:], columns=data[0])
+    dataframe.to_csv(filename, index=False)
+
+    return filename


### PR DESCRIPTION
1. experiment.py, api.py and train.py all use more or less the exact same code for model training. This commit removes the redundancy. All of them now use the full_train method from train.py
2. Adds a test case for api.py. I modified one of the test cases for experiment to use api.py
3. Refactored some of the integration tests

All tests pass. 

