### PR TITLE
Renaming `lenght` variables with `length`

### DIFF
--- a/docs/user_guide/index.html
+++ b/docs/user_guide/index.html
@@ -2875,7 +2875,7 @@ Different datatypes may have different formatters that format the values of a ce
 </pre></div>
 
 
-<p>Finally a numpy matrix is created with sizes <code>n x l</code> where <code>n</code> is the number of rows in the column and <code>l</code> is the minimum of the longest tokenized list and a <code>max_lenght</code> parameter that can be set.
+<p>Finally a numpy matrix is created with sizes <code>n x l</code> where <code>n</code> is the number of rows in the column and <code>l</code> is the minimum of the longest tokenized list and a <code>max_length</code> parameter that can be set.
 All sequences shorter than <code>l</code> are padded on the right (but this behavior may also be modified through a parameter).</p>
 <table>
 <thead>

--- a/ludwig/features/category_feature.py
+++ b/ludwig/features/category_feature.py
@@ -508,16 +508,16 @@ class CategoryOutputFeature(CategoryBaseFeature, OutputFeature):
                     'class_similarities_temperature']
 
                 curr_row = 0
-                first_row_lenght = 0
+                first_row_length = 0
                 is_first_row = True
                 for row in similarities:
                     if is_first_row:
-                        first_row_lenght = len(row)
+                        first_row_length = len(row)
                         is_first_row = False
                         curr_row += 1
                     else:
-                        curr_row_lenght = len(row)
-                        if curr_row_lenght != first_row_lenght:
+                        curr_row_length = len(row)
+                        if curr_row_length != first_row_length:
                             raise ValueError(
                                 'The length of row {} of the class_similarities '
                                 'of {} is {}, different from the length of '
@@ -525,13 +525,13 @@ class CategoryOutputFeature(CategoryBaseFeature, OutputFeature):
                                 'the same length.'.format(
                                     curr_row,
                                     output_feature['name'],
-                                    curr_row_lenght,
-                                    first_row_lenght
+                                    curr_row_length,
+                                    first_row_length
                                 )
                             )
                         else:
                             curr_row += 1
-                all_rows_length = first_row_lenght
+                all_rows_length = first_row_length
 
                 if all_rows_length != len(similarities):
                     raise ValueError(

--- a/ludwig/features/sequence_feature.py
+++ b/ludwig/features/sequence_feature.py
@@ -624,16 +624,16 @@ class SequenceOutputFeature(SequenceBaseFeature, OutputFeature):
                     'class_similarities_temperature']
 
                 curr_row = 0
-                first_row_lenght = 0
+                first_row_length = 0
                 is_first_row = True
                 for row in similarities:
                     if is_first_row:
-                        first_row_lenght = len(row)
+                        first_row_length = len(row)
                         is_first_row = False
                         curr_row += 1
                     else:
-                        curr_row_lenght = len(row)
-                        if curr_row_lenght != first_row_lenght:
+                        curr_row_length = len(row)
+                        if curr_row_length != first_row_length:
                             raise ValueError(
                                 'The length of row {} of the class_similarities '
                                 'of {} is {}, different from the length of '
@@ -641,13 +641,13 @@ class SequenceOutputFeature(SequenceBaseFeature, OutputFeature):
                                 'the same length.'.format(
                                     curr_row,
                                     output_feature['name'],
-                                    curr_row_lenght,
-                                    first_row_lenght
+                                    curr_row_length,
+                                    first_row_length
                                 )
                             )
                         else:
                             curr_row += 1
-                all_rows_length = first_row_lenght
+                all_rows_length = first_row_length
 
                 if all_rows_length != len(similarities):
                     raise ValueError(

--- a/ludwig/models/modules/loss_modules.py
+++ b/ludwig/models/modules/loss_modules.py
@@ -60,31 +60,31 @@ def mean_confidence_penalty(probabilities, num_classes):
 
 def seq2seq_sequence_loss(targets, targets_sequence_length, logits,
                           softmax_function=None):
-    batch_max_targets_sequence_lenght = tf.shape(targets)[1]
-    batch_max_logits_sequence_lenght = tf.shape(logits)[1]
-    difference = tf.maximum(0, batch_max_targets_sequence_lenght - batch_max_logits_sequence_lenght)
+    batch_max_targets_sequence_length = tf.shape(targets)[1]
+    batch_max_logits_sequence_length = tf.shape(logits)[1]
+    difference = tf.maximum(0, batch_max_targets_sequence_length - batch_max_logits_sequence_length)
     padded_logits = tf.pad(logits, [[0, 0], [0, difference], [0, 0]])
-    padded_logits = padded_logits[:, :batch_max_targets_sequence_lenght, :]
+    padded_logits = padded_logits[:, :batch_max_targets_sequence_length, :]
 
     with tf.variable_scope('sequence_loss'):
         sequence_loss = tf.contrib.seq2seq.sequence_loss(
             padded_logits,
             targets,
             tf.sequence_mask(targets_sequence_length,
-                             batch_max_targets_sequence_lenght,
+                             batch_max_targets_sequence_length,
                              dtype=tf.float32),
             average_across_timesteps=True,
             average_across_batch=False,
             softmax_loss_function=softmax_function
         )
 
-    # batch_max_seq_lenght = tf.shape(logits)[1]
+    # batch_max_seq_length = tf.shape(logits)[1]
     # unpadded_targets = targets[:, :tf.shape(logits)[1]]
     # with tf.variable_scope('sequence_loss'):
     #     sequence_loss = tf.contrib.seq2seq.sequence_loss(
     #         logits,
     #         unpadded_targets,
-    #         tf.sequence_mask(targets_sequence_length, batch_max_seq_lenght, dtype=tf.float32),
+    #         tf.sequence_mask(targets_sequence_length, batch_max_seq_length, dtype=tf.float32),
     #         average_across_timesteps=True,
     #         average_across_batch=False,
     #         softmax_loss_function=softmax_function
@@ -181,20 +181,20 @@ def sequence_sampled_softmax_cross_entropy(targets, targets_sequence_length,
                                            class_weights,
                                            class_biases, loss,
                                            num_classes):
-    batch_max_targets_sequence_lenght = tf.shape(targets)[1]
+    batch_max_targets_sequence_length = tf.shape(targets)[1]
 
-    batch_max_train_logits_sequence_lenght = tf.shape(train_logits)[1]
-    difference_train = batch_max_targets_sequence_lenght - batch_max_train_logits_sequence_lenght
+    batch_max_train_logits_sequence_length = tf.shape(train_logits)[1]
+    difference_train = batch_max_targets_sequence_length - batch_max_train_logits_sequence_length
     padded_train_logits = tf.pad(train_logits,
                                  [[0, 0], [0, difference_train], [0, 0]])
 
-    batch_max_eval_logits_sequence_lenght = tf.shape(eval_logits)[1]
-    difference_eval = batch_max_targets_sequence_lenght - batch_max_eval_logits_sequence_lenght
+    batch_max_eval_logits_sequence_length = tf.shape(eval_logits)[1]
+    difference_eval = batch_max_targets_sequence_length - batch_max_eval_logits_sequence_length
     padded_eval_logits = tf.pad(eval_logits,
                                 [[0, 0], [0, difference_eval], [0, 0]])
 
-    # batch_max_seq_lenght = tf.shape(train_logits)[1]
-    # unpadded_targets = targets[:, :batch_max_seq_lenght]
+    # batch_max_seq_length = tf.shape(train_logits)[1]
+    # unpadded_targets = targets[:, :batch_max_seq_length]
     # output_exp = tf.cast(tf.reshape(unpadded_targets, [-1, 1]), tf.int64)
     output_exp = tf.cast(tf.reshape(targets, [-1, 1]), tf.int64)
 
@@ -256,20 +256,20 @@ def sequence_sampled_softmax_cross_entropy(targets, targets_sequence_length,
         padded_train_logits,
         targets,
         tf.sequence_mask(targets_sequence_length,
-                         batch_max_targets_sequence_lenght, dtype=tf.float32),
+                         batch_max_targets_sequence_length, dtype=tf.float32),
         average_across_timesteps=True,
         average_across_batch=False,
         softmax_loss_function=_sampled_loss
     )
 
-    # batch_max_seq_lenght_eval = tf.shape(eval_logits)[1]
-    # unpadded_targets_eval = targets[:, :batch_max_seq_lenght_eval]
+    # batch_max_seq_length_eval = tf.shape(eval_logits)[1]
+    # unpadded_targets_eval = targets[:, :batch_max_seq_length_eval]
 
     eval_loss = tf.contrib.seq2seq.sequence_loss(
         padded_eval_logits,
         targets,
         tf.sequence_mask(targets_sequence_length,
-                         batch_max_targets_sequence_lenght, dtype=tf.float32),
+                         batch_max_targets_sequence_length, dtype=tf.float32),
         average_across_timesteps=True,
         average_across_batch=False
     )

--- a/mkdocs/docs/user_guide.md
+++ b/mkdocs/docs/user_guide.md
@@ -606,7 +606,7 @@ Then a list `idx2str` and two dictionaries `str2idx` and `str2freq` are created 
 }
 ```
 
-Finally a numpy matrix is created with sizes `n x l` where `n` is the number of rows in the column and `l` is the minimum of the longest tokenized list and a `max_lenght` parameter that can be set.
+Finally a numpy matrix is created with sizes `n x l` where `n` is the number of rows in the column and `l` is the minimum of the longest tokenized list and a `max_length` parameter that can be set.
 All sequences shorter than `l` are padded on the right (but this behavior may also be modified through a parameter).
 
 | after formatter          | numpy matrix |


### PR DESCRIPTION
Looks like a length typo has been used in multiple places, this PR fixes this issue.