### PR TITLE
Refactor tests

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -138,6 +138,7 @@ class LudwigModel:
             self.model_definition = merge_with_defaults(model_definition)
         self.train_set_metadata = None
         self.model = None
+        self.exp_dir_name = None
 
     @staticmethod
     def _read_data(data_csv, data_dict):
@@ -407,7 +408,7 @@ class LudwigModel:
         (
             self.model,
             preprocessed_data,
-            _,
+            self.exp_dir_name,
             train_stats,
             self.model_definition
         ) = full_train(

--- a/tests/integration_tests/test_api.py
+++ b/tests/integration_tests/test_api.py
@@ -19,9 +19,10 @@ import shutil
 from ludwig.api import LudwigModel
 from ludwig.utils.data_utils import read_csv
 from tests.integration_tests.utils import ENCODERS
+from tests.integration_tests.utils import categorical_feature
 from tests.integration_tests.utils import generate_data
 from tests.integration_tests.utils import sequence_feature
-from tests.integration_tests.utils import categorical_feature
+
 # The following imports are pytest fixtures, required for running the tests
 from tests.fixtures.filenames import csv_filename
 

--- a/tests/integration_tests/test_api.py
+++ b/tests/integration_tests/test_api.py
@@ -20,8 +20,8 @@ from ludwig.api import LudwigModel
 from ludwig.utils.data_utils import read_csv
 from tests.integration_tests.utils import ENCODERS
 from tests.integration_tests.utils import generate_data
-from tests.integration_tests.utils import _sequence_feature
-from tests.integration_tests.utils import _categorical_feature
+from tests.integration_tests.utils import sequence_feature
+from tests.integration_tests.utils import categorical_feature
 # The following imports are pytest fixtures, required for running the tests
 from tests.fixtures.filenames import csv_filename
 
@@ -70,8 +70,8 @@ def run_api_experiment(input_features, output_features, data_csv):
 
 def test_api_intent_classification(csv_filename):
     # Single sequence input, single category output
-    input_features = [_sequence_feature()]
-    output_features = [_categorical_feature(vocab_size=2, reduce_input='sum')]
+    input_features = [sequence_feature(reduce_output='sum')]
+    output_features = [categorical_feature(vocab_size=2, reduce_input='sum')]
 
     # Generate test data
     rel_path = generate_data(input_features, output_features, csv_filename)

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -15,25 +15,25 @@
 # ==============================================================================
 import logging
 import os
+import shutil
 
 import pytest
 import yaml
-import shutil
 
-from ludwig.utils.data_utils import read_csv
 from ludwig.data.concatenate_datasets import concatenate_df
 from ludwig.experiment import experiment
 from ludwig.predict import full_predict
+from ludwig.utils.data_utils import read_csv
 from tests.integration_tests.utils import ENCODERS
+from tests.integration_tests.utils import bag_feature
+from tests.integration_tests.utils import binary_feature
+from tests.integration_tests.utils import categorical_feature
 from tests.integration_tests.utils import generate_data
+from tests.integration_tests.utils import image_feature
+from tests.integration_tests.utils import numerical_feature
 from tests.integration_tests.utils import sequence_feature
 from tests.integration_tests.utils import set_feature
 from tests.integration_tests.utils import text_feature
-from tests.integration_tests.utils import binary_feature
-from tests.integration_tests.utils import image_feature
-from tests.integration_tests.utils import numerical_feature
-from tests.integration_tests.utils import categorical_feature
-from tests.integration_tests.utils import bag_feature
 from tests.integration_tests.utils import timeseries_feature
 
 # The following imports are pytest fixtures, required for running the tests

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -13,389 +13,433 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-import glob
 import logging
 import os
-from string import Template
 
-import pandas as pd
 import pytest
 import yaml
+import shutil
 
+from ludwig.utils.data_utils import read_csv
 from ludwig.data.concatenate_datasets import concatenate_df
 from ludwig.experiment import experiment
 from ludwig.predict import full_predict
 from tests.integration_tests.utils import ENCODERS
 from tests.integration_tests.utils import generate_data
-from tests.integration_tests.utils import model_definition_template
+from tests.integration_tests.utils import _sequence_feature
+from tests.integration_tests.utils import _set_feature
+from tests.integration_tests.utils import _text_feature
+from tests.integration_tests.utils import _binary_feature
+from tests.integration_tests.utils import _image_feature
+from tests.integration_tests.utils import _numerical_feature
+from tests.integration_tests.utils import _categorical_feature
+from tests.integration_tests.utils import _bag_feature
+from tests.integration_tests.utils import _timeseries_feature
+
 # The following imports are pytest fixtures, required for running the tests
 from tests.fixtures.filenames import csv_filename
 from tests.fixtures.filenames import yaml_filename
 
 
-def run_experiment(input_features, output_features, data_csv):
+def run_experiment(input_features, output_features, **kwargs):
     """
-    Helper method to avoid code repetition in running an experiment
-    :param input_features: input schema
-    :param output_features: output schema
-    :param data_csv: path to data
+    Helper method to avoid code repetition in running an experiment. Deletes
+    the data saved to disk after running the experiment
+    :param input_features: list of input feature dictionaries
+    :param output_features: list of output feature dictionaries
+    **kwargs you may also pass extra parameters to the experiment as keyword
+    arguments
     :return: None
     """
-    model_definition = model_definition_template.substitute(
-        input_name=input_features,
-        output_name=output_features
-    )
+    model_definition = None
+    if input_features is not None and output_features is not None:
+        model_definition = {
+            'input_features': input_features,
+            'output_features': output_features,
+            'combiner': {
+                'type': 'concat',
+                'fc_size': 14
+            },
+            'training': {'epochs': 2}
+        }
 
-    experiment(
-        yaml.safe_load(model_definition),
-        skip_save_processed_input=True,
-        skip_save_progress=True,
-        skip_save_unprocessed_output=True,
-        data_csv=data_csv
-    )
+    args = {
+        'model_definition': model_definition,
+        'skip_save_processed_input': True,
+        'skip_save_progress': True,
+        'skip_save_unprocessed_output': True,
+    }
+    args.update(kwargs)
+
+    exp_dir_name = experiment(**args)
+    shutil.rmtree(exp_dir_name, ignore_errors=True)
 
 
-def test_experiment_seq_seq1(csv_filename):
+def test_experiment_seq_seq(csv_filename):
     # Single Sequence input, single sequence output
     # Only the following encoders are working
-    input_features_template = Template(
-        '[{name: utterance, type: text, reduce_output: null,'
-        ' vocab_size: 10, min_len: 10, max_len: 10, encoder: ${encoder}}]')
+    input_features = [_text_feature(reduce_output=None, encoder='rnn')]
+    output_features = [_text_feature(reduce_input=None, decoder='tagger')]
 
-    output_features = '[{name: iob, type: text, reduce_input: null,' \
-                      ' vocab_size: 3, min_len: 10, max_len: 10,' \
-                      ' decoder: tagger}]'
     # Generate test data
-    rel_path = generate_data(
-        input_features_template.substitute(encoder='rnn'),
-        output_features,
-        csv_filename
-    )
+    rel_path = generate_data(input_features, output_features, csv_filename)
 
-    encoders2 = ['embed', 'rnn', 'cnnrnn']
+    encoders2 = ['cnnrnn', 'stacked_cnn']
     for encoder in encoders2:
-        logging.info('Test 2, Encoder: {0}'.format(encoder))
-
-        input_features = input_features_template.substitute(encoder=encoder)
+        logging.error('seq to seq test, Encoder: {0}'.format(encoder))
+        input_features[0]['encoder'] = encoder
         run_experiment(input_features, output_features, data_csv=rel_path)
 
 
-def test_experiment_seq_seq1_model_def_file(csv_filename, yaml_filename):
+def test_experiment_seq_seq_model_def_file(csv_filename, yaml_filename):
     # seq-to-seq test to use model definition file instead of dictionary
-    input_features = ('[{name: utt, type: text, reduce_output: null, '
-                      'vocab_size: 10, min_len: 10, max_len: 10,'
-                      ' encoder: embed}]')
-
-    output_features = ('[{name: iob, type: text, reduce_input: null, '
-                       'vocab_size: 3, min_len: 10, max_len: 10,'
-                       ' decoder: tagger}]')
+    input_features = [_text_feature(reduce_output=None, encoder='embed')]
+    output_features = [
+        _text_feature(reduce_input=None, vocab_size=3, decoder='tagger')
+    ]
 
     # Save the model definition to a yaml file
-    model_definition = yaml.load(model_definition_template.substitute(
-        input_name=input_features,
-        output_name=output_features
-    ))
+    model_definition = {
+        'input_features': input_features,
+        'output_features': output_features,
+        'combiner': {'type': 'concat', 'fc_size': 14},
+        'training': {'epochs': 2}
+    }
     with open(yaml_filename, 'w') as yaml_out:
-        yaml.dump(model_definition, yaml_out)
+        yaml.safe_dump(model_definition, yaml_out)
 
     rel_path = generate_data(input_features, output_features, csv_filename)
-    experiment(
-        model_definition=None,
-        model_definition_file=yaml_filename,
-        skip_save_processed_input=True,
-        skip_save_progress=True,
-        skip_save_unprocessed_output=True,
-        data_csv=rel_path
+    run_experiment(
+        None, None, data_csv=rel_path, model_definition_file=yaml_filename
     )
+
+
+def test_experiment_seq_seq_train_test_valid(csv_filename):
+    # seq-to-seq test to use train, test, validation files
+    input_features = [_text_feature(reduce_output=None, encoder='rnn')]
+    output_features = [
+        _text_feature(reduce_input=None, vocab_size=3, decoder='tagger')
+    ]
+
+    train_csv = generate_data(
+        input_features, output_features, 'tr_' + csv_filename
+    )
+    test_csv = generate_data(
+        input_features, output_features, 'test_' + csv_filename, 20
+    )
+    valdation_csv = generate_data(
+        input_features, output_features, 'val_' + csv_filename, 20
+    )
+
+    run_experiment(
+        input_features,
+        output_features,
+        data_train_csv=train_csv,
+        data_test_csv=test_csv,
+        data_validation_csv=valdation_csv
+    )
+
+    input_features[0]['encoder'] = 'parallel_cnn'
+    # Save intermediate output
+    run_experiment(
+        input_features,
+        output_features,
+        data_train_csv=train_csv,
+        data_test_csv=test_csv,
+        data_validation_csv=valdation_csv,
+        skip_save_processed_input=False,
+    )
+
+    # Delete the temporary data created
+    for prefix in ['tr_', 'test_', 'val_']:
+        if os.path.isfile(prefix + csv_filename):
+            os.remove(prefix + csv_filename)
 
 
 def test_experiment_multi_input_intent_classification(csv_filename):
     # Multiple inputs, Single category output
-    input_features_string = Template(
-        "[{type: text, name: random_text, vocab_size: 100, max_len: 10,"
-        " encoder: ${encoder1}}, {type: category, name: random_category,"
-        " vocab_size: 10, encoder: ${encoder2}}]")
-    output_features_string = ("[{type: category, name: intent, reduce_input:"
-                              " sum, vocab_size: 2}]")
+    input_features = [
+        _text_feature(vocab_size=10, min_len=1, representation='sparse'),
+        _categorical_feature(
+            vocab_size=10,
+            loss='sampled_softmax_cross_entropy'
+        )
+    ]
+    output_features = [_categorical_feature(vocab_size=2, reduce_input='sum')]
 
     # Generate test data
-    rel_path = generate_data(
-        input_features_string.substitute(encoder1='rnn', encoder2='rnn'),
-        output_features_string,
-        csv_filename
-    )
+    rel_path = generate_data(input_features, output_features, csv_filename)
 
-    for encoder1, encoder2 in zip(ENCODERS, ENCODERS):
-        input_features = input_features_string.substitute(encoder1=encoder1,
-                                                          encoder2=encoder2)
-
-        run_experiment(input_features, output_features_string, rel_path)
+    for encoder in ENCODERS:
+        input_features[0]['encoder'] = encoder
+        run_experiment(input_features, output_features, data_csv=rel_path)
 
 
 def test_experiment_multiple_seq_seq(csv_filename):
     # Multiple inputs, Multiple outputs
-    input_features = "[{type: text, name: random_text, vocab_size: 100," \
-                     " max_len: 10, encoder: stacked_cnn}, {type: numerical," \
-                     " name: random_number}, " \
-                     "{type: category, name: random_category, vocab_size: 10," \
-                     " encoder: stacked_parallel_cnn}, " \
-                     "{type: set, name: random_set, vocab_size: 10," \
-                     " max_len: 10}," \
-                     "{type: sequence, name: random_sequence, vocab_size: 10," \
-                     " max_len: 10, encoder: embed}]"
-    output_features = "[{type: category, name: intent, reduce_input: sum," \
-                      " vocab_size: 2}," \
-                      "{type: sequence, name: random_seq_output, vocab_size: " \
-                      "10, max_len: 5}," \
-                      "{type: numerical, name: random_num_output}]"
+    input_features = [
+        _text_feature(vocab_size=100, min_len=1, encoder='stacked_cnn'),
+        _numerical_feature(),
+        _categorical_feature(vocab_size=10, embedding_size=5),
+        _set_feature(),
+        _sequence_feature(vocab_size=10, max_len=10, encoder='embed')
+    ]
+    output_features = [
+        _categorical_feature(vocab_size=2, reduce_input='sum'),
+        _sequence_feature(vocab_size=10, max_len=5),
+        _numerical_feature()
+    ]
 
     rel_path = generate_data(input_features, output_features, csv_filename)
-    run_experiment(input_features, output_features, rel_path)
+    run_experiment(input_features, output_features, data_csv=rel_path)
 
     # Use generator as decoder
-    output_features = "[{type: category, name: intent, reduce_input: sum," \
-                      " vocab_size: 2, decoder: generator, " \
-                      "reduce_input: sum}," \
-                      "{type: sequence, name: random_seq_output, " \
-                      "vocab_size: 10, max_len: 5}," \
-                      "{type: numerical, name: random_num_output}]"
+    output_features = [
+        _categorical_feature(vocab_size=2, reduce_input='sum'),
+        _sequence_feature(vocab_size=10, max_len=5, decoder='generator'),
+        _numerical_feature()
+    ]
 
     rel_path = generate_data(input_features, output_features, csv_filename)
-    run_experiment(input_features, output_features, rel_path)
+    run_experiment(input_features, output_features, data_csv=rel_path)
 
     # Generator decoder and reduce_input = None
-    output_features = "[{type: category, name: intent, reduce_input: sum," \
-                      " vocab_size: 2}," \
-                      "{type: sequence, name: random_seq_op, vocab_size: 10," \
-                      " max_len: 5, decoder: generator, reduce_input: None}," \
-                      "{type: numerical, name: random_num_op}]"
-
+    output_features = [
+        _categorical_feature(vocab_size=2, reduce_input='sum'),
+        _sequence_feature(max_len=5, decoder='generator', reduce_input=None),
+        _numerical_feature()
+    ]
     rel_path = generate_data(input_features, output_features, csv_filename)
-    run_experiment(input_features, output_features, rel_path)
+    run_experiment(input_features, output_features, data_csv=rel_path)
 
 
 def test_experiment_image_inputs(csv_filename):
     # Image Inputs
     image_dest_folder = os.path.join(os.getcwd(), 'generated_images')
-    input_features_template = Template(
-        "[{type: text, name: random_text, vocab_size: 10,"
-        " max_len: 10, encoder: stacked_cnn}, {type: numerical,"
-        " name: random_number}, "
-        "{type: image, name: random_image, encoder: ${encoder},"
-        "preprocessing: {in_memory: ${in_memory}, height: 8, width: 8, "
-        "num_channels: 3}, resnet_size: 8, destination_folder: ${folder}, "
-        "fc_size: 32, num_filters: 8}]")
 
     # Resnet encoder
-    input_features = input_features_template.substitute(
-        encoder='resnet',
-        folder=image_dest_folder,
-        in_memory='true',
-    )
-    output_features = "[{type: category, name: intent, reduce_input: sum," \
-                      " vocab_size: 2}," \
-                      "{type: numerical, name: random_num_output}]"
+    input_features = [
+        _image_feature(
+            folder=image_dest_folder,
+            encoder='resnet',
+            preprocessing={
+                'in_memory': True,
+                'height': 8,
+                'width': 8,
+                'num_channels': 3
+            },
+            fc_size=16,
+            num_filters=8
+        ),
+        _text_feature(encoder='embed', min_len=1),
+        _numerical_feature()
+    ]
+    output_features = [
+        _categorical_feature(vocab_size=2, reduce_input='sum'),
+        _numerical_feature()
+    ]
 
     rel_path = generate_data(input_features, output_features, csv_filename)
-    run_experiment(input_features, output_features, rel_path)
+    run_experiment(input_features, output_features, data_csv=rel_path)
 
     # Stacked CNN encoder
-    input_features = input_features_template.substitute(
-        encoder='stacked_cnn',
-        folder=image_dest_folder,
-        in_memory='true',
-    )
-
+    input_features[0]['encoder'] = 'stacked_cnn'
     rel_path = generate_data(input_features, output_features, csv_filename)
-    run_experiment(input_features, output_features, rel_path)
+    run_experiment(input_features, output_features, data_csv=rel_path)
 
-    # Stacked CNN encoder
-    input_features = input_features_template.substitute(
-        encoder='stacked_cnn',
-        folder=image_dest_folder,
-        in_memory='false',
-    )
-
+    # Stacked CNN encoder, in_memory = False
+    input_features[0]['preprocessing']['in_memory'] = False
     rel_path = generate_data(input_features, output_features, csv_filename)
-    run_experiment(input_features, output_features, rel_path)
+    run_experiment(input_features, output_features, data_csv=rel_path)
 
     # Delete the temporary data created
-    all_images = glob.glob(os.path.join(image_dest_folder, '*.jpg'))
-    for im in all_images:
-        os.remove(im)
-
-    os.rmdir(image_dest_folder)
+    shutil.rmtree(image_dest_folder)
 
 
 def test_experiment_tied_weights(csv_filename):
     # Single sequence input, single category output
-    input_features = Template('[{name: utterance1, type: text,'
-                              'vocab_size: 10, max_len: 10, '
-                              'encoder: ${encoder}, reduce_output: sum},'
-                              '{name: utterance2, type: text, vocab_size: 10,'
-                              'max_len: 10, encoder: ${encoder}, '
-                              'reduce_output: sum, tied_weights: utterance1}]')
-    output_features = "[{name: intent, type: category, vocab_size: 2," \
-                      " reduce_input: sum}] "
+    input_features = [
+        _text_feature(
+            name='text_feature1',
+            min_len=1,
+            encoder='cnnrnn',
+            reduce_output='sum'
+        ),
+        _text_feature(
+            name='text_feature2',
+            min_len=1,
+            encoder='cnnrnn',
+            reduce_output='sum',
+            tied_weights='text_feature1'
+        )
+    ]
+    output_features = [_categorical_feature(vocab_size=2, reduce_input='sum')]
 
     # Generate test data
-    rel_path = generate_data(
-        input_features.substitute(encoder='rnn'),
-        output_features,
-        csv_filename
-    )
+    rel_path = generate_data(input_features, output_features, csv_filename)
     for encoder in ENCODERS:
-        run_experiment(input_features.substitute(encoder=encoder),
-                       output_features,
-                       data_csv=rel_path)
+        input_features[0]['encoder'] = encoder
+        input_features[1]['encoder'] = encoder
+        run_experiment(input_features, output_features, data_csv=rel_path)
 
 
 def test_experiment_attention(csv_filename):
     # Machine translation with attention
-    input_features = '[{name: english, type: sequence, vocab_size: 10,' \
-                     ' max_len: 10, encoder: rnn, cell_type: lstm} ]'
-    output_features = Template("[{name: spanish, type: sequence,"
-                               " vocab_size: 10, max_len: 10,"
-                               " decoder: generator, cell_type: lstm,"
-                               " attention: ${attention}}] ")
+    input_features = [
+            _sequence_feature(encoder='rnn', cell_type='lstm', max_len=10)
+        ]
+    output_features = [
+        _sequence_feature(
+            max_len=10,
+            cell_type='lstm',
+            decoder='generator',
+            attention='bahdanau'
+        )
+    ]
 
     # Generate test data
-    rel_path = generate_data(
-        input_features,
-        output_features.substitute(attention='bahdanau'),
-        csv_filename
-    )
+    rel_path = generate_data(input_features, output_features, csv_filename)
 
     for attention in ['bahdanau', 'luong']:
-        run_experiment(input_features, output_features.substitute(
-            attention=attention), data_csv=rel_path)
+        output_features[0]['attention'] = attention
+        run_experiment(input_features, output_features, data_csv=rel_path)
 
 
 def test_experiment_sequence_combiner(csv_filename):
     # Sequence combiner
-    input_features_template = Template(
-        '[{name: english, type: sequence, vocab_size: 10,'
-        ' max_len: 5, min_len: 5, encoder: rnn, cell_type: lstm,'
-        ' reduce_output: null}, {name: spanish, type: sequence, vocab_size: 10,'
-        ' max_len: 5, min_len: 5, encoder: rnn, cell_type: lstm,'
-        ' reduce_output: null}, {name: category,'
-        ' type: category, vocab_size: 5} ]')
+    input_features = [
+        _sequence_feature(
+            name='english',
+            min_len=5,
+            max_len=5,
+            encoder='rnn',
+            cell_type='lstm',
+            reduce_output=None
+        ),
+        _sequence_feature(
+            name='spanish',
+            min_len=5,
+            max_len=5,
+            encoder='rnn',
+            cell_type='lstm',
+            reduce_output=None
+        ),
+        _categorical_feature(vocab_size=5)
+    ]
+    output_features = [
+        _categorical_feature(reduce_input='sum', vocab_size=5)
+    ]
 
-    output_features_string = "[{type: category, name: intent, reduce_input:" \
-                             " sum, vocab_size: 5}]"
-
-    model_definition_template2 = Template(
-        '{input_features: ${input_name}, output_features: ${output_name}, '
-        'training: {epochs: 2}, combiner: {type: sequence_concat, encoder: rnn,'
-        'main_sequence_feature: random_sequence}}')
+    model_definition = {
+        'input_features': input_features,
+        'output_features': output_features,
+        'training': {
+            'epochs': 2
+        },
+        'combiner': {
+            'type': 'sequence_concat',
+            'encoder': 'rnn',
+            'main_sequence_feature': 'random_sequence'
+        }
+    }
 
     # Generate test data
-    rel_path = generate_data(
-        input_features_template.substitute(encoder1='rnn', encoder2='rnn'),
-        output_features_string,
-        csv_filename
-    )
+    rel_path = generate_data(input_features, output_features, csv_filename)
 
-    for encoder1, encoder2 in zip(ENCODERS, ENCODERS):
-        input_features = input_features_template.substitute(
-            encoder1=encoder1,
-            encoder2=encoder2)
+    for encoder in ENCODERS[:-2]:
+        logging.error('sequence combiner. encoders: {0}, {1}'.format(
+            encoder,
+            encoder
+        ))
+        input_features[0]['encoder'] = encoder
+        input_features[1]['encoder'] = encoder
 
-        model_definition = model_definition_template2.substitute(
-            input_name=input_features,
-            output_name=output_features_string
+        model_definition['input_features'] = input_features
+
+        exp_dir_name = experiment(
+            model_definition,
+            skip_save_processed_input=True,
+            skip_save_progress=True,
+            skip_save_unprocessed_output=True,
+            data_csv=rel_path
         )
-
-        experiment(yaml.safe_load(model_definition),
-                   skip_save_processed_input=True,
-                   skip_save_progress=True,
-                   skip_save_unprocessed_output=True, data_csv=rel_path
-                   )
+        shutil.rmtree(exp_dir_name, ignore_errors=True)
 
 
 def test_experiment_model_resume(csv_filename):
     # Single sequence input, single category output
     # Tests saving a model file, loading it to rerun training and predict
-    input_features = '[{name: utterance, type: sequence, vocab_size: 10,' \
-                     ' max_len: 10, encoder: rnn, reduce_output: sum}]'
-    output_features = "[{name: intent, type: category, vocab_size: 2," \
-                      " reduce_input: sum}] "
-
+    input_features = [_sequence_feature(encoder='rnn', reduce_output='sum')]
+    output_features = [_categorical_feature(vocab_size=2, reduce_input='sum')]
     # Generate test data
     rel_path = generate_data(input_features, output_features, csv_filename)
 
-    model_definition = model_definition_template.substitute(
-        input_name=input_features, output_name=output_features
-    )
+    model_definition = {
+        'input_features': input_features,
+        'output_features': output_features,
+        'combiner': {'type': 'concat', 'fc_size': 14},
+        'training': {'epochs': 2}
+    }
 
-    exp_dir_name = experiment(yaml.safe_load(model_definition),
-                              data_csv=rel_path)
+    exp_dir_name = experiment(model_definition, data_csv=rel_path)
     logging.info('Experiment Directory: {0}'.format(exp_dir_name))
 
-    experiment(yaml.safe_load(model_definition), data_csv=rel_path,
-               model_resume_path=exp_dir_name)
+    experiment(
+        model_definition,
+        data_csv=rel_path,
+        model_resume_path=exp_dir_name
+    )
 
     full_predict(os.path.join(exp_dir_name, 'model'), data_csv=rel_path)
+    shutil.rmtree(exp_dir_name, ignore_errors=True)
 
 
 def test_experiment_various_feature_types(csv_filename):
-    input_features_template = Template(
-        '[{name: binary_input, type: binary}, '
-        '{name: bag_input, type: bag, max_len: 5, vocab_size: 10,'
-        ' encoder: ${encoder}}]')
-    # {name: intent_binary, type: binary},
-    output_features = "[ {name: set_output, type: set, max_len: 3," \
-                      " vocab_size: 5}] "
+    input_features = [_binary_feature(), _bag_feature()]
+    output_features = [_set_feature(max_len=3, vocab_size=5)]
 
     # Generate test data
-    rel_path = generate_data(
-        input_features_template.substitute(encoder='rnn'),
-        output_features,
-        csv_filename
-    )
-    for encoder in ENCODERS:
-        run_experiment(input_features_template.substitute(encoder=encoder),
-                       output_features, data_csv=rel_path)
+    rel_path = generate_data(input_features, output_features, csv_filename)
+    run_experiment(input_features, output_features, data_csv=rel_path)
 
 
 def test_experiment_timeseries(csv_filename):
-    input_features_template = Template(
-        '[{name: time_series, type: timeseries, max_len: 10}]')
-    output_features = "[ {name: binary_output, type: binary}, ]"
+    input_features = [_timeseries_feature()]
+    output_features = [_binary_feature()]
 
+    encoders2 = [
+        'rnn', 'cnnrnn', 'stacked_cnn', 'parallel_cnn', 'stacked_parallel_cnn'
+    ]
     # Generate test data
-    rel_path = generate_data(
-        input_features_template.substitute(encoder='rnn'),
-        output_features,
-        csv_filename
-    )
-    for encoder in ENCODERS:
-        run_experiment(input_features_template.substitute(encoder=encoder),
-                       output_features, data_csv=rel_path)
+    rel_path = generate_data(input_features, output_features, csv_filename)
+    for encoder in encoders2:
+        input_features[0]['encoder'] = encoder
+        run_experiment(input_features, output_features, data_csv=rel_path)
 
 
 def test_visual_question_answering(csv_filename):
     image_dest_folder = os.path.join(os.getcwd(), 'generated_images')
-    input_features = Template(
-        '[{name: image_path, type: image, encoder: stacked_cnn, preprocessing:'
-        '{width: 10, height: 10, num_channels: 3}, resnet_size: 8, fc_size: 32,'
-        'destination_folder: ${folder}}, {name: question, type: text, '
-        'vocab_size: 20, max_len: 10,encoder: parallel_cnn, '
-        'level: word}]').substitute(
-        folder=image_dest_folder)
-
-    output_features = "[ {name: answer, type: sequence, max_len: 5, " \
-                      "vocab_size: 10, decoder: generator, cell_type: lstm}]"
-
+    input_features = [
+        _image_feature(
+            folder=image_dest_folder,
+            encoder='resnet',
+            preprocessing={
+                'in_memory': True,
+                'height': 8,
+                'width': 8,
+                'num_channels': 3
+            },
+            fc_size=8,
+            num_filters=8
+        ),
+        _text_feature(encoder='embed', min_len=1, level='word'),
+    ]
+    output_features = [_sequence_feature(decoder='generator', cell_type='lstm')]
     rel_path = generate_data(input_features, output_features, csv_filename)
-    run_experiment(input_features, output_features, rel_path)
+    run_experiment(input_features, output_features, data_csv=rel_path)
 
     # Delete the temporary data created
-    all_images = glob.glob(os.path.join(image_dest_folder, '*.jpg'))
-    for im in all_images:
-        os.remove(im)
-
-    os.rmdir(image_dest_folder)
+    shutil.rmtree(image_dest_folder)
 
 
 def test_image_resizing_num_channel_handling(csv_filename):
@@ -409,78 +453,51 @@ def test_image_resizing_num_channel_handling(csv_filename):
     """
     # Image Inputs
     image_dest_folder = os.path.join(os.getcwd(), 'generated_images')
-    input_features_template = Template(
-        "[{type: text, name: random_text, vocab_size: 100,"
-        " max_len: 10, encoder: stacked_cnn}, {type: numerical,"
-        " name: random_number}, "
-        "{type: image, name: random_image, encoder: ${encoder}, preprocessing:"
-        " {width: 8, in_memory: ${in_memory},"
-        " height: 8, num_channels: 3},"
-        " resnet_size: 8, fc_size: 32, destination_folder: ${folder}}]")
 
     # Resnet encoder
-    input_features = input_features_template.substitute(
-        encoder='resnet',
-        folder=image_dest_folder,
-        in_memory='true',
-    )
-    output_features = "[{type: binary, name: intent, reduce_input: sum}, " \
-                      "{type: numerical, name: random_num_output}]"
-
+    input_features = [
+        _image_feature(
+            folder=image_dest_folder,
+            encoder='resnet',
+            preprocessing={
+                'in_memory': True,
+                'height': 8,
+                'width': 8,
+                'num_channels': 3
+            },
+            fc_size=8,
+            num_filters=8
+        ),
+        _text_feature(encoder='embed', min_len=1),
+        _numerical_feature()
+    ]
+    output_features = [_binary_feature(), _numerical_feature()]
     rel_path = generate_data(
-        input_features, output_features, csv_filename, num_examples=100
+        input_features, output_features, csv_filename, num_examples=50
     )
 
-    df1 = pd.read_csv(rel_path)
+    df1 = read_csv(rel_path)
 
-    input_features_template = Template(
-        "[{type: text, name: random_text, vocab_size: 100,"
-        " max_len: 10, encoder: stacked_cnn}, {type: numerical,"
-        " name: random_number}, "
-        "{type: image, name: random_image, preprocessing: {width: 8,"
-        " in_memory: ${in_memory}, height: 8, num_channels: 1},"
-        " encoder: ${encoder}, fc_size: 32, "
-        " resnet_size: 8, destination_folder: ${folder}}]")
-
-    input_features = input_features_template.substitute(
-        encoder='resnet',
-        folder=image_dest_folder,
-        in_memory='true',
-    )
+    input_features[0]['preprocessing']['num_channels'] = 1
     rel_path = generate_data(
-        input_features, output_features, csv_filename, num_examples=100
+        input_features, output_features, csv_filename, num_examples=50
     )
-    df2 = pd.read_csv(rel_path)
+    df2 = read_csv(rel_path)
 
     df = concatenate_df(df1, df2, None)
     df.to_csv(rel_path, index=False)
 
     # Here the user sepcifiies number of channels. Exception shouldn't be thrown
-    run_experiment(input_features, output_features, rel_path)
+    run_experiment(input_features, output_features, data_csv=rel_path)
 
-    input_features_template = Template(
-        "[{type: text, name: random_text, vocab_size: 100,"
-        " max_len: 10, encoder: stacked_cnn}, {type: numerical,"
-        " name: random_number}, "
-        "{type: image, name: random_image, preprocessing: {width: 8, "
-        "in_memory: ${in_memory}, height: 8} , encoder: ${encoder},"
-        " resnet_size: 8, fc_size: 32, destination_folder: ${folder}}]")
+    del input_features[0]['preprocessing']['num_channels']
 
-    input_features = input_features_template.substitute(
-        encoder='resnet',
-        folder=image_dest_folder,
-        in_memory='true',
-    )
     # User now doesn't specify num channels. Should throw exception
     with pytest.raises(ValueError):
-        run_experiment(input_features, output_features, rel_path)
+        run_experiment(input_features, output_features, data_csv=rel_path)
 
     # Delete the temporary data created
-    all_images = glob.glob(os.path.join(image_dest_folder, '*.jpg'))
-    for im in all_images:
-        os.remove(im)
-
-    os.rmdir(image_dest_folder)
+    shutil.rmtree(image_dest_folder)
 
 
 if __name__ == '__main__':

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -26,15 +26,15 @@ from ludwig.experiment import experiment
 from ludwig.predict import full_predict
 from tests.integration_tests.utils import ENCODERS
 from tests.integration_tests.utils import generate_data
-from tests.integration_tests.utils import _sequence_feature
-from tests.integration_tests.utils import _set_feature
-from tests.integration_tests.utils import _text_feature
-from tests.integration_tests.utils import _binary_feature
-from tests.integration_tests.utils import _image_feature
-from tests.integration_tests.utils import _numerical_feature
-from tests.integration_tests.utils import _categorical_feature
-from tests.integration_tests.utils import _bag_feature
-from tests.integration_tests.utils import _timeseries_feature
+from tests.integration_tests.utils import sequence_feature
+from tests.integration_tests.utils import set_feature
+from tests.integration_tests.utils import text_feature
+from tests.integration_tests.utils import binary_feature
+from tests.integration_tests.utils import image_feature
+from tests.integration_tests.utils import numerical_feature
+from tests.integration_tests.utils import categorical_feature
+from tests.integration_tests.utils import bag_feature
+from tests.integration_tests.utils import timeseries_feature
 
 # The following imports are pytest fixtures, required for running the tests
 from tests.fixtures.filenames import csv_filename
@@ -53,6 +53,8 @@ def run_experiment(input_features, output_features, **kwargs):
     """
     model_definition = None
     if input_features is not None and output_features is not None:
+        # This if is necessary so that the caller can call with
+        # model_definition_file (and not model_definition)
         model_definition = {
             'input_features': input_features,
             'output_features': output_features,
@@ -78,24 +80,24 @@ def run_experiment(input_features, output_features, **kwargs):
 def test_experiment_seq_seq(csv_filename):
     # Single Sequence input, single sequence output
     # Only the following encoders are working
-    input_features = [_text_feature(reduce_output=None, encoder='rnn')]
-    output_features = [_text_feature(reduce_input=None, decoder='tagger')]
+    input_features = [text_feature(reduce_output=None, encoder='rnn')]
+    output_features = [text_feature(reduce_input=None, decoder='tagger')]
 
     # Generate test data
     rel_path = generate_data(input_features, output_features, csv_filename)
 
     encoders2 = ['cnnrnn', 'stacked_cnn']
     for encoder in encoders2:
-        logging.error('seq to seq test, Encoder: {0}'.format(encoder))
+        logging.info('seq to seq test, Encoder: {0}'.format(encoder))
         input_features[0]['encoder'] = encoder
         run_experiment(input_features, output_features, data_csv=rel_path)
 
 
 def test_experiment_seq_seq_model_def_file(csv_filename, yaml_filename):
     # seq-to-seq test to use model definition file instead of dictionary
-    input_features = [_text_feature(reduce_output=None, encoder='embed')]
+    input_features = [text_feature(reduce_output=None, encoder='embed')]
     output_features = [
-        _text_feature(reduce_input=None, vocab_size=3, decoder='tagger')
+        text_feature(reduce_input=None, vocab_size=3, decoder='tagger')
     ]
 
     # Save the model definition to a yaml file
@@ -116,9 +118,9 @@ def test_experiment_seq_seq_model_def_file(csv_filename, yaml_filename):
 
 def test_experiment_seq_seq_train_test_valid(csv_filename):
     # seq-to-seq test to use train, test, validation files
-    input_features = [_text_feature(reduce_output=None, encoder='rnn')]
+    input_features = [text_feature(reduce_output=None, encoder='rnn')]
     output_features = [
-        _text_feature(reduce_input=None, vocab_size=3, decoder='tagger')
+        text_feature(reduce_input=None, vocab_size=3, decoder='tagger')
     ]
 
     train_csv = generate_data(
@@ -159,13 +161,13 @@ def test_experiment_seq_seq_train_test_valid(csv_filename):
 def test_experiment_multi_input_intent_classification(csv_filename):
     # Multiple inputs, Single category output
     input_features = [
-        _text_feature(vocab_size=10, min_len=1, representation='sparse'),
-        _categorical_feature(
+        text_feature(vocab_size=10, min_len=1, representation='sparse'),
+        categorical_feature(
             vocab_size=10,
             loss='sampled_softmax_cross_entropy'
         )
     ]
-    output_features = [_categorical_feature(vocab_size=2, reduce_input='sum')]
+    output_features = [categorical_feature(vocab_size=2, reduce_input='sum')]
 
     # Generate test data
     rel_path = generate_data(input_features, output_features, csv_filename)
@@ -178,16 +180,16 @@ def test_experiment_multi_input_intent_classification(csv_filename):
 def test_experiment_multiple_seq_seq(csv_filename):
     # Multiple inputs, Multiple outputs
     input_features = [
-        _text_feature(vocab_size=100, min_len=1, encoder='stacked_cnn'),
-        _numerical_feature(),
-        _categorical_feature(vocab_size=10, embedding_size=5),
-        _set_feature(),
-        _sequence_feature(vocab_size=10, max_len=10, encoder='embed')
+        text_feature(vocab_size=100, min_len=1, encoder='stacked_cnn'),
+        numerical_feature(),
+        categorical_feature(vocab_size=10, embedding_size=5),
+        set_feature(),
+        sequence_feature(vocab_size=10, max_len=10, encoder='embed')
     ]
     output_features = [
-        _categorical_feature(vocab_size=2, reduce_input='sum'),
-        _sequence_feature(vocab_size=10, max_len=5),
-        _numerical_feature()
+        categorical_feature(vocab_size=2, reduce_input='sum'),
+        sequence_feature(vocab_size=10, max_len=5),
+        numerical_feature()
     ]
 
     rel_path = generate_data(input_features, output_features, csv_filename)
@@ -195,9 +197,9 @@ def test_experiment_multiple_seq_seq(csv_filename):
 
     # Use generator as decoder
     output_features = [
-        _categorical_feature(vocab_size=2, reduce_input='sum'),
-        _sequence_feature(vocab_size=10, max_len=5, decoder='generator'),
-        _numerical_feature()
+        categorical_feature(vocab_size=2, reduce_input='sum'),
+        sequence_feature(vocab_size=10, max_len=5, decoder='generator'),
+        numerical_feature()
     ]
 
     rel_path = generate_data(input_features, output_features, csv_filename)
@@ -205,9 +207,9 @@ def test_experiment_multiple_seq_seq(csv_filename):
 
     # Generator decoder and reduce_input = None
     output_features = [
-        _categorical_feature(vocab_size=2, reduce_input='sum'),
-        _sequence_feature(max_len=5, decoder='generator', reduce_input=None),
-        _numerical_feature()
+        categorical_feature(vocab_size=2, reduce_input='sum'),
+        sequence_feature(max_len=5, decoder='generator', reduce_input=None),
+        numerical_feature()
     ]
     rel_path = generate_data(input_features, output_features, csv_filename)
     run_experiment(input_features, output_features, data_csv=rel_path)
@@ -219,7 +221,7 @@ def test_experiment_image_inputs(csv_filename):
 
     # Resnet encoder
     input_features = [
-        _image_feature(
+        image_feature(
             folder=image_dest_folder,
             encoder='resnet',
             preprocessing={
@@ -231,12 +233,12 @@ def test_experiment_image_inputs(csv_filename):
             fc_size=16,
             num_filters=8
         ),
-        _text_feature(encoder='embed', min_len=1),
-        _numerical_feature()
+        text_feature(encoder='embed', min_len=1),
+        numerical_feature()
     ]
     output_features = [
-        _categorical_feature(vocab_size=2, reduce_input='sum'),
-        _numerical_feature()
+        categorical_feature(vocab_size=2, reduce_input='sum'),
+        numerical_feature()
     ]
 
     rel_path = generate_data(input_features, output_features, csv_filename)
@@ -259,13 +261,13 @@ def test_experiment_image_inputs(csv_filename):
 def test_experiment_tied_weights(csv_filename):
     # Single sequence input, single category output
     input_features = [
-        _text_feature(
+        text_feature(
             name='text_feature1',
             min_len=1,
             encoder='cnnrnn',
             reduce_output='sum'
         ),
-        _text_feature(
+        text_feature(
             name='text_feature2',
             min_len=1,
             encoder='cnnrnn',
@@ -273,7 +275,7 @@ def test_experiment_tied_weights(csv_filename):
             tied_weights='text_feature1'
         )
     ]
-    output_features = [_categorical_feature(vocab_size=2, reduce_input='sum')]
+    output_features = [categorical_feature(vocab_size=2, reduce_input='sum')]
 
     # Generate test data
     rel_path = generate_data(input_features, output_features, csv_filename)
@@ -286,10 +288,10 @@ def test_experiment_tied_weights(csv_filename):
 def test_experiment_attention(csv_filename):
     # Machine translation with attention
     input_features = [
-            _sequence_feature(encoder='rnn', cell_type='lstm', max_len=10)
+            sequence_feature(encoder='rnn', cell_type='lstm', max_len=10)
         ]
     output_features = [
-        _sequence_feature(
+        sequence_feature(
             max_len=10,
             cell_type='lstm',
             decoder='generator',
@@ -308,7 +310,7 @@ def test_experiment_attention(csv_filename):
 def test_experiment_sequence_combiner(csv_filename):
     # Sequence combiner
     input_features = [
-        _sequence_feature(
+        sequence_feature(
             name='english',
             min_len=5,
             max_len=5,
@@ -316,7 +318,7 @@ def test_experiment_sequence_combiner(csv_filename):
             cell_type='lstm',
             reduce_output=None
         ),
-        _sequence_feature(
+        sequence_feature(
             name='spanish',
             min_len=5,
             max_len=5,
@@ -324,10 +326,10 @@ def test_experiment_sequence_combiner(csv_filename):
             cell_type='lstm',
             reduce_output=None
         ),
-        _categorical_feature(vocab_size=5)
+        categorical_feature(vocab_size=5)
     ]
     output_features = [
-        _categorical_feature(reduce_input='sum', vocab_size=5)
+        categorical_feature(reduce_input='sum', vocab_size=5)
     ]
 
     model_definition = {
@@ -369,8 +371,8 @@ def test_experiment_sequence_combiner(csv_filename):
 def test_experiment_model_resume(csv_filename):
     # Single sequence input, single category output
     # Tests saving a model file, loading it to rerun training and predict
-    input_features = [_sequence_feature(encoder='rnn', reduce_output='sum')]
-    output_features = [_categorical_feature(vocab_size=2, reduce_input='sum')]
+    input_features = [sequence_feature(encoder='rnn', reduce_output='sum')]
+    output_features = [categorical_feature(vocab_size=2, reduce_input='sum')]
     # Generate test data
     rel_path = generate_data(input_features, output_features, csv_filename)
 
@@ -395,8 +397,8 @@ def test_experiment_model_resume(csv_filename):
 
 
 def test_experiment_various_feature_types(csv_filename):
-    input_features = [_binary_feature(), _bag_feature()]
-    output_features = [_set_feature(max_len=3, vocab_size=5)]
+    input_features = [binary_feature(), bag_feature()]
+    output_features = [set_feature(max_len=3, vocab_size=5)]
 
     # Generate test data
     rel_path = generate_data(input_features, output_features, csv_filename)
@@ -404,8 +406,8 @@ def test_experiment_various_feature_types(csv_filename):
 
 
 def test_experiment_timeseries(csv_filename):
-    input_features = [_timeseries_feature()]
-    output_features = [_binary_feature()]
+    input_features = [timeseries_feature()]
+    output_features = [binary_feature()]
 
     encoders2 = [
         'rnn', 'cnnrnn', 'stacked_cnn', 'parallel_cnn', 'stacked_parallel_cnn'
@@ -420,7 +422,7 @@ def test_experiment_timeseries(csv_filename):
 def test_visual_question_answering(csv_filename):
     image_dest_folder = os.path.join(os.getcwd(), 'generated_images')
     input_features = [
-        _image_feature(
+        image_feature(
             folder=image_dest_folder,
             encoder='resnet',
             preprocessing={
@@ -432,9 +434,9 @@ def test_visual_question_answering(csv_filename):
             fc_size=8,
             num_filters=8
         ),
-        _text_feature(encoder='embed', min_len=1, level='word'),
+        text_feature(encoder='embed', min_len=1, level='word'),
     ]
-    output_features = [_sequence_feature(decoder='generator', cell_type='lstm')]
+    output_features = [sequence_feature(decoder='generator', cell_type='lstm')]
     rel_path = generate_data(input_features, output_features, csv_filename)
     run_experiment(input_features, output_features, data_csv=rel_path)
 
@@ -456,7 +458,7 @@ def test_image_resizing_num_channel_handling(csv_filename):
 
     # Resnet encoder
     input_features = [
-        _image_feature(
+        image_feature(
             folder=image_dest_folder,
             encoder='resnet',
             preprocessing={
@@ -468,10 +470,10 @@ def test_image_resizing_num_channel_handling(csv_filename):
             fc_size=8,
             num_filters=8
         ),
-        _text_feature(encoder='embed', min_len=1),
-        _numerical_feature()
+        text_feature(encoder='embed', min_len=1),
+        numerical_feature()
     ]
-    output_features = [_binary_feature(), _numerical_feature()]
+    output_features = [binary_feature(), numerical_feature()]
     rel_path = generate_data(
         input_features, output_features, csv_filename, num_examples=50
     )

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -14,8 +14,9 @@
 # limitations under the License.
 # ==============================================================================
 
-import pandas as pd
 import uuid
+
+import pandas as pd
 
 from ludwig.data.dataset_synthesyzer import build_synthetic_dataset
 

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -13,25 +13,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from string import Template
 
 import pandas as pd
-import yaml
+import uuid
 
 from ludwig.data.dataset_synthesyzer import build_synthetic_dataset
 
-ENCODERS = ['embed', 'rnn', 'parallel_cnn', 'cnnrnn', 'stacked_parallel_cnn',
-            'stacked_cnn']
-
-model_definition_template = Template(
-    '{input_features: ${input_name}, output_features: ${output_name}, '
-    'training: {epochs: 2}, combiner: {type: concat, fc_size: 56}}')
+ENCODERS = [
+    'embed', 'rnn', 'parallel_cnn', 'cnnrnn', 'stacked_parallel_cnn',
+    'stacked_cnn'
+]
 
 
-def generate_data(input_features,
-                  output_features,
-                  filename='test_csv.csv',
-                  num_examples=25):
+def generate_data(
+        input_features,
+        output_features,
+        filename='test_csv.csv',
+        num_examples=25
+):
     """
     Helper method to generate synthetic data based on input, output feature
     specs
@@ -41,8 +40,7 @@ def generate_data(input_features,
     :param filename: path to the file where data is stored
     :return:
     """
-    features = yaml.safe_load(input_features) + yaml.safe_load(
-        output_features)
+    features = input_features + output_features
     df = build_synthetic_dataset(num_examples, features)
     data = [next(df) for _ in range(num_examples)]
 
@@ -50,3 +48,116 @@ def generate_data(input_features,
     dataframe.to_csv(filename, index=False)
 
     return filename
+
+
+def _random_name(length=5):
+    return uuid.uuid4().hex[:length].upper()
+
+
+def _numerical_feature():
+    return {'name': 'num_' + _random_name(), 'type': 'numerical'}
+
+
+def _categorical_feature(**kwargs):
+    cat_feature = {
+        'type': 'category',
+        'name': 'category_' + _random_name(),
+        'vocab_size': 10,
+        'embedding_size': 5
+    }
+
+    cat_feature.update(kwargs)
+    return cat_feature
+
+
+def _text_feature(**kwargs):
+    text_feature = {
+        'name': 'text_' + _random_name(),
+        'type': 'text',
+        'reduce_input': 'null',
+        'vocab_size': 5,
+        'min_len': 7,
+        'max_len': 7,
+        'embedding_size': 8,
+        'state_size': 8
+    }
+    text_feature.update(kwargs)
+    return text_feature
+
+
+def _set_feature(**kwargs):
+    set_feature = {
+        'type': 'set',
+        'name': 'set_' + _random_name(),
+        'vocab_size': 10,
+        'max_len': 5,
+        'embedding_size': 5
+    }
+    set_feature.update(kwargs)
+    return set_feature
+
+
+def _sequence_feature(**kwargs):
+    seq_feature = {
+        'type': 'sequence',
+        'name': 'sequence_' + _random_name(),
+        'vocab_size': 10,
+        'max_len': 7,
+        'encoder': 'embed',
+        'embedding_size': 8,
+        'fc_size': 8,
+        'state_size': 8,
+        'num_filters': 8
+    }
+    seq_feature.update(kwargs)
+    return seq_feature
+
+
+def _image_feature(folder, **kwargs):
+    img_feature = {
+        'type': 'image',
+        'name': 'image_' + _random_name(),
+        'encoder': 'resnet',
+        'preprocessing': {
+            'in_memory': True,
+            'height': 8,
+            'width': 8,
+            'num_channels': 3
+        },
+        'resnet_size': 8,
+        'destination_folder': folder,
+        'fc_size': 8,
+        'num_filters': 8
+    }
+    img_feature.update(kwargs)
+    return img_feature
+
+
+def _timeseries_feature(**kwargs):
+    ts_feature = {
+        'name': 'timeseries_' + _random_name(),
+        'type': 'timeseries',
+        'max_len': 7
+    }
+    ts_feature.update(kwargs)
+    return ts_feature
+
+
+def _binary_feature():
+    return {
+        'name': 'binary_' + _random_name(),
+        'type': 'binary'
+    }
+
+
+def _bag_feature(**kwargs):
+    bag_feature = {
+        'name': 'bag_' + _random_name(),
+        'type': 'bag',
+        'max_len': 5,
+        'vocab_size': 10,
+        'embedding_size': 5
+    }
+    bag_feature.update(kwargs)
+
+    return bag_feature

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -50,18 +50,18 @@ def generate_data(
     return filename
 
 
-def _random_name(length=5):
+def random_name(length=5):
     return uuid.uuid4().hex[:length].upper()
 
 
-def _numerical_feature():
-    return {'name': 'num_' + _random_name(), 'type': 'numerical'}
+def numerical_feature():
+    return {'name': 'num_' + random_name(), 'type': 'numerical'}
 
 
-def _categorical_feature(**kwargs):
+def categorical_feature(**kwargs):
     cat_feature = {
         'type': 'category',
-        'name': 'category_' + _random_name(),
+        'name': 'category_' + random_name(),
         'vocab_size': 10,
         'embedding_size': 5
     }
@@ -70,9 +70,9 @@ def _categorical_feature(**kwargs):
     return cat_feature
 
 
-def _text_feature(**kwargs):
-    text_feature = {
-        'name': 'text_' + _random_name(),
+def text_feature(**kwargs):
+    feature = {
+        'name': 'text_' + random_name(),
         'type': 'text',
         'reduce_input': 'null',
         'vocab_size': 5,
@@ -81,26 +81,26 @@ def _text_feature(**kwargs):
         'embedding_size': 8,
         'state_size': 8
     }
-    text_feature.update(kwargs)
-    return text_feature
+    feature.update(kwargs)
+    return feature
 
 
-def _set_feature(**kwargs):
-    set_feature = {
+def set_feature(**kwargs):
+    feature = {
         'type': 'set',
-        'name': 'set_' + _random_name(),
+        'name': 'set_' + random_name(),
         'vocab_size': 10,
         'max_len': 5,
         'embedding_size': 5
     }
-    set_feature.update(kwargs)
-    return set_feature
+    feature.update(kwargs)
+    return feature
 
 
-def _sequence_feature(**kwargs):
+def sequence_feature(**kwargs):
     seq_feature = {
         'type': 'sequence',
-        'name': 'sequence_' + _random_name(),
+        'name': 'sequence_' + random_name(),
         'vocab_size': 10,
         'max_len': 7,
         'encoder': 'embed',
@@ -113,10 +113,10 @@ def _sequence_feature(**kwargs):
     return seq_feature
 
 
-def _image_feature(folder, **kwargs):
+def image_feature(folder, **kwargs):
     img_feature = {
         'type': 'image',
-        'name': 'image_' + _random_name(),
+        'name': 'image_' + random_name(),
         'encoder': 'resnet',
         'preprocessing': {
             'in_memory': True,
@@ -133,9 +133,9 @@ def _image_feature(folder, **kwargs):
     return img_feature
 
 
-def _timeseries_feature(**kwargs):
+def timeseries_feature(**kwargs):
     ts_feature = {
-        'name': 'timeseries_' + _random_name(),
+        'name': 'timeseries_' + random_name(),
         'type': 'timeseries',
         'max_len': 7
     }
@@ -143,21 +143,21 @@ def _timeseries_feature(**kwargs):
     return ts_feature
 
 
-def _binary_feature():
+def binary_feature():
     return {
-        'name': 'binary_' + _random_name(),
+        'name': 'binary_' + random_name(),
         'type': 'binary'
     }
 
 
-def _bag_feature(**kwargs):
-    bag_feature = {
-        'name': 'bag_' + _random_name(),
+def bag_feature(**kwargs):
+    feature = {
+        'name': 'bag_' + random_name(),
         'type': 'bag',
         'max_len': 5,
         'vocab_size': 10,
         'embedding_size': 5
     }
-    bag_feature.update(kwargs)
+    feature.update(kwargs)
 
-    return bag_feature
+    return feature


### PR DESCRIPTION
1. Now the tests use dictionaries for model definition instead of yaml files
2. Helper methods with default values for each feature type for the tests
3. Tests are faster because all the parameters are chosen as small as possible
4. All tests delete the intermediate data saved to disk -> model, predictions etc.
5. One of the new tests saves processed input data (and deletes after). Another new test uses train/test/valid files instead of just using data_csv. 

All tests pass. 