### PR TITLE
Fix copy\paste typos on binary feature in place of numerical\set\category feature

### DIFF
--- a/docs/user_guide/index.html
+++ b/docs/user_guide/index.html
@@ -3370,7 +3370,7 @@ There is only one decoder available for numerical features and it is a (potentia
 
 <h4 id="numerical-features-measures">Numerical Features Measures<a class="headerlink" href="#numerical-features-measures" title="Permanent link">&para;</a></h4>
 <p>The measures that are calculated every epoch and are available for numerical features are <code>mean_squared_error</code>, <code>mean_absolute_error</code>, <code>r2</code> and the <code>loss</code> itself.
-You can set either of them as <code>validation_measure</code> in the <code>training</code> section of the model definition if you set the <code>validation_field</code> to be the name of a binary feature.</p>
+You can set either of them as <code>validation_measure</code> in the <code>training</code> section of the model definition if you set the <code>validation_field</code> to be the name of a numerical feature.</p>
 <h3 id="category-features">Category Features<a class="headerlink" href="#category-features" title="Permanent link">&para;</a></h3>
 <h4 id="category-features-preprocessing">Category Features Preprocessing<a class="headerlink" href="#category-features-preprocessing" title="Permanent link">&para;</a></h4>
 <p>Category features are transformed into an integer valued vector of size <code>n</code> (where <code>n</code> is the size of the dataset) and added to HDF5 with a key that reflects the name of column in the CSV.
@@ -3499,7 +3499,7 @@ There is only one decoder available for category features and it is a (potential
 
 <h4 id="category-features-measures">Category Features Measures<a class="headerlink" href="#category-features-measures" title="Permanent link">&para;</a></h4>
 <p>The measures that are calculated every epoch and are available for category features are <code>accuracy</code>, <code>top_k</code> (computes accuracy considering as a match if the true category appears in the first <code>k</code> predicted categories ranked by decoder's confidence) and the <code>loss</code> itself.
-You can set either of them as <code>validation_measure</code> in the <code>training</code> section of the model definition if you set the <code>validation_field</code> to be the name of a binary feature.</p>
+You can set either of them as <code>validation_measure</code> in the <code>training</code> section of the model definition if you set the <code>validation_field</code> to be the name of a category feature.</p>
 <h3 id="set-features">Set Features<a class="headerlink" href="#set-features" title="Permanent link">&para;</a></h3>
 <h4 id="set-features-preprocessing">Set Features Preprocessing<a class="headerlink" href="#set-features-preprocessing" title="Permanent link">&para;</a></h4>
 <p>Set features are transformed into a binary (int8 actually) valued matrix of size <code>n x l</code> (where <code>n</code> is the size of the dataset and <code>l</code> is the minimum of the size of the biggest set and a <code>max_size</code> parameter) and added to HDF5 with a key that reflects the name of column in the CSV.
@@ -4320,7 +4320,7 @@ If a <code>b x h</code> input is provided to a generator decoder using an rnn wi
                     (the levenshtein distance between the predicted and ground truth sequence), <code>perplexity</code>
                     (the perplexity of the ground truth sequence according to the model) and the <code>loss</code>
                     itself.
-You can set either of them as <code>validation_measure</code> in the <code>training</code> section of the model definition if you set the <code>validation_field</code> to be the name of a binary feature.</p>
+You can set either of them as <code>validation_measure</code> in the <code>training</code> section of the model definition if you set the <code>validation_field</code> to be the name of a sequence feature.</p>
 <h3 id="text-features">Text Features<a class="headerlink" href="#text-features" title="Permanent link">&para;</a></h3>
 <h4 id="text-features-preprocessing">Text Features Preprocessing<a class="headerlink" href="#text-features-preprocessing" title="Permanent link">&para;</a></h4>
 <p>Text features are treated in the same way of sequence features, with a couple differences.

--- a/docs/user_guide/index.html
+++ b/docs/user_guide/index.html
@@ -3619,7 +3619,7 @@ There is only one decoder available for set features and it is a (potentially em
 
 <h4 id="set-features-measures">Set Features Measures<a class="headerlink" href="#set-features-measures" title="Permanent link">&para;</a></h4>
 <p>The measures that are calculated every epoch and are available for category features are <code>jaccard_index</code> and the <code>loss</code> itself.
-You can set either of them as <code>validation_measure</code> in the <code>training</code> section of the model definition if you set the <code>validation_field</code> to be the name of a binary feature.</p>
+You can set either of them as <code>validation_measure</code> in the <code>training</code> section of the model definition if you set the <code>validation_field</code> to be the name of a set feature.</p>
 <h3 id="bag-features">Bag Features<a class="headerlink" href="#bag-features" title="Permanent link">&para;</a></h3>
 <h4 id="bag-features-preprocessing">Bag Features Preprocessing<a class="headerlink" href="#bag-features-preprocessing" title="Permanent link">&para;</a></h4>
 <p>Bag features are treated in the same way of set features, with the only difference being that the matrix had float values (frequencies).</p>

--- a/mkdocs/docs/user_guide.md
+++ b/mkdocs/docs/user_guide.md
@@ -1212,7 +1212,7 @@ top_k: 3
 ### Category Features Measures
 
 The measures that are calculated every epoch and are available for category features are `accuracy`, `top_k` (computes accuracy considering as a match if the true category appears in the first `k` predicted categories ranked by decoder's confidence) and the `loss` itself.
-You can set either of them as `validation_measure` in the `training` section of the model definition if you set the `validation_field` to be the name of a binary feature.
+You can set either of them as `validation_measure` in the `training` section of the model definition if you set the `validation_field` to be the name of a category feature.
 
 Set Features
 ------------
@@ -1340,7 +1340,7 @@ threshold: 0.5
 ### Set Features Measures
 
 The measures that are calculated every epoch and are available for category features are `jaccard_index` and the `loss` itself.
-You can set either of them as `validation_measure` in the `training` section of the model definition if you set the `validation_field` to be the name of a binary feature.
+You can set either of them as `validation_measure` in the `training` section of the model definition if you set the `validation_field` to be the name of a set feature.
 
 Bag Features
 ------------
@@ -2003,7 +2003,7 @@ attention_mechanism: null
 ### Sequence Features Measures
 
 The measures that are calculated every epoch and are available for category features are `accuracy` (counts the number of datapoints where all the elements of the predicted sequence are correct over the number of all datapoints), `token_accuracy` (computes the number of elements in all the sequences that are correctly predicted over the number of all the elements in all the sequences), `last_accuracy` (accuracy considering only the last element of the sequence, it is useful for being sure special end-of-sequence tokens are generated or tagged), `edit_distance` (the levenshtein distance between the predicted and ground truth sequence), `perplexity` (the perplexity of the ground truth sequence according to the model) and the `loss` itself.
-You can set either of them as `validation_measure` in the `training` section of the model definition if you set the `validation_field` to be the name of a binary feature.
+You can set either of them as `validation_measure` in the `training` section of the model definition if you set the `validation_field` to be the name of a sequence feature.
 
 Text Features
 -------------


### PR DESCRIPTION
Fix copy\paste typos on binary feature in place of numerical\set\category feature