### PR TITLE
Fixes a model definition bug causing failures when using model_definition_file

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -132,7 +132,7 @@ class LudwigModel:
         if model_definition_file is not None:
             with open(model_definition_file, 'r') as def_file:
                 self.model_definition = merge_with_defaults(
-                    yaml.load(def_file)
+                    yaml.safe_load(def_file)
                 )
         else:
             self.model_definition = merge_with_defaults(model_definition)
@@ -1052,7 +1052,7 @@ def main(sys_argv):
     parser.add_argument(
         '-md',
         '--model_definition',
-        type=yaml.load,
+        type=yaml.safe_load,
         help='model definition'
     )
 

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -404,7 +404,13 @@ class LudwigModel:
         if data_df is None and data_dict is not None:
             data_df = pd.DataFrame(data_dict)
 
-        self.model, preprocessed_data, _, train_stats = full_train(
+        (
+            self.model,
+            preprocessed_data,
+            _,
+            train_stats,
+            self.model_definition
+        ) = full_train(
             self.model_definition,
             data_df=data_df,
             data_train_df=data_train_df,

--- a/ludwig/cli.py
+++ b/ludwig/cli.py
@@ -24,7 +24,7 @@ class CLI(object):
     """CLI describes a command line interface for interacting with Ludwig, there
     are several different functions that can be performed. These functions are:
     - experiment - run an experiment using ludwig
-    - predict - Given a list of $hat{y}$ values, compute $d(\hat{y}, y) under a
+    - predict - Given a list of $hat{y}$ values, compute $d(\\hat{y}, y) under a
       specified metric
     - train - trains a model on the input file specified to it
     - visualize - Analysis of the results for the model on the dataset and

--- a/ludwig/collect.py
+++ b/ludwig/collect.py
@@ -25,6 +25,7 @@ import sys
 
 import numpy as np
 
+from ludwig.contrib import contrib_command
 from ludwig.data.preprocessing import preprocess_for_prediction
 from ludwig.globals import LUDWIG_VERSION
 from ludwig.globals import TRAIN_SET_METADATA_FILE_NAME
@@ -360,8 +361,10 @@ def cli_collect_weights(sys_argv):
 if __name__ == '__main__':
     if len(sys.argv) > 1:
         if sys.argv[1] == 'activations':
+            contrib_command("collect_activations", *sys.argv)
             cli_collect_activations(sys.argv[2:])
         elif sys.argv[1] == 'weights':
+            contrib_command("collect_weights", *sys.argv)
             cli_collect_weights(sys.argv[2:])
         else:
             print('Unrecognized command')

--- a/ludwig/data/dataset_synthesyzer.py
+++ b/ludwig/data/dataset_synthesyzer.py
@@ -15,11 +15,12 @@
 # limitations under the License.
 # ==============================================================================
 import argparse
-import numpy as np
 import os
 import random
 import string
 import uuid
+
+import numpy as np
 import yaml
 from skimage.io import imsave
 
@@ -275,7 +276,7 @@ if __name__ == '__main__':
           {name: timeseries_1, type: timeseries, max_len: 20}, \
           {name: timeseries_2, type: timeseries, max_len: 20}, \
           ]',
-        type=yaml.load, help='dataset features'
+        type=yaml.safe_load, help='dataset features'
     )
     args = parser.parse_args()
 

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -803,14 +803,14 @@ if __name__ == '__main__':
     parser.add_argument(
         '-f',
         '--features',
-        type=yaml.load,
+        type=yaml.safe_load,
         help='list of features in the CSV to map to hdf5 and JSON files'
     )
 
     parser.add_argument(
         '-p',
         '--preprocessing_parameters',
-        type=yaml.load,
+        type=yaml.safe_load,
         default='{}',
         help='the parameters for preprocessing the different features'
     )

--- a/ludwig/experiment.py
+++ b/ludwig/experiment.py
@@ -352,7 +352,7 @@ def cli(sys_argv):
     model_definition.add_argument(
         '-md',
         '--model_definition',
-        type=yaml.load,
+        type=yaml.safe_load,
         help='model definition'
     )
     model_definition.add_argument(
@@ -473,4 +473,5 @@ def cli(sys_argv):
 
 
 if __name__ == '__main__':
+    contrib_command("experiment", *sys.argv)
     cli(sys.argv[1:])

--- a/ludwig/experiment.py
+++ b/ludwig/experiment.py
@@ -165,7 +165,13 @@ def experiment(
     :type debug: Boolean
     """
 
-    model, preprocessed_data, experiment_dir_name, _ = full_train(
+    (
+        model,
+        preprocessed_data,
+        experiment_dir_name,
+        _,
+        model_definition
+    ) = full_train(
         model_definition,
         model_definition_file=model_definition_file,
         data_csv=data_csv,

--- a/ludwig/globals.py
+++ b/ludwig/globals.py
@@ -19,7 +19,7 @@ LUDWIG_VERSION = '0.1.1'
 MODEL_WEIGHTS_FILE_NAME = 'model_weights'
 MODEL_WEIGHTS_PROGRESS_FILE_NAME = 'model_weights_progress'
 MODEL_HYPERPARAMETERS_FILE_NAME = 'model_hyperparameters.json'
-TRAINING_PROGRESS_FILE_NAME = 'training_progress.p'
+TRAINING_PROGRESS_FILE_NAME = 'training_progress.json'
 TRAIN_SET_METADATA_FILE_NAME = 'train_set_metadata.json'
 
 DISABLE_PROGRESSBAR = False

--- a/ludwig/models/model.py
+++ b/ludwig/models/model.py
@@ -27,8 +27,8 @@ import os
 import re
 import signal
 import sys
-import time
 import threading
+import time
 from collections import OrderedDict
 
 import numpy as np
@@ -58,8 +58,6 @@ from ludwig.utils.batcher import Batcher
 from ludwig.utils.batcher import BucketedBatcher
 from ludwig.utils.batcher import DistributedBatcher
 from ludwig.utils.data_utils import load_json, save_json
-from ludwig.utils.data_utils import load_object
-from ludwig.utils.data_utils import save_object
 from ludwig.utils.defaults import default_random_seed
 from ludwig.utils.defaults import default_training_params
 from ludwig.utils.math_utils import learning_rate_warmup
@@ -488,7 +486,7 @@ class Model:
 
             # ================ Train ================
             if is_on_master():
-                bar = tqdm(
+                progress_bar = tqdm(
                     desc='Training',
                     total=batcher.steps_per_epoch,
                     file=sys.stdout,
@@ -534,11 +532,11 @@ class Model:
 
                 progress_tracker.steps += 1
                 if is_on_master():
-                    bar.update(1)
+                    progress_bar.update(1)
 
             # post training
             if is_on_master():
-                bar.close()
+                progress_bar.close()
 
             progress_tracker.epoch += 1
             batcher.reset()  # todo this may be useless, doublecheck
@@ -648,12 +646,11 @@ class Model:
             if is_on_master():
                 if not skip_save_progress:
                     self.save_weights(session, model_weights_progress_path)
-                    save_object(
+                    progress_tracker.save(
                         os.path.join(
                             save_path,
                             TRAINING_PROGRESS_FILE_NAME
-                        ),
-                        progress_tracker
+                        )
                     )
                     if skip_save_model:
                         self.save_hyperparameters(
@@ -688,7 +685,7 @@ class Model:
         batcher = self.initialize_batcher(dataset, batch_size, bucketing_field)
 
         # training step loop
-        bar = tqdm(
+        progress_bar = tqdm(
             desc='Trainining online',
             total=batcher.steps_per_epoch,
             file=sys.stdout,
@@ -708,9 +705,9 @@ class Model:
                     is_training=True
                 )
             )
-            bar.update(1)
+            progress_bar.update(1)
 
-        bar.close()
+        progress_bar.close()
 
     def evaluation(
             self,
@@ -789,7 +786,7 @@ class Model:
         )
 
         if is_on_master():
-            bar = tqdm(
+            progress_bar = tqdm(
                 desc='Evaluation' if name is None
                 else 'Evaluation {0: <5.5}'.format(name),
                 total=batcher.steps_per_epoch,
@@ -817,10 +814,10 @@ class Model:
                 result
             )
             if is_on_master():
-                bar.update(1)
+                progress_bar.update(1)
 
         if is_on_master():
-            bar.close()
+            progress_bar.close()
 
         if self.horovod:
             output_stats, seq_set_size = self.merge_workers_outputs(
@@ -878,7 +875,7 @@ class Model:
             should_shuffle=False
         )
 
-        bar = tqdm(
+        progress_bar = tqdm(
             desc='Collecting Tensors',
             total=batcher.steps_per_epoch,
             file=sys.stdout,
@@ -899,9 +896,9 @@ class Model:
                 for row in result[tensor_name]:
                     collected_tensors[tensor_name].append(row)
 
-            bar.update(1)
+            progress_bar.update(1)
 
-        bar.close()
+        progress_bar.close()
 
         return collected_tensors
 
@@ -1364,7 +1361,7 @@ class Model:
         if is_on_master():
             logging.info('Resuming training of model: {0}'.format(save_path))
         self.weights_save_path = model_weights_path
-        progress_tracker = load_object(
+        progress_tracker = ProgressTracker.load(
             os.path.join(
                 save_path,
                 TRAINING_PROGRESS_FILE_NAME
@@ -1598,13 +1595,14 @@ class ProgressTracker:
             num_increases_bs,
             train_stats,
             vali_stats,
-            test_stats
+            test_stats,
+            last_improvement=0
     ):
         self.batch_size = batch_size
         self.epoch = epoch
         self.steps = steps
         self.last_improvement_epoch = last_improvement_epoch
-        self.last_improvement = 0
+        self.last_improvement = last_improvement
         self.learning_rate = learning_rate
         self.best_valid_measure = best_valid_measure
         self.num_reductions_lr = num_reductions_lr
@@ -1612,6 +1610,14 @@ class ProgressTracker:
         self.train_stats = train_stats
         self.vali_stats = vali_stats
         self.test_stats = test_stats
+
+    def save(self, filepath):
+        save_json(filepath, self.__dict__)
+
+    @staticmethod
+    def load(filepath):
+        loaded = load_json(filepath)
+        return ProgressTracker(**loaded)
 
 
 def load_model_and_definition(model_dir, use_horovod=False):

--- a/ludwig/predict.py
+++ b/ludwig/predict.py
@@ -25,6 +25,7 @@ import sys
 from collections import OrderedDict
 from pprint import pformat
 
+from ludwig.contrib import contrib_command
 from ludwig.data.postprocessing import postprocess
 from ludwig.data.preprocessing import preprocess_for_prediction
 from ludwig.features.feature_registries import output_type_registry
@@ -380,4 +381,5 @@ def cli(sys_argv):
 
 
 if __name__ == '__main__':
+    contrib_command("predict", *sys.argv)
     cli(sys.argv[1:])

--- a/ludwig/train.py
+++ b/ludwig/train.py
@@ -175,7 +175,7 @@ def full_train(
     # set input features defaults
     if model_definition_file is not None:
         with open(model_definition_file, 'r') as def_file:
-            model_definition = merge_with_defaults(yaml.load(def_file))
+            model_definition = merge_with_defaults(yaml.safe_load(def_file))
     else:
         model_definition = merge_with_defaults(model_definition)
 
@@ -649,7 +649,7 @@ def cli(sys_argv):
     model_definition.add_argument(
         '-md',
         '--model_definition',
-        type=yaml.load,
+        type=yaml.safe_load,
         help='model definition'
     )
     model_definition.add_argument(
@@ -765,4 +765,5 @@ def cli(sys_argv):
 
 
 if __name__ == '__main__':
+    contrib_command("train", *sys.argv)
     cli(sys.argv[1:])

--- a/ludwig/train.py
+++ b/ludwig/train.py
@@ -347,7 +347,12 @@ def full_train(
 
     contrib_command("train_save", experiment_dir_name)
 
-    return model, preprocessed_data, experiment_dir_name, train_stats
+    return (model,
+            preprocessed_data,
+            experiment_dir_name,
+            train_stats,
+            model_definition
+            )
 
 
 def train(

--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -46,7 +46,7 @@ def read_csv(data_fp, header=0):
         df = pd.read_csv(data_fp, header=header)
     except ParserError:
         logging.warning('Failed to parse the CSV with pandas default way,'
-                        ' trying \ as escape character.')
+                        ' trying \\ as escape character.')
         df = pd.read_csv(data_fp, header=header, escapechar='\\')
 
     return df

--- a/ludwig/utils/print_utils.py
+++ b/ludwig/utils/print_utils.py
@@ -31,8 +31,8 @@ logging_level_registry = {
 def print_ludwig(message, ludwig_version):
     logging.info('\n'.join([' _         _        _      ',
                             '| |_  _ __| |_ __ _(_)__ _ ',
-                            '| | || / _` \ V  V / / _` |',
-                            '|_|\_,_\__,_|\_/\_/|_\__, |',
+                            '| | || / _` \\ V  V / / _` |',
+                            '|_|\\_,_\\__,_|\\_/\\_/|_\\__, |',
                             '                     |___/ ',
                             'ludwig v{1} - {0}'.format(message, ludwig_version),
                             '']

--- a/ludwig/visualize.py
+++ b/ludwig/visualize.py
@@ -29,6 +29,7 @@ from sklearn.calibration import calibration_curve
 from sklearn.metrics import brier_score_loss
 
 from ludwig.constants import *
+from ludwig.contrib import contrib_command
 from ludwig.utils import visualization_utils
 from ludwig.utils.data_utils import load_json, load_from_file
 from ludwig.utils.print_utils import logging_level_registry
@@ -1832,4 +1833,5 @@ def cli(sys_argv):
 
 
 if __name__ == '__main__':
+    contrib_command("visualize", *sys.argv)
     cli(sys.argv[1:])

--- a/tests/fixtures/filenames.py
+++ b/tests/fixtures/filenames.py
@@ -32,6 +32,20 @@ def csv_filename():
     delete_temporary_data(csv_filename)
 
 
+@pytest.fixture()
+def yaml_filename():
+    """
+    This methods returns a random filename for the tests to use for generating
+    a model definition file. After the test runs, this file will be deleted
+    :return: None
+    """
+    yaml_filename = 'model_def_' + uuid.uuid4().hex[:10].upper() + '.yaml'
+    yield yaml_filename
+
+    if os.path.exists(yaml_filename):
+        os.remove(yaml_filename)
+
+
 def delete_temporary_data(csv_path):
     """
     Helper method to delete temporary data created for running tests. Deletes

--- a/tests/integration_tests/test_api.py
+++ b/tests/integration_tests/test_api.py
@@ -39,7 +39,7 @@ def run_api_experiment(input_features, output_features, data_csv):
         output_name=output_features
     )
 
-    model = LudwigModel(yaml.load(model_definition))
+    model = LudwigModel(yaml.safe_load(model_definition))
 
     # Training with csv
     model.train(

--- a/tests/integration_tests/test_api.py
+++ b/tests/integration_tests/test_api.py
@@ -22,6 +22,7 @@ from ludwig.utils.data_utils import read_csv
 from tests.integration_tests.utils import ENCODERS
 from tests.integration_tests.utils import generate_data
 from tests.integration_tests.utils import model_definition_template
+from tests.fixtures.filenames import csv_filename
 
 
 def run_api_experiment(input_features, output_features, data_csv):

--- a/tests/integration_tests/test_api.py
+++ b/tests/integration_tests/test_api.py
@@ -22,6 +22,7 @@ from ludwig.utils.data_utils import read_csv
 from tests.integration_tests.utils import ENCODERS
 from tests.integration_tests.utils import generate_data
 from tests.integration_tests.utils import model_definition_template
+# The following imports are pytest fixtures, required for running the tests
 from tests.fixtures.filenames import csv_filename
 
 

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -47,7 +47,7 @@ def run_experiment(input_features, output_features, data_csv):
     )
 
     experiment(
-        yaml.load(model_definition),
+        yaml.safe_load(model_definition),
         skip_save_processed_input=True,
         skip_save_progress=True,
         skip_save_unprocessed_output=True,
@@ -305,7 +305,7 @@ def test_experiment_sequence_combiner(csv_filename):
             output_name=output_features_string
         )
 
-        experiment(yaml.load(model_definition),
+        experiment(yaml.safe_load(model_definition),
                    skip_save_processed_input=True,
                    skip_save_progress=True,
                    skip_save_unprocessed_output=True, data_csv=rel_path
@@ -327,10 +327,11 @@ def test_experiment_model_resume(csv_filename):
         input_name=input_features, output_name=output_features
     )
 
-    exp_dir_name = experiment(yaml.load(model_definition), data_csv=rel_path)
+    exp_dir_name = experiment(yaml.safe_load(model_definition),
+                              data_csv=rel_path)
     logging.info('Experiment Directory: {0}'.format(exp_dir_name))
 
-    experiment(yaml.load(model_definition), data_csv=rel_path,
+    experiment(yaml.safe_load(model_definition), data_csv=rel_path,
                model_resume_path=exp_dir_name)
 
     full_predict(os.path.join(exp_dir_name, 'model'), data_csv=rel_path)

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -28,6 +28,7 @@ from ludwig.predict import full_predict
 from tests.integration_tests.utils import ENCODERS
 from tests.integration_tests.utils import generate_data
 from tests.integration_tests.utils import model_definition_template
+# The following imports are pytest fixtures, required for running the tests
 from tests.fixtures.filenames import csv_filename
 from tests.fixtures.filenames import yaml_filename
 

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -95,7 +95,8 @@ def test_experiment_seq_seq1_model_def_file(csv_filename, yaml_filename):
         input_name=input_features,
         output_name=output_features
     ))
-    yaml.dump(model_definition, open(yaml_filename, 'w'))
+    with open(yaml_filename, 'w') as yaml_out:
+        yaml.dump(model_definition, yaml_out)
 
     rel_path = generate_data(input_features, output_features, csv_filename)
     experiment(

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -28,6 +28,8 @@ from ludwig.predict import full_predict
 from tests.integration_tests.utils import ENCODERS
 from tests.integration_tests.utils import generate_data
 from tests.integration_tests.utils import model_definition_template
+from tests.fixtures.filenames import csv_filename
+from tests.fixtures.filenames import yaml_filename
 
 
 def run_experiment(input_features, output_features, data_csv):
@@ -75,6 +77,34 @@ def test_experiment_seq_seq1(csv_filename):
 
         input_features = input_features_template.substitute(encoder=encoder)
         run_experiment(input_features, output_features, data_csv=rel_path)
+
+
+def test_experiment_seq_seq1_model_def_file(csv_filename, yaml_filename):
+    # seq-to-seq test to use model definition file instead of dictionary
+    input_features = ('[{name: utt, type: text, reduce_output: null, '
+                      'vocab_size: 10, min_len: 10, max_len: 10,'
+                      ' encoder: embed}]')
+
+    output_features = ('[{name: iob, type: text, reduce_input: null, '
+                       'vocab_size: 3, min_len: 10, max_len: 10,'
+                       ' decoder: tagger}]')
+
+    # Save the model definition to a yaml file
+    model_definition = yaml.load(model_definition_template.substitute(
+        input_name=input_features,
+        output_name=output_features
+    ))
+    yaml.dump(model_definition, open(yaml_filename, 'w'))
+
+    rel_path = generate_data(input_features, output_features, csv_filename)
+    experiment(
+        model_definition=None,
+        model_definition_file=yaml_filename,
+        skip_save_processed_input=True,
+        skip_save_progress=True,
+        skip_save_unprocessed_output=True,
+        data_csv=rel_path
+    )
 
 
 def test_experiment_multi_input_intent_classification(csv_filename):

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -41,7 +41,8 @@ def generate_data(input_features,
     :param filename: path to the file where data is stored
     :return:
     """
-    features = yaml.load(input_features) + yaml.load(output_features)
+    features = yaml.safe_load(input_features) + yaml.safe_load(
+        output_features)
     df = build_synthetic_dataset(num_examples, features)
     data = [next(df) for _ in range(num_examples)]
 


### PR DESCRIPTION
1. currently model_definition is missing in experiment.py, api.py if a model_definition_file was used. Fixing it by having full_train return the updated model_definition2
2. Modifies one of the integration tests to use a model_definition file instead of a dictionary.
     >> I re-used one of the existing tests, so as to not increase the testing time. 