### PR TITLE
Fixes style in landing page footer

### DIFF
--- a/mkdocs/custom/landing.html
+++ b/mkdocs/custom/landing.html
@@ -384,25 +384,25 @@ predictions = model.predict(test_dataframe)</code></pre>
 
     <!-- Link to previous and/or next page -->
 
-    <div class="md-footer-nav">
+
+    <div class="md-footer-nav md-footer-nav-wrapper">
         <nav class="md-footer-nav__inner md-grid">
 
             <!-- Link to next page -->
 
-            <a class="md-flex md-footer-nav__link md-footer-nav__link--next" href="getting_started/" rel="next"
+            <a class="md-flex md-footer-nav__link md-footer-nav__link--next md-footer-nav__link-wrapper" href="getting_started/" rel="next"
                title="Examples">
                 <div class="md-flex__cell md-flex__cell--stretch
-                  md-footer-nav__title">
-              <span class="md-flex__ellipsis">
-                <span class="md-footer-nav__direction">
+                  md-footer-nav__title md-flex__cell-wrapper">
+              <span class="md-flex__ellipsis md-flex__ellipsis-wrapper">
+                <span class="md-footer-nav__direction md-footer-nav-item md-footer-nav-item-wrapper">
                   Next
                 </span>
-                Getting Started
+                <span class="md-footer-nav-item-wrapper md-footer-nav-item-title-wrapper">Getting Started</span>
               </span>
                 </div>
-                <div class="md-flex__cell md-flex__cell--shrink">
-                    <i class="md-icon md-icon--arrow-forward
-                    md-footer-nav__button"></i>
+                <div class="md-flex__cell md-flex__cell--shrink md-flex__cell-arrow">
+                    <i class="fa fa-arrow-right arrow-wrapper"></i>
                 </div>
             </a>
 
@@ -415,10 +415,10 @@ predictions = model.predict(test_dataframe)</code></pre>
         <div class="md-footer-meta__inner md-grid">
 
             <!-- Copyright and theme information -->
-            <div class="md-footer-copyright">
+            <div class="md-footer-copyright md-footer-copyright-wrapper">
                 <div class="footer-logo-smallpad"></div>
 
-                <div class="md-footer-copyright__highlight">
+                <div class="md-footer-copyright__highlight md-footer-copyright__highlight-wrapper">
                     Copyright © 2018 - 2019 Uber Technologies Inc.
                 </div>
 

--- a/mkdocs/docs/stylesheets/landing_main.css
+++ b/mkdocs/docs/stylesheets/landing_main.css
@@ -2656,8 +2656,7 @@ html[data-useragent*='MSIE 10.0'] .home-scrolldown,
  * ------------------------------------------------------------------- */
 
 footer {
-    padding-top: 9rem;
-    padding-bottom: 4.2rem;
+    padding:2.2rem 9rem 2.2rem 9rem;
     font-size: 1.5rem;
     line-height: 2.7rem;
     color: rgba(255, 255, 255, 0.25);
@@ -2988,5 +2987,61 @@ footer ul a:visited {
     }
 }
 
+.md-footer-nav-wrapper {
+  height: 7rem;
+}
+
+.md-footer-nav__link-wrapper {
+    width: 50%;
+    float:right;
+    display: inline-flex;
+    flex-direction: row;
+    position: relative;
+}
+
+.md-flex__ellipsis-wrapper {
+  display: table;
+}
+
+.md-flex__cell-wrapper {
+  height: 7rem;
+  width: 20rem;
+  position: absolute;
+  right: 0;
+}
+
+.md-footer-nav-item-wrapper {
+  color: #666;
+  display: table-row;
+  text-align: right;
+}
+
+.md-footer-nav-item-title-wrapper {
+  color: #ececec;
+  font-size: 1.8rem;
+}
+
+.md-flex__cell-arrow {
+  font-size: 2rem;
+  width:3rem;
+  height: 5rem;
+  display: table;
+  position: absolute;
+  right: 0;
+}
+
+.arrow-wrapper {
+  display: table-cell;
+  vertical-align: middle;
+}
+
+.md-footer-copyright-wrapper {
+  font-family: "Roboto","Helvetica Neue",Helvetica,Arial,sans-serif;
+  font-size: 1.2rem;
+  line-height: 1.6;
+}
+.md-footer-copyright__highlight-wrapper {
+  color:#ececec;
+}
 
 /*# sourceMappingURL=landing_main.css.map */


### PR DESCRIPTION
## Summary:
For #371. Fixes the `css` style of the landing page, to be similar to the others, as can be seen below .
- How it is now:
![result](https://user-images.githubusercontent.com/42987854/59567838-5d123f00-9049-11e9-8a12-cb308e050c89.JPG)


- How it should look like:
![target](https://user-images.githubusercontent.com/42987854/59567839-63082000-9049-11e9-9fa6-6222a0e04357.JPG)

## Important notes:

- Most critical part is the arrow, which looks too bold. It turns out all other pages except the landing page use `mkdocs-material`, that has Font Awesome arrow right weight **REGULAR**  as standard. However, if I want to use it in the html directly, only  Font Awesome arrow-right weight **SOLID** is free, the **REGULAR** needs a paid account. I tried to just copy and paste the arrow from the `css` already minified for the other pages, but then the icon breaks
- I still did **not** run `mkdocs build` because there might be more style changes.