### PR TITLE
Update numerical_feature.py

### DIFF
--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -62,7 +62,7 @@ class BinaryBaseFeature(BaseFeature):
             preprocessing_parameters=None
     ):
         data[feature['name']] = dataset_df[feature['name']].astype(
-            np.bool_).as_matrix()
+            np.bool_).values
 
 
 class BinaryInputFeature(BinaryBaseFeature, InputFeature):

--- a/ludwig/features/numerical_feature.py
+++ b/ludwig/features/numerical_feature.py
@@ -63,7 +63,7 @@ class NumericalBaseFeature(BaseFeature):
             preprocessing_parameters,
     ):
         data[feature['name']] = dataset_df[feature['name']].astype(
-            np.float32).as_matrix()
+            np.float32).values
 
 
 class NumericalInputFeature(NumericalBaseFeature, InputFeature):


### PR DESCRIPTION
Minor fix: `as_matrix()` method is deprecated.
Getting a warning:

```
/home/jupyter/.local/lib/python3.5/site-packages/ludwig/features/numerical_feature.py:63: FutureWarning: Method .as_matrix will be removed in a future version. Use .values instead.
  np.float32).as_matrix()
```

Change it to `.values`
https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.as_matrix.html

# Code Pull Requests

Please provide the following:

- a clear explanation of what your code dose
- if applicable, a reference to an issue
- a reproducible test for your PR (code, model definition and data sample)

# Documentation Pull Requests

Note that the documentation HTML files are in `docs/` while the Markdown sources are in `mkdocs/docs`.

If you are proposing a modification to the documentation you should change only the Markdown files, then recreate the documentation as explained in the `mkdocs/README.md` file with `mkdocs build`, which will create the HTML files automatically, and only after this create a commit.

`api.md` is automatically generated from the docstrings in the code, so if you want to change something in that file, first modify `ludwig/api.py` docstring, then run `mkdocs/code_docs_autogen.py`, which will create `mkdocs/docs/api.md` and then finally run `mkdocs build` which will generate the HTML in `docs/`.
