### PR TITLE
Fix visualize parameter naming

### DIFF
--- a/docs/user_guide/index.html
+++ b/docs/user_guide/index.html
@@ -2757,9 +2757,9 @@ optional arguments:
                         predictions files
   -prob PROBABILITIES [PROBABILITIES ...], --probabilities PROBABILITIES [PROBABILITIES ...]
                         probabilities files
-  -tes TRAINING_STATS [TRAINING_STATS ...], --training_statistics TRAINING_STATS [TRAINING_STATS ...]
+  -trs TRAINING_STATS [TRAINING_STATS ...], --training_statistics TRAINING_STATS [TRAINING_STATS ...]
                         training stats files
-  -trs TEST_STATS [TEST_STATS ...], --test_statistics TEST_STATS [TEST_STATS ...]
+  -tes TEST_STATS [TEST_STATS ...], --test_statistics TEST_STATS [TEST_STATS ...]
                         test stats files
   -alg ALGORITHMS [ALGORITHMS ...], --algorithms ALGORITHMS [ALGORITHMS ...]
                         names of the algorithms (for better graphs)

--- a/ludwig/visualize.py
+++ b/ludwig/visualize.py
@@ -1692,7 +1692,7 @@ def cli(sys_argv):
         help='probabilities files'
     )
     parser.add_argument(
-        '-ts',
+        '-trs',
         '--training_statistics',
         default=[],
         nargs='+',
@@ -1700,8 +1700,8 @@ def cli(sys_argv):
         help='training stats files'
     )
     parser.add_argument(
-        '-ps',
-        '--prediction_statistics',
+        '-tes',
+        '--test_statistics',
         default=[],
         nargs='+',
         type=str,

--- a/mkdocs/docs/user_guide.md
+++ b/mkdocs/docs/user_guide.md
@@ -2419,9 +2419,9 @@ optional arguments:
                         predictions files
   -prob PROBABILITIES [PROBABILITIES ...], --probabilities PROBABILITIES [PROBABILITIES ...]
                         probabilities files
-  -ts TRAINING_STATISTICS [TRAINING_STATISTICS ...], --training_statistics TRAINING_STATISTICS [TRAINING_STATISTICS ...]
+  -trs TRAINING_STATS [TRAINING_STATS ...], --training_statistics TRAINING_STATS [TRAINING_STATS ...]
                         training stats files
-  -ps PREDICTION_STATISTICS [PREDICTION_STATISTICS ...], --prediction_statistics PREDICTION_STATISTICS [PREDICTION_STATISTICS ...]
+  -tes TEST_STATS [TEST_STATS ...], --test_statistics TEST_STATS [TEST_STATS ...]
                         test stats files
   -mn MODEL_NAMES [MODEL_NAMES ...], --model_names MODEL_NAMES [MODEL_NAMES ...]
                         names of the models to use as labels


### PR DESCRIPTION
Renaming Prediction Stats to Test Stats (i'm taking the published website documentation as the most valid)

Inverting "trs" and "tes" in the user guide on the idea that TRS->TRainingStatistics and TES -> TEstStatistics

Updating mkdocs to reflect published html, since it seems to still contain the "old" name (prediction statistics).