### PR TITLE
add savefig for roc curve

### DIFF
--- a/ludwig/utils/visualization_utils.py
+++ b/ludwig/utils/visualization_utils.py
@@ -705,6 +705,7 @@ def roc_curves(fpr_tprs, algorithm_names=None, title=None, graded_color=False):
     plt.tight_layout()
     ludwig.contrib.contrib_command("visualize_figure", plt.gcf())
     plt.show()
+    plt.savefig('_'.join(title.split(' ')) + '.png')
 
 
 def calibration_plot(fraction_positives, mean_predicted_values,


### PR DESCRIPTION
# Code Pull Requests

ROC curve plot is saved in same dir where ludwig visualize ... command is executed.

Please provide the following:

- a clear explanation of what your code dose
- if applicable, a reference to an issue
- a reproducible test for your PR (code, model definition and data sample)

# Documentation Pull Requests

Note that the documentation HTML files are in `docs/` while the Markdown sources are in `mkdocs/docs`.

If you are proposing a modification to the documentation you should change only the Markdown files, then recreate the documentation as explained in the `mkdocs/README.md` file with `mkdocs build`, which will create the HTML files automatically, and only after this create a commit.

`api.md` is automatically generated from the docstrings in the code, so if you want to change something in that file, first modify `ludwig/api.py` docstring, then run `mkdocs/code_docs_autogen.py`, which will create `mkdocs/docs/api.md` and then finally run `mkdocs build` which will generate the HTML in `docs/`.
