### PR TITLE
Fix test pattern glob in .deepsource.toml

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,7 +1,7 @@
 version = 1
 
 test_patterns = [
-  "tests/"
+  "tests/**"
 ]
 
 [[analyzers]]


### PR DESCRIPTION
The `test_patterns` glob was configured incorrectly as `tests/`. A valid test pattern glob for this repository would be `tests/**`.