### PR TITLE
Resizing image before switching channels

### DIFF
--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -84,6 +84,9 @@ class ImageBaseFeature(BaseFeature):
         if img_num_channels == 1:
             img = img.reshape((img.shape[0], img.shape[1], 1))
 
+        if should_resize:
+            img = resize_image(img, (img_height, img_width), resize_method)
+
         if user_specified_num_channels is True:
             # Number of channels is specified by the user
             img_padded = np.zeros((img_height, img_width, num_channels))
@@ -105,9 +108,6 @@ class ImageBaseFeature(BaseFeature):
                     ' has {2} channels'.format(filepath,
                                                img_num_channels,
                                                num_channels))
-        if should_resize:
-            img = resize_image(img, (img_height, img_width), resize_method)
-
         return img
 
     @staticmethod


### PR DESCRIPTION
A simple fix for `ImageBaseFeature` `_read_image_and_resize` method. 

### Info of the initial problem:

Traceback:
```
Traceback (most recent call last):
  File "<input>", line 4, in <module>
  File "/home/ignisor/dev/ludwig-human-classifier/.env/lib/python3.7/site-packages/ludwig-0.1.1-py3.7.egg/ludwig/api.py", line 946, in predict
    logging_level=logging_level,
  File "/home/ignisor/dev/ludwig-human-classifier/.env/lib/python3.7/site-packages/ludwig-0.1.1-py3.7.egg/ludwig/api.py", line 809, in _predict
    self.model_definition['preprocessing']
  File "/home/ignisor/dev/ludwig-human-classifier/.env/lib/python3.7/site-packages/ludwig-0.1.1-py3.7.egg/ludwig/data/preprocessing.py", line 164, in build_data
    preprocessing_parameters
  File "/home/ignisor/dev/ludwig-human-classifier/.env/lib/python3.7/site-packages/ludwig-0.1.1-py3.7.egg/ludwig/features/image_feature.py", line 213, in add_feature_data
    user_specified_num_channels
  File "/home/ignisor/dev/ludwig-human-classifier/.env/lib/python3.7/site-packages/ludwig-0.1.1-py3.7.egg/ludwig/features/image_feature.py", line 91, in _read_image_and_resize
    img_padded[:,:,:min_num_channels] = img[:,:,:min_num_channels]
ValueError: could not broadcast input array from shape (300,451,3) into shape (400,300,3)
```

Model defenition:
```
MODEL_DEFENITION = {
    'input_features': [
        {
            "name": "image_path",
            "type": "image",
            "encoder": "stacked_cnn",
            'preprocessing': {
                'resize_method': 'interpolate', 
                'height': 400, 
                'width': 300,
            },
        },
    ],
    "output_features": [
        {
            "name": "class",
            "type": "category",
        },
    ],
}
```
