### PR TITLE
Add TF summary logging for validate loss

### DIFF
--- a/ludwig/models/model.py
+++ b/ludwig/models/model.py
@@ -202,7 +202,7 @@ class Model:
             )
 
             tf.summary.scalar('train_reg_mean_loss', self.train_reg_mean_loss)
-            eval_mean_loss = tf.reduce_sum(self.eval_combined_loss)
+            eval_mean_loss = tf.reduce_mean(self.eval_combined_loss)
             tf.summary.scalar('eval_mean_loss', eval_mean_loss)
 
             self.merged_summary = tf.summary.merge_all()

--- a/ludwig/models/model.py
+++ b/ludwig/models/model.py
@@ -202,6 +202,8 @@ class Model:
             )
 
             tf.summary.scalar('train_reg_mean_loss', self.train_reg_mean_loss)
+            eval_mean_loss = tf.reduce_sum(self.eval_combined_loss)
+            tf.summary.scalar('eval_mean_loss', eval_mean_loss)
 
             self.merged_summary = tf.summary.merge_all()
             self.graph = graph


### PR DESCRIPTION
I know it's ugly but this serves the purpose I need. Having few data to work on, training loss and validate loss do not always go hand-in-hand, and this gives me an easy way to have an overview on how validation loss is performing (and infer how likely the model is to be successfully updated in the near future).