### PR TITLE
Refactor text formatters

### DIFF
--- a/ludwig/features/feature_utils.py
+++ b/ludwig/features/feature_utils.py
@@ -42,6 +42,6 @@ def set_str_to_idx(set_string, feature_dict, format_func):
         raise Exception('Format {} not supported'.format(format_func))
 
     out = [feature_dict.get(item, feature_dict[UNKNOWN_SYMBOL]) for item in
-           tokenizer.tokenize(set_string)]
+           tokenizer(set_string)]
 
     return np.array(out, dtype=np.int32)

--- a/ludwig/features/feature_utils.py
+++ b/ludwig/features/feature_utils.py
@@ -20,7 +20,7 @@ from ludwig.constants import SEQUENCE
 from ludwig.constants import TEXT
 from ludwig.constants import TIMESERIES
 from ludwig.utils.strings_utils import UNKNOWN_SYMBOL
-from ludwig.utils.strings_utils import format_registry
+from ludwig.utils.strings_utils import tokenizer_registry
 
 SEQUENCE_TYPES = {SEQUENCE, TEXT, TIMESERIES}
 
@@ -37,11 +37,11 @@ def should_regularize(regularize_layers):
 
 def set_str_to_idx(set_string, feature_dict, format_func):
     try:
-        format_function = format_registry[format_func]
+        tokenizer = tokenizer_registry[format_func]()
     except ValueError:
         raise Exception('Format {} not supported'.format(format_func))
 
     out = [feature_dict.get(item, feature_dict[UNKNOWN_SYMBOL]) for item in
-           format_function(set_string)]
+           tokenizer.tokenize(set_string)]
 
     return np.array(out, dtype=np.int32)

--- a/ludwig/features/timeseries_feature.py
+++ b/ludwig/features/timeseries_feature.py
@@ -31,7 +31,7 @@ from ludwig.models.modules.measure_modules import r2
 from ludwig.models.modules.measure_modules import squared_error
 from ludwig.utils.misc import get_from_registry
 from ludwig.utils.misc import set_default_value
-from ludwig.utils.strings_utils import format_registry
+from ludwig.utils.strings_utils import tokenizer_registry
 
 
 logger = logging.getLogger(__name__)
@@ -53,13 +53,13 @@ class TimeseriesBaseFeature(BaseFeature):
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters):
-        format_function = get_from_registry(
+        tokenizer = get_from_registry(
             preprocessing_parameters['format'],
-            format_registry
-        )
+            tokenizer_registry
+        )()
         max_length = 0
         for timeseries in column:
-            processed_line = format_function(timeseries)
+            processed_line = tokenizer.tokenize(timeseries)
             max_length = max(max_length, len(processed_line))
         max_length = min(
             preprocessing_parameters['timeseries_length_limit'],
@@ -76,14 +76,14 @@ class TimeseriesBaseFeature(BaseFeature):
             padding_value,
             padding='right'
     ):
-        format_function = get_from_registry(
+        tokenizer = get_from_registry(
             format_str,
-            format_registry
-        )
+            tokenizer_registry
+        )()
         max_length = 0
         ts_vectors = []
         for ts in timeseries:
-            ts_vector = np.array(format_function(ts)).astype(np.float32)
+            ts_vector = np.array(tokenizer.tokenize(ts)).astype(np.float32)
             ts_vectors.append(ts_vector)
             if len(ts_vector) > max_length:
                 max_length = len(ts_vector)

--- a/ludwig/features/timeseries_feature.py
+++ b/ludwig/features/timeseries_feature.py
@@ -59,7 +59,7 @@ class TimeseriesBaseFeature(BaseFeature):
         )()
         max_length = 0
         for timeseries in column:
-            processed_line = tokenizer.tokenize(timeseries)
+            processed_line = tokenizer(timeseries)
             max_length = max(max_length, len(processed_line))
         max_length = min(
             preprocessing_parameters['timeseries_length_limit'],
@@ -83,7 +83,7 @@ class TimeseriesBaseFeature(BaseFeature):
         max_length = 0
         ts_vectors = []
         for ts in timeseries:
-            ts_vector = np.array(tokenizer.tokenize(ts)).astype(np.float32)
+            ts_vector = np.array(tokenizer(ts)).astype(np.float32)
             ts_vectors.append(ts_vector)
             if len(ts_vector) > max_length:
                 max_length = len(ts_vector)

--- a/ludwig/utils/strings_utils.py
+++ b/ludwig/utils/strings_utils.py
@@ -87,8 +87,7 @@ def create_vocabulary(data, format='space', custom_vocabulary=(),
     else:
         tokenizer = get_from_registry(format, tokenizer_registry)()
         for line in data:
-            processed_line = tokenizer.tokenize(
-                line.lower() if lowercase else line)
+            processed_line = tokenizer(line.lower() if lowercase else line)
             unit_counts.update(processed_line)
             max_line_length = max(max_line_length, len(processed_line))
 
@@ -126,7 +125,7 @@ def _get_sequence_vector(
     unit_to_id,
     lowercase=True
 ):
-    unit_sequence = tokenizer.tokenize(
+    unit_sequence = tokenizer(
         sequence.lower() if lowercase else sequence
     )
     unit_indices_vector = np.empty(len(unit_sequence), dtype=format_dtype)
@@ -178,52 +177,56 @@ def build_sequence_matrix(sequences, inverse_vocabulary, format, length_limit,
 
 class BaseTokenizer:
     @abstractmethod
-    def tokenize(self, s):
+    def __init__(self, **kwargs):
+        pass
+
+    @abstractmethod
+    def __call__(self, s):
         pass
 
 
 class CharactersToListTokenizer(BaseTokenizer):
-    def tokenize(self, s):
+    def __call__(self, s):
         return s
 
 
 class SpaceStringToListTokenizer(BaseTokenizer):
-    def tokenize(self, s):
+    def __call__(self, s):
         return SPLIT_REGEX.split(s.strip())
 
 
 class SpacePunctuationStringToListTokenizer(BaseTokenizer):
-    def tokenize(self, s):
+    def __call__(self, s):
         return SPACE_PUNCTUATION_REGEX.findall(s.strip())
 
 
 class UnderscoreStringToListTokenizer(BaseTokenizer):
-    def tokenize(self, s):
+    def __call__(self, s):
         return UNDERSCORE_REGEX.split(s.strip())
 
 
 class CommaStringToListTokenizer(BaseTokenizer):
-    def tokenize(self, s):
+    def __call__(self, s):
         return COMMA_REGEX.split(s.strip())
 
 
 class UntokenizedStringToListTokenizer(BaseTokenizer):
-    def tokenize(self, s):
+    def __call__(self, s):
         return [s]
 
 
 class StrippedStringToListTokenizer(BaseTokenizer):
-    def tokenize(self, s):
+    def __call__(self, s):
         return [s.strip()]
 
 
 class EnglishTokenizer(BaseTokenizer):
-    def tokenize(self, s):
+    def __call__(self, s):
         return process_text(text, load_nlp_pipeline('en'))
 
 
 class EnglishFilterTokenizer(BaseTokenizer):
-    def tokenize(self, s):
+    def __call__(self, s):
         return process_text(
             text,
             load_nlp_pipeline('en'),
@@ -234,7 +237,7 @@ class EnglishFilterTokenizer(BaseTokenizer):
 
 
 class EnglishRemoveStopwordsTokenizer(BaseTokenizer):
-    def tokenize(self, s):
+    def __call__(self, s):
         return process_text(
             text,
             load_nlp_pipeline('en'),
@@ -243,12 +246,12 @@ class EnglishRemoveStopwordsTokenizer(BaseTokenizer):
 
 
 class EnglishLemmatizeTokenizer(BaseTokenizer):
-    def tokenize(self, s):
+    def __call__(self, s):
         process_text(text, load_nlp_pipeline('en'), return_lemma=True)
 
 
 class EnglishLemmatizeFilterTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(
             text,
             load_nlp_pipeline('en'),
@@ -260,7 +263,7 @@ class EnglishLemmatizeFilterTokenizer(BaseTokenizer):
 
 
 class EnglishLemmatizeRemoveStopwordsTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(
             text,
             load_nlp_pipeline('en'),
@@ -270,12 +273,12 @@ class EnglishLemmatizeRemoveStopwordsTokenizer(BaseTokenizer):
 
 
 class ItalianTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(text, load_nlp_pipeline('it'))
 
 
 class ItalianFilterTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(
             text,
             load_nlp_pipeline('it'),
@@ -286,7 +289,7 @@ class ItalianFilterTokenizer(BaseTokenizer):
 
 
 class ItalianRemoveStopwordsTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(
             text,
             load_nlp_pipeline('it'),
@@ -295,7 +298,7 @@ class ItalianRemoveStopwordsTokenizer(BaseTokenizer):
 
 
 class ItalianLemmatizeTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(
             text,
             load_nlp_pipeline('it'),
@@ -304,7 +307,7 @@ class ItalianLemmatizeTokenizer(BaseTokenizer):
 
 
 class ItalianLemmatizeFilterTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(
             text,
             load_nlp_pipeline('it'),
@@ -316,7 +319,7 @@ class ItalianLemmatizeFilterTokenizer(BaseTokenizer):
 
 
 class ItalianLemmatizeRemoveStopwordsTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(
             text,
             load_nlp_pipeline('it'),
@@ -326,12 +329,12 @@ class ItalianLemmatizeRemoveStopwordsTokenizer(BaseTokenizer):
 
 
 class SpanishTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(text, load_nlp_pipeline('es'))
 
 
 class SpanishFilterTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(
             text,
             load_nlp_pipeline('es'),
@@ -342,7 +345,7 @@ class SpanishFilterTokenizer(BaseTokenizer):
 
 
 class SpanishRemoveStopwordsTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(
             text,
             load_nlp_pipeline('es'),
@@ -351,7 +354,7 @@ class SpanishRemoveStopwordsTokenizer(BaseTokenizer):
 
 
 class SpanishLemmatizeTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(
             text,
             load_nlp_pipeline('es'),
@@ -360,7 +363,7 @@ class SpanishLemmatizeTokenizer(BaseTokenizer):
 
 
 class SpanishLemmatizeFilterTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(
             text,
             load_nlp_pipeline('es'),
@@ -372,7 +375,7 @@ class SpanishLemmatizeFilterTokenizer(BaseTokenizer):
 
 
 class SpanishLemmatizeRemoveStopwordsTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(
             text,
             load_nlp_pipeline('es'),
@@ -382,12 +385,12 @@ class SpanishLemmatizeRemoveStopwordsTokenizer(BaseTokenizer):
 
 
 class GermanTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(text, load_nlp_pipeline('de'))
 
 
 class GermanFilterTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(
             text,
             load_nlp_pipeline('de'),
@@ -398,7 +401,7 @@ class GermanFilterTokenizer(BaseTokenizer):
 
 
 class GermanRemoveStopwordsTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(
             text,
             load_nlp_pipeline('de'),
@@ -407,7 +410,7 @@ class GermanRemoveStopwordsTokenizer(BaseTokenizer):
 
 
 class GermanLemmatizeTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(
             text,
             load_nlp_pipeline('de'),
@@ -416,7 +419,7 @@ class GermanLemmatizeTokenizer(BaseTokenizer):
 
 
 class GermanLemmatizeFilterTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(
             text,
             load_nlp_pipeline('de'),
@@ -428,7 +431,7 @@ class GermanLemmatizeFilterTokenizer(BaseTokenizer):
 
 
 class GermanLemmatizeRemoveStopwordsTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(
             text,
             load_nlp_pipeline('de'),
@@ -438,12 +441,12 @@ class GermanLemmatizeRemoveStopwordsTokenizer(BaseTokenizer):
 
 
 class FrenchTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(text, load_nlp_pipeline('fr'))
 
 
 class FrenchFilterTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(
             text,
             load_nlp_pipeline('fr'),
@@ -454,7 +457,7 @@ class FrenchFilterTokenizer(BaseTokenizer):
 
 
 class FrenchRemoveStopwordsTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(
             text,
             load_nlp_pipeline('fr'),
@@ -463,7 +466,7 @@ class FrenchRemoveStopwordsTokenizer(BaseTokenizer):
 
 
 class FrenchLemmatizeTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(
             text,
             load_nlp_pipeline('fr'),
@@ -472,7 +475,7 @@ class FrenchLemmatizeTokenizer(BaseTokenizer):
 
 
 class FrenchLemmatizeFilterTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(
             text,
             load_nlp_pipeline('fr'),
@@ -484,7 +487,7 @@ class FrenchLemmatizeFilterTokenizer(BaseTokenizer):
 
 
 class FrenchLemmatizeRemoveStopwordsTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(
             text,
             load_nlp_pipeline('fr'),
@@ -494,12 +497,12 @@ class FrenchLemmatizeRemoveStopwordsTokenizer(BaseTokenizer):
 
 
 class PortugueseTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(text, load_nlp_pipeline('pt'))
 
 
 class PortugueseFilterTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(
             text,
             load_nlp_pipeline('pt'),
@@ -510,7 +513,7 @@ class PortugueseFilterTokenizer(BaseTokenizer):
 
 
 class PortugueseRemoveStopwordsTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(
             text,
             load_nlp_pipeline('pt'),
@@ -519,12 +522,12 @@ class PortugueseRemoveStopwordsTokenizer(BaseTokenizer):
 
 
 class PortugueseLemmatizeTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(text, load_nlp_pipeline('pt'), return_lemma=True)
 
 
 class PortugueseLemmatizeFilterTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(
             text,
             load_nlp_pipeline('pt'),
@@ -536,7 +539,7 @@ class PortugueseLemmatizeFilterTokenizer(BaseTokenizer):
 
 
 class PortugueseLemmatizeRemoveStopwordsTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(
             text,
             load_nlp_pipeline('pt'),
@@ -546,12 +549,12 @@ class PortugueseLemmatizeRemoveStopwordsTokenizer(BaseTokenizer):
 
 
 class DutchTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(text, load_nlp_pipeline('nl'))
 
 
 class DutchFilterTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(
             text,
             load_nlp_pipeline('nl'),
@@ -562,7 +565,7 @@ class DutchFilterTokenizer(BaseTokenizer):
 
 
 class DutchRemoveStopwordsTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(
             text,
             load_nlp_pipeline('nl'),
@@ -571,12 +574,12 @@ class DutchRemoveStopwordsTokenizer(BaseTokenizer):
 
 
 class DutchLemmatizeTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(text, load_nlp_pipeline('nl'), return_lemma=True)
 
 
 class DutchLemmatizeFilterTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(
             text,
             load_nlp_pipeline('nl'),
@@ -588,7 +591,7 @@ class DutchLemmatizeFilterTokenizer(BaseTokenizer):
 
 
 class DutchLemmatizeRemoveStopwordsTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(
             text,
             load_nlp_pipeline('nl'),
@@ -598,12 +601,12 @@ class DutchLemmatizeRemoveStopwordsTokenizer(BaseTokenizer):
 
 
 class GreekTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(text, load_nlp_pipeline('el'))
 
 
 class GreekFilterTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(
             text,
             load_nlp_pipeline('el'),
@@ -614,7 +617,7 @@ class GreekFilterTokenizer(BaseTokenizer):
 
 
 class GreekRemoveStopwordsTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(
             text,
             load_nlp_pipeline('el'),
@@ -623,12 +626,12 @@ class GreekRemoveStopwordsTokenizer(BaseTokenizer):
 
 
 class GreekLemmatizeTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(text, load_nlp_pipeline('el'), return_lemma=True)
 
 
 class GreekLemmatizeFilterTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(
             text,
             load_nlp_pipeline('el'),
@@ -640,7 +643,7 @@ class GreekLemmatizeFilterTokenizer(BaseTokenizer):
 
 
 class GreekLemmatizeRemoveStopwordsFilterTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(
             text,
             load_nlp_pipeline('el'),
@@ -650,12 +653,12 @@ class GreekLemmatizeRemoveStopwordsFilterTokenizer(BaseTokenizer):
 
 
 class MultiTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(text, load_nlp_pipeline('xx'))
 
 
 class MultiFilterTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(
             text,
             load_nlp_pipeline('xx'),
@@ -666,7 +669,7 @@ class MultiFilterTokenizer(BaseTokenizer):
 
 
 class MultiRemoveStopwordsTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(
             text,
             load_nlp_pipeline('xx'),
@@ -675,12 +678,12 @@ class MultiRemoveStopwordsTokenizer(BaseTokenizer):
 
 
 class MultiLemmatizeTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(text, load_nlp_pipeline('xx'), return_lemma=True)
 
 
 class MultiLemmatizeFilterTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(
             text,
             load_nlp_pipeline('xx'),
@@ -692,7 +695,7 @@ class MultiLemmatizeFilterTokenizer(BaseTokenizer):
 
 
 class MultiLemmatizeRemoveStopwordsTokenizer(BaseTokenizer):
-    def tokenize(self, text):
+    def __call__(self, text):
         return process_text(
             text,
             load_nlp_pipeline('xx'),

--- a/ludwig/utils/strings_utils.py
+++ b/ludwig/utils/strings_utils.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from abc import ABC, abstractmethod
+
 import json
 import logging
 import re
@@ -83,12 +85,9 @@ def create_vocabulary(data, format='space', custom_vocabulary=(),
     if format == 'custom':
         vocab = sorted(list(set(custom_vocabulary)))
     else:
-        format_function = get_from_registry(
-            format,
-            format_registry
-        )
+        tokenizer = get_from_registry(format, tokenizer_registry)()
         for line in data:
-            processed_line = format_function(
+            processed_line = tokenizer.tokenize(
                 line.lower() if lowercase else line)
             unit_counts.update(processed_line)
             max_line_length = max(max_line_length, len(processed_line))
@@ -109,18 +108,27 @@ def create_vocabulary(data, format='space', custom_vocabulary=(),
 
 
 def get_sequence_vector(sequence, format, unit_to_id, lowercase=True):
-    format_function = get_from_registry(
-        format,
-        format_registry
-    )
+    tokenizer = get_from_registry(format, tokenizer_registry)()
     format_dtype = int_type(len(unit_to_id) - 1)
-    return _get_sequence_vector(sequence, format_function, format_dtype,
-                                unit_to_id, lowercase=lowercase)
+    return _get_sequence_vector(
+        sequence,
+        tokenizer,
+        format_dtype,
+        unit_to_id,
+        lowercase=lowercase
+    )
 
 
-def _get_sequence_vector(sequence, format_function, format_dtype, unit_to_id,
-                         lowercase=True):
-    unit_sequence = format_function(sequence.lower() if lowercase else sequence)
+def _get_sequence_vector(
+    sequence,
+    tokenizer,
+    format_dtype,
+    unit_to_id,
+    lowercase=True
+):
+    unit_sequence = tokenizer.tokenize(
+        sequence.lower() if lowercase else sequence
+    )
     unit_indices_vector = np.empty(len(unit_sequence), dtype=format_dtype)
     for i in range(len(unit_sequence)):
         curr_unit = unit_sequence[i]
@@ -134,19 +142,19 @@ def _get_sequence_vector(sequence, format_function, format_dtype, unit_to_id,
 def build_sequence_matrix(sequences, inverse_vocabulary, format, length_limit,
                           padding_symbol, padding='right',
                           lowercase=True):
-    format_function = get_from_registry(
-        format,
-        format_registry
-    )
+    tokenizer = get_from_registry(format, tokenizer_registry)()
     format_dtype = int_type(len(inverse_vocabulary) - 1)
 
     max_length = 0
     unit_vectors = []
     for sequence in sequences:
-        unit_indices_vector = _get_sequence_vector(sequence, format_function,
-                                                   format_dtype,
-                                                   inverse_vocabulary,
-                                                   lowercase=lowercase)
+        unit_indices_vector = _get_sequence_vector(
+            sequence,
+            tokenizer,
+            format_dtype,
+            inverse_vocabulary,
+            lowercase=lowercase
+        )
         unit_vectors.append(unit_indices_vector)
         if len(unit_indices_vector) > max_length:
             max_length = len(unit_indices_vector)
@@ -168,423 +176,591 @@ def build_sequence_matrix(sequences, inverse_vocabulary, format, length_limit,
     return sequence_matrix
 
 
-def ids_array_to_string(matrix, idx2str):
-    texts = []
-    for row in matrix:
-        texts.append(
-            ' '.join(map(lambda x: idx2str[x], [x for x in row if x > 0])))
-    return texts
+class BaseTokenizer:
+    @abstractmethod
+    def tokenize(self, s):
+        pass
 
 
-def json_string_to_list(s):
-    s = str.replace(s, '\'', '\'')
-    return json.loads(str.replace(s, '\'', '\''))
+class CharactersToListTokenizer(BaseTokenizer):
+    def tokenize(self, s):
+        return s
 
 
-def characters_to_list(s):
-    return s
+class SpaceStringToListTokenizer(BaseTokenizer):
+    def tokenize(self, s):
+        return SPLIT_REGEX.split(s.strip())
 
 
-def space_string_to_list(s):
-    return SPLIT_REGEX.split(s.strip())
+class SpacePunctuationStringToListTokenizer(BaseTokenizer):
+    def tokenize(self, s):
+        return SPACE_PUNCTUATION_REGEX.findall(s.strip())
 
 
-def space_punctuation_string_to_list(s):
-    return SPACE_PUNCTUATION_REGEX.findall(s.strip())
+class UnderscoreStringToListTokenizer(BaseTokenizer):
+    def tokenize(self, s):
+        return UNDERSCORE_REGEX.split(s.strip())
 
 
-def underscore_string_to_list(s):
-    return UNDERSCORE_REGEX.split(s.strip())
+class CommaStringToListTokenizer(BaseTokenizer):
+    def tokenize(self, s):
+        return COMMA_REGEX.split(s.strip())
 
 
-def comma_string_to_list(s):
-    return COMMA_REGEX.split(s.strip())
+class UntokenizedStringToListTokenizer(BaseTokenizer):
+    def tokenize(self, s):
+        return [s]
 
 
-def untokenized_string_to_list(s):
-    return [s]
+class StrippedStringToListTokenizer(BaseTokenizer):
+    def tokenize(self, s):
+        return [s.strip()]
 
 
-def stripped_string_to_list(s):
-    return [s.strip()]
+class EnglishTokenizer(BaseTokenizer):
+    def tokenize(self, s):
+        return process_text(text, load_nlp_pipeline('en'))
 
 
-def english_tokenize(text):
-    return process_text(text, load_nlp_pipeline('en'))
+class EnglishFilterTokenizer(BaseTokenizer):
+    def tokenize(self, s):
+        return process_text(
+            text,
+            load_nlp_pipeline('en'),
+            filter_numbers=True,
+            filter_punctuation=True,
+            filter_short_tokens=True
+        )
 
 
-def english_tokenize_filter(text):
-    return process_text(text, load_nlp_pipeline('en'),
-                        filter_numbers=True,
-                        filter_punctuation=True,
-                        filter_short_tokens=True)
+class EnglishRemoveStopwordsTokenizer(BaseTokenizer):
+    def tokenize(self, s):
+        return process_text(
+            text,
+            load_nlp_pipeline('en'),
+            filter_stopwords=True
+        )
 
 
-def english_tokenize_remove_stopwords(text):
-    return process_text(text, load_nlp_pipeline('en'),
-                        filter_stopwords=True)
+class EnglishLemmatizeTokenizer(BaseTokenizer):
+    def tokenize(self, s):
+        process_text(text, load_nlp_pipeline('en'), return_lemma=True)
 
 
-def english_lemmatize(text):
-    return process_text(text, load_nlp_pipeline('en'),
-                        return_lemma=True)
+class EnglishLemmatizeFilterTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(
+            text,
+            load_nlp_pipeline('en'),
+            return_lemma=True,
+            filter_numbers=True,
+            filter_punctuation=True,
+            filter_short_tokens=True
+        )
 
 
-def english_lemmatize_filter(text):
-    return process_text(text, load_nlp_pipeline('en'),
-                        return_lemma=True,
-                        filter_numbers=True,
-                        filter_punctuation=True,
-                        filter_short_tokens=True)
+class EnglishLemmatizeRemoveStopwordsTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(
+            text,
+            load_nlp_pipeline('en'),
+            return_lemma=True,
+            filter_stopwords=True
+        )
 
 
-def english_lemmatize_remove_stopwords(text):
-    return process_text(text, load_nlp_pipeline('en'),
-                        return_lemma=True,
-                        filter_stopwords=True)
+class ItalianTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(text, load_nlp_pipeline('it'))
 
 
-def italian_tokenize(text):
-    return process_text(text, load_nlp_pipeline('it'))
-
-
-def italian_tokenize_filter(text):
-    return process_text(text, load_nlp_pipeline('it'),
-                        filter_numbers=True,
-                        filter_punctuation=True,
-                        filter_short_tokens=True)
-
-
-def italian_tokenize_remove_stopwords(text):
-    return process_text(text, load_nlp_pipeline('it'),
-                        filter_stopwords=True)
-
-
-def italian_lemmatize(text):
-    return process_text(text, load_nlp_pipeline('it'),
-                        return_lemma=True)
-
-
-def italian_lemmatize_filter(text):
-    return process_text(text, load_nlp_pipeline('it'),
-                        return_lemma=True,
-                        filter_numbers=True,
-                        filter_punctuation=True,
-                        filter_short_tokens=True)
-
-
-def italian_lemmatize_remove_stopwords(text):
-    return process_text(text, load_nlp_pipeline('it'),
-                        return_lemma=True,
-                        filter_stopwords=True)
-
-
-def spanish_tokenize(text):
-    return process_text(text, load_nlp_pipeline('es'))
-
-
-def spanish_tokenize_filter(text):
-    return process_text(text, load_nlp_pipeline('es'),
-                        filter_numbers=True,
-                        filter_punctuation=True,
-                        filter_short_tokens=True)
-
-
-def spanish_tokenize_remove_stopwords(text):
-    return process_text(text, load_nlp_pipeline('es'),
-                        filter_stopwords=True)
-
-
-def spanish_lemmatize(text):
-    return process_text(text, load_nlp_pipeline('es'),
-                        return_lemma=True)
-
-
-def spanish_lemmatize_filter(text):
-    return process_text(text, load_nlp_pipeline('es'),
-                        return_lemma=True,
-                        filter_numbers=True,
-                        filter_punctuation=True,
-                        filter_short_tokens=True)
-
-
-def spanish_lemmatize_remove_stopwords(text):
-    return process_text(text, load_nlp_pipeline('es'),
-                        return_lemma=True,
-                        filter_stopwords=True)
-
-
-def german_tokenize(text):
-    return process_text(text, load_nlp_pipeline('de'))
-
-
-def german_tokenize_filter(text):
-    return process_text(text, load_nlp_pipeline('de'),
-                        filter_numbers=True,
-                        filter_punctuation=True,
-                        filter_short_tokens=True)
-
-
-def german_tokenize_remove_stopwords(text):
-    return process_text(text, load_nlp_pipeline('de'),
-                        filter_stopwords=True)
-
-
-def german_lemmatize(text):
-    return process_text(text, load_nlp_pipeline('de'),
-                        return_lemma=True)
-
-
-def german_lemmatize_filter(text):
-    return process_text(text, load_nlp_pipeline('de'),
-                        return_lemma=True,
-                        filter_numbers=True,
-                        filter_punctuation=True,
-                        filter_short_tokens=True)
-
-
-def german_lemmatize_remove_stopwords(text):
-    return process_text(text, load_nlp_pipeline('de'),
-                        return_lemma=True,
-                        filter_stopwords=True)
-
-
-def french_tokenize(text):
-    return process_text(text, load_nlp_pipeline('fr'))
-
-
-def french_tokenize_filter(text):
-    return process_text(text, load_nlp_pipeline('fr'),
-                        filter_numbers=True,
-                        filter_punctuation=True,
-                        filter_short_tokens=True)
-
-
-def french_tokenize_remove_stopwords(text):
-    return process_text(text, load_nlp_pipeline('fr'),
-                        filter_stopwords=True)
-
-
-def french_lemmatize(text):
-    return process_text(text, load_nlp_pipeline('fr'),
-                        return_lemma=True)
-
-
-def french_lemmatize_filter(text):
-    return process_text(text, load_nlp_pipeline('fr'),
-                        return_lemma=True,
-                        filter_numbers=True,
-                        filter_punctuation=True,
-                        filter_short_tokens=True)
-
-
-def french_lemmatize_remove_stopwords(text):
-    return process_text(text, load_nlp_pipeline('fr'),
-                        return_lemma=True,
-                        filter_stopwords=True)
-
-
-def portuguese_tokenize(text):
-    return process_text(text, load_nlp_pipeline('pt'))
-
-
-def portuguese_tokenize_filter(text):
-    return process_text(text, load_nlp_pipeline('pt'),
-                        filter_numbers=True,
-                        filter_punctuation=True,
-                        filter_short_tokens=True)
-
-
-def portuguese_tokenize_remove_stopwords(text):
-    return process_text(text, load_nlp_pipeline('pt'),
-                        filter_stopwords=True)
-
-
-def portuguese_lemmatize(text):
-    return process_text(text, load_nlp_pipeline('pt'),
-                        return_lemma=True)
-
-
-def portuguese_lemmatize_filter(text):
-    return process_text(text, load_nlp_pipeline('pt'),
-                        return_lemma=True,
-                        filter_numbers=True,
-                        filter_punctuation=True,
-                        filter_short_tokens=True)
-
-
-def portuguese_lemmatize_remove_stopwords(text):
-    return process_text(text, load_nlp_pipeline('pt'),
-                        return_lemma=True,
-                        filter_stopwords=True)
-
-
-def dutch_tokenize(text):
-    return process_text(text, load_nlp_pipeline('nl'))
-
-
-def dutch_tokenize_filter(text):
-    return process_text(text, load_nlp_pipeline('nl'),
-                        filter_numbers=True,
-                        filter_punctuation=True,
-                        filter_short_tokens=True)
-
-
-def dutch_tokenize_remove_stopwords(text):
-    return process_text(text, load_nlp_pipeline('nl'),
-                        filter_stopwords=True)
-
-
-def dutch_lemmatize(text):
-    return process_text(text, load_nlp_pipeline('nl'),
-                        return_lemma=True)
-
-
-def dutch_lemmatize_filter(text):
-    return process_text(text, load_nlp_pipeline('nl'),
-                        return_lemma=True,
-                        filter_numbers=True,
-                        filter_punctuation=True,
-                        filter_short_tokens=True)
-
-
-def dutch_lemmatize_remove_stopwords(text):
-    return process_text(text, load_nlp_pipeline('nl'),
-                        return_lemma=True,
-                        filter_stopwords=True)
-
-
-def greek_tokenize(text):
-    return process_text(text, load_nlp_pipeline('el'))
-
-
-def greek_tokenize_filter(text):
-    return process_text(text, load_nlp_pipeline('el'),
-                        filter_numbers=True,
-                        filter_punctuation=True,
-                        filter_short_tokens=True)
-
-
-def greek_tokenize_remove_stopwords(text):
-    return process_text(text, load_nlp_pipeline('el'),
-                        filter_stopwords=True)
-
-
-def greek_lemmatize(text):
-    return process_text(text, load_nlp_pipeline('el'),
-                        return_lemma=True)
-
-
-def greek_lemmatize_filter(text):
-    return process_text(text, load_nlp_pipeline('el'),
-                        return_lemma=True,
-                        filter_numbers=True,
-                        filter_punctuation=True,
-                        filter_short_tokens=True)
-
-
-def greek_lemmatize_remove_stopwords(text):
-    return process_text(text, load_nlp_pipeline('el'),
-                        return_lemma=True,
-                        filter_stopwords=True)
-
-
-def multi_tokenize(text):
-    return process_text(text, load_nlp_pipeline('xx'))
-
-
-def multi_tokenize_filter(text):
-    return process_text(text, load_nlp_pipeline('xx'),
-                        filter_numbers=True,
-                        filter_punctuation=True,
-                        filter_short_tokens=True)
-
-
-def multi_tokenize_remove_stopwords(text):
-    return process_text(text, load_nlp_pipeline('xx'),
-                        filter_stopwords=True)
-
-
-def multi_lemmatize(text):
-    return process_text(text, load_nlp_pipeline('xx'),
-                        return_lemma=True)
-
-
-def multi_lemmatize_filter(text):
-    return process_text(text, load_nlp_pipeline('xx'),
-                        return_lemma=True,
-                        filter_numbers=True,
-                        filter_punctuation=True,
-                        filter_short_tokens=True)
-
-
-def multi_lemmatize_remove_stopwords(text):
-    return process_text(text, load_nlp_pipeline('xx'),
-                        return_lemma=True,
-                        filter_stopwords=True)
-
-
-format_registry = {
-    'characters': characters_to_list,
-    'json': json_string_to_list,
-    'space': space_string_to_list,
-    'space_punct': space_punctuation_string_to_list,
-    'underscore': underscore_string_to_list,
-    'comma': comma_string_to_list,
-    'untokenized': untokenized_string_to_list,
-    'stripped': stripped_string_to_list,
-    'english_tokenize': english_tokenize,
-    'english_tokenize_filter': english_tokenize_filter,
-    'english_tokenize_remove_stopwords': english_tokenize_remove_stopwords,
-    'english_lemmatize': english_lemmatize,
-    'english_lemmatize_filter': english_lemmatize_filter,
-    'english_lemmatize_remove_stopwords': english_lemmatize_remove_stopwords,
-    'italian_tokenize': italian_tokenize,
-    'italian_tokenize_filter': italian_tokenize_filter,
-    'italian_tokenize_remove_stopwords': italian_tokenize_remove_stopwords,
-    'italian_lemmatize': italian_lemmatize,
-    'italian_lemmatize_filter': italian_lemmatize_filter,
-    'italian_lemmatize_remove_stopwords': italian_lemmatize_remove_stopwords,
-    'spanish_tokenize': spanish_tokenize,
-    'spanish_tokenize_filter': spanish_tokenize_filter,
-    'spanish_tokenize_remove_stopwords': spanish_tokenize_remove_stopwords,
-    'spanish_lemmatize': spanish_lemmatize,
-    'spanish_lemmatize_filter': spanish_lemmatize_filter,
-    'spanish_lemmatize_remove_stopwords': spanish_lemmatize_remove_stopwords,
-    'german_tokenize': german_tokenize,
-    'german_tokenize_filter': german_tokenize_filter,
-    'german_tokenize_remove_stopwords': german_tokenize_remove_stopwords,
-    'german_lemmatize': german_lemmatize,
-    'german_lemmatize_filter': german_lemmatize_filter,
-    'german_lemmatize_remove_stopwords': german_lemmatize_remove_stopwords,
-    'french_tokenize': french_tokenize,
-    'french_tokenize_filter': french_tokenize_filter,
-    'french_tokenize_remove_stopwords': french_tokenize_remove_stopwords,
-    'french_lemmatize': french_lemmatize,
-    'french_lemmatize_filter': french_lemmatize_filter,
-    'french_lemmatize_remove_stopwords': french_lemmatize_remove_stopwords,
-    'portuguese_tokenize': portuguese_tokenize,
-    'portuguese_tokenize_filter': portuguese_tokenize_filter,
-    'portuguese_tokenize_remove_stopwords': portuguese_tokenize_remove_stopwords,
-    'portuguese_lemmatize': portuguese_lemmatize,
-    'portuguese_lemmatize_filter': portuguese_lemmatize_filter,
-    'portuguese_lemmatize_remove_stopwords': portuguese_lemmatize_remove_stopwords,
-    'dutch_tokenize': dutch_tokenize,
-    'dutch_tokenize_filter': dutch_tokenize_filter,
-    'dutch_tokenize_remove_stopwords': dutch_tokenize_remove_stopwords,
-    'dutch_lemmatize': dutch_lemmatize,
-    'dutch_lemmatize_filter': dutch_lemmatize_filter,
-    'dutch_lemmatize_remove_stopwords': dutch_lemmatize_remove_stopwords,
-    'greek_tokenize': greek_tokenize,
-    'greek_tokenize_filter': greek_tokenize_filter,
-    'greek_tokenize_remove_stopwords': greek_tokenize_remove_stopwords,
-    'greek_lemmatize': greek_lemmatize,
-    'greek_lemmatize_filter': greek_lemmatize_filter,
-    'greek_lemmatize_remove_stopwords': greek_lemmatize_remove_stopwords,
-    'multi_tokenize': multi_tokenize,
-    'multi_tokenize_filter': multi_tokenize_filter,
-    'multi_tokenize_remove_stopwords': multi_tokenize_remove_stopwords,
-    'multi_lemmatize': multi_lemmatize,
-    'multi_lemmatize_filter': multi_lemmatize_filter,
-    'multi_lemmatize_remove_stopwords': multi_lemmatize_remove_stopwords
+class ItalianFilterTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(
+            text,
+            load_nlp_pipeline('it'),
+            filter_numbers=True,
+            filter_punctuation=True,
+            filter_short_tokens=True
+        )
+
+
+class ItalianRemoveStopwordsTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(
+            text,
+            load_nlp_pipeline('it'),
+            filter_stopwords=True
+        )
+
+
+class ItalianLemmatizeTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(
+            text,
+            load_nlp_pipeline('it'),
+            return_lemma=True
+        )
+
+
+class ItalianLemmatizeFilterTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(
+            text,
+            load_nlp_pipeline('it'),
+            return_lemma=True,
+            filter_numbers=True,
+            filter_punctuation=True,
+            filter_short_tokens=True
+        )
+
+
+class ItalianLemmatizeRemoveStopwordsTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(
+            text,
+            load_nlp_pipeline('it'),
+            return_lemma=True,
+            filter_stopwords=True
+        )
+
+
+class SpanishTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(text, load_nlp_pipeline('es'))
+
+
+class SpanishFilterTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(
+            text,
+            load_nlp_pipeline('es'),
+            filter_numbers=True,
+            filter_punctuation=True,
+            filter_short_tokens=True
+        )
+
+
+class SpanishRemoveStopwordsTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(
+            text,
+            load_nlp_pipeline('es'),
+            filter_stopwords=True
+        )
+
+
+class SpanishLemmatizeTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(
+            text,
+            load_nlp_pipeline('es'),
+            return_lemma=True
+        )
+
+
+class SpanishLemmatizeFilterTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(
+            text,
+            load_nlp_pipeline('es'),
+            return_lemma=True,
+            filter_numbers=True,
+            filter_punctuation=True,
+            filter_short_tokens=True
+        )
+
+
+class SpanishLemmatizeRemoveStopwordsTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(
+            text,
+            load_nlp_pipeline('es'),
+            return_lemma=True,
+            filter_stopwords=True
+        )
+
+
+class GermanTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(text, load_nlp_pipeline('de'))
+
+
+class GermanFilterTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(
+            text,
+            load_nlp_pipeline('de'),
+            filter_numbers=True,
+            filter_punctuation=True,
+            filter_short_tokens=True
+        )
+
+
+class GermanRemoveStopwordsTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(
+            text,
+            load_nlp_pipeline('de'),
+            filter_stopwords=True
+        )
+
+
+class GermanLemmatizeTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(
+            text,
+            load_nlp_pipeline('de'),
+            return_lemma=True
+        )
+
+
+class GermanLemmatizeFilterTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(
+            text,
+            load_nlp_pipeline('de'),
+            return_lemma=True,
+            filter_numbers=True,
+            filter_punctuation=True,
+            filter_short_tokens=True
+        )
+
+
+class GermanLemmatizeRemoveStopwordsTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(
+            text,
+            load_nlp_pipeline('de'),
+            return_lemma=True,
+            filter_stopwords=True
+        )
+
+
+class FrenchTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(text, load_nlp_pipeline('fr'))
+
+
+class FrenchFilterTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(
+            text,
+            load_nlp_pipeline('fr'),
+            filter_numbers=True,
+            filter_punctuation=True,
+            filter_short_tokens=True
+        )
+
+
+class FrenchRemoveStopwordsTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(
+            text,
+            load_nlp_pipeline('fr'),
+            filter_stopwords=True
+        )
+
+
+class FrenchLemmatizeTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(
+            text,
+            load_nlp_pipeline('fr'),
+            return_lemma=True
+        )
+
+
+class FrenchLemmatizeFilterTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(
+            text,
+            load_nlp_pipeline('fr'),
+            return_lemma=True,
+            filter_numbers=True,
+            filter_punctuation=True,
+            filter_short_tokens=True
+        )
+
+
+class FrenchLemmatizeRemoveStopwordsTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(
+            text,
+            load_nlp_pipeline('fr'),
+            return_lemma=True,
+            filter_stopwords=True
+        )
+
+
+class PortugueseTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(text, load_nlp_pipeline('pt'))
+
+
+class PortugueseFilterTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(
+            text,
+            load_nlp_pipeline('pt'),
+            filter_numbers=True,
+            filter_punctuation=True,
+            filter_short_tokens=True
+        )
+
+
+class PortugueseRemoveStopwordsTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(
+            text,
+            load_nlp_pipeline('pt'),
+            filter_stopwords=True
+        )
+
+
+class PortugueseLemmatizeTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(text, load_nlp_pipeline('pt'), return_lemma=True)
+
+
+class PortugueseLemmatizeFilterTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(
+            text,
+            load_nlp_pipeline('pt'),
+            return_lemma=True,
+            filter_numbers=True,
+            filter_punctuation=True,
+            filter_short_tokens=True
+        )
+
+
+class PortugueseLemmatizeRemoveStopwordsTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(
+            text,
+            load_nlp_pipeline('pt'),
+            return_lemma=True,
+            filter_stopwords=True
+        )
+
+
+class DutchTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(text, load_nlp_pipeline('nl'))
+
+
+class DutchFilterTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(
+            text,
+            load_nlp_pipeline('nl'),
+            filter_numbers=True,
+            filter_punctuation=True,
+            filter_short_tokens=True
+        )
+
+
+class DutchRemoveStopwordsTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(
+            text,
+            load_nlp_pipeline('nl'),
+            filter_stopwords=True
+        )
+
+
+class DutchLemmatizeTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(text, load_nlp_pipeline('nl'), return_lemma=True)
+
+
+class DutchLemmatizeFilterTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(
+            text,
+            load_nlp_pipeline('nl'),
+            return_lemma=True,
+            filter_numbers=True,
+            filter_punctuation=True,
+            filter_short_tokens=True
+        )
+
+
+class DutchLemmatizeRemoveStopwordsTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(
+            text,
+            load_nlp_pipeline('nl'),
+            return_lemma=True,
+            filter_stopwords=True
+        )
+
+
+class GreekTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(text, load_nlp_pipeline('el'))
+
+
+class GreekFilterTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(
+            text,
+            load_nlp_pipeline('el'),
+            filter_numbers=True,
+            filter_punctuation=True,
+            filter_short_tokens=True
+        )
+
+
+class GreekRemoveStopwordsTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(
+            text,
+            load_nlp_pipeline('el'),
+            filter_stopwords=True
+        )
+
+
+class GreekLemmatizeTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(text, load_nlp_pipeline('el'), return_lemma=True)
+
+
+class GreekLemmatizeFilterTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(
+            text,
+            load_nlp_pipeline('el'),
+            return_lemma=True,
+            filter_numbers=True,
+            filter_punctuation=True,
+            filter_short_tokens=True
+        )
+
+
+class GreekLemmatizeRemoveStopwordsFilterTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(
+            text,
+            load_nlp_pipeline('el'),
+            return_lemma=True,
+            filter_stopwords=True
+        )
+
+
+class MultiTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(text, load_nlp_pipeline('xx'))
+
+
+class MultiFilterTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(
+            text,
+            load_nlp_pipeline('xx'),
+            filter_numbers=True,
+            filter_punctuation=True,
+            filter_short_tokens=True
+        )
+
+
+class MultiRemoveStopwordsTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(
+            text,
+            load_nlp_pipeline('xx'),
+            filter_stopwords=True
+        )
+
+
+class MultiLemmatizeTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(text, load_nlp_pipeline('xx'), return_lemma=True)
+
+
+class MultiLemmatizeFilterTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(
+            text,
+            load_nlp_pipeline('xx'),
+            return_lemma=True,
+            filter_numbers=True,
+            filter_punctuation=True,
+            filter_short_tokens=True
+        )
+
+
+class MultiLemmatizeRemoveStopwordsTokenizer(BaseTokenizer):
+    def tokenize(self, text):
+        return process_text(
+            text,
+            load_nlp_pipeline('xx'),
+            return_lemma=True,
+            filter_stopwords=True
+        )
+
+
+tokenizer_registry = {
+    'characters': CharactersToListTokenizer,
+    'space': SpaceStringToListTokenizer,
+    'space_punct': SpacePunctuationStringToListTokenizer,
+    'underscore': UnderscoreStringToListTokenizer,
+    'comma': CommaStringToListTokenizer,
+    'untokenized': UntokenizedStringToListTokenizer,
+    'stripped': StrippedStringToListTokenizer,
+    'english_tokenize': EnglishTokenizer,
+    'english_tokenize_filter': EnglishFilterTokenizer,
+    'english_tokenize_remove_stopwords': EnglishRemoveStopwordsTokenizer,
+    'english_lemmatize': EnglishLemmatizeTokenizer,
+    'english_lemmatize_filter': EnglishLemmatizeFilterTokenizer,
+    'english_lemmatize_remove_stopwords': EnglishLemmatizeRemoveStopwordsTokenizer,
+    'italian_tokenize': ItalianTokenizer,
+    'italian_tokenize_filter': ItalianFilterTokenizer,
+    'italian_tokenize_remove_stopwords': ItalianRemoveStopwordsTokenizer,
+    'italian_lemmatize': ItalianLemmatizeTokenizer,
+    'italian_lemmatize_filter': ItalianLemmatizeFilterTokenizer,
+    'italian_lemmatize_remove_stopwords': ItalianLemmatizeRemoveStopwordsTokenizer,
+    'spanish_tokenize': SpanishTokenizer,
+    'spanish_tokenize_filter': SpanishFilterTokenizer,
+    'spanish_tokenize_remove_stopwords': SpanishRemoveStopwordsTokenizer,
+    'spanish_lemmatize': SpanishLemmatizeTokenizer,
+    'spanish_lemmatize_filter': SpanishLemmatizeFilterTokenizer,
+    'spanish_lemmatize_remove_stopwords': SpanishLemmatizeRemoveStopwordsTokenizer,
+    'german_tokenize': GermanTokenizer,
+    'german_tokenize_filter': GermanFilterTokenizer,
+    'german_tokenize_remove_stopwords': GermanRemoveStopwordsTokenizer,
+    'german_lemmatize': GermanLemmatizeTokenizer,
+    'german_lemmatize_filter': GermanLemmatizeFilterTokenizer,
+    'german_lemmatize_remove_stopwords': GermanLemmatizeRemoveStopwordsTokenizer,
+    'french_tokenize': FrenchTokenizer,
+    'french_tokenize_filter': FrenchFilterTokenizer,
+    'french_tokenize_remove_stopwords': FrenchRemoveStopwordsTokenizer,
+    'french_lemmatize': FrenchLemmatizeTokenizer,
+    'french_lemmatize_filter': FrenchLemmatizeFilterTokenizer,
+    'french_lemmatize_remove_stopwords': FrenchLemmatizeRemoveStopwordsTokenizer,
+    'portuguese_tokenize': PortugueseTokenizer,
+    'portuguese_tokenize_filter': PortugueseFilterTokenizer,
+    'portuguese_tokenize_remove_stopwords': PortugueseRemoveStopwordsTokenizer,
+    'portuguese_lemmatize': PortugueseLemmatizeTokenizer,
+    'portuguese_lemmatize_filter': PortugueseLemmatizeFilterTokenizer,
+    'portuguese_lemmatize_remove_stopwords': PortugueseLemmatizeRemoveStopwordsTokenizer,
+    'dutch_tokenize': DutchTokenizer,
+    'dutch_tokenize_filter': DutchFilterTokenizer,
+    'dutch_tokenize_remove_stopwords': DutchRemoveStopwordsTokenizer,
+    'dutch_lemmatize': DutchLemmatizeTokenizer,
+    'dutch_lemmatize_filter': DutchLemmatizeFilterTokenizer,
+    'dutch_lemmatize_remove_stopwords': DutchLemmatizeRemoveStopwordsTokenizer,
+    'greek_tokenize': GreekTokenizer,
+    'greek_tokenize_filter': GreekFilterTokenizer,
+    'greek_tokenize_remove_stopwords': GreekRemoveStopwordsTokenizer,
+    'greek_lemmatize': GreekLemmatizeTokenizer,
+    'greek_lemmatize_filter': GreekLemmatizeFilterTokenizer,
+    'greek_lemmatize_remove_stopwords': GreekLemmatizeRemoveStopwordsFilterTokenizer,
+    'multi_tokenize': MultiTokenizer,
+    'multi_tokenize_filter': MultiFilterTokenizer,
+    'multi_tokenize_remove_stopwords': MultiRemoveStopwordsTokenizer,
+    'multi_lemmatize': MultiLemmatizeTokenizer,
+    'multi_lemmatize_filter': MultiLemmatizeFilterTokenizer,
+    'multi_lemmatize_remove_stopwords': MultiLemmatizeRemoveStopwordsTokenizer
 }


### PR DESCRIPTION
Have tokenizer objects instead of functions so we can have encoders which require initialization to follow similar interface.

Test plan: unit and integration tests.