### PR TITLE
Change binary cross entropy to weighted ce

### DIFF
--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -128,7 +128,8 @@ class BinaryOutputFeature(BinaryBaseFeature, OutputFeature):
 
         self.loss = {
             'robust_lambda': 0,
-            'confidence_penalty': 0
+            'confidence_penalty': 0,
+            'pos_weight': 1
         }
 
         _ = self.overwrite_defaults(feature)
@@ -179,8 +180,13 @@ class BinaryOutputFeature(BinaryBaseFeature, OutputFeature):
 
     def _get_loss(self, targets, logits, probabilities):
         with tf.variable_scope('loss_{}'.format(self.name)):
+            pos_weight = self.loss['pos_weight']
+            if(not pos_weight > 0):
+                raise ValueError('{} has to be > 0 to ensure that loss for positive labels 
+                p_label=1 * log(sigmoid(p_predict)) is > 0'.format(pos_weight))
+
             train_loss = tf.nn.sigmoid_cross_entropy_with_logits(
-                labels=tf.cast(targets, tf.float32), logits=logits)
+                labels=tf.cast(targets, tf.float32), logits=logits, pos_weight=pos_weight)
 
             if self.loss['robust_lambda'] > 0:
                 train_loss = ((1 - self.loss['robust_lambda']) * train_loss +
@@ -400,11 +406,11 @@ class BinaryOutputFeature(BinaryBaseFeature, OutputFeature):
                 'threshold': 0.5,
                 'robust_lambda': 0,
                 'confidence_penalty': 0,
-                'weight': 1
+                'pos_weight': 1
             }
         )
-        set_default_value(output_feature, 'threshold', 0.5)
+#        set_default_value(output_feature, 'threshold', 0.5)
         set_default_value(output_feature, 'dependencies', [])
-        set_default_value(output_feature, 'weight', 1)
+#        set_default_value(output_feature, 'weight', 1)
         set_default_value(output_feature, 'reduce_input', SUM)
         set_default_value(output_feature, 'reduce_dependencies', SUM)

--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -180,13 +180,12 @@ class BinaryOutputFeature(BinaryBaseFeature, OutputFeature):
 
     def _get_loss(self, targets, logits, probabilities):
         with tf.variable_scope('loss_{}'.format(self.name)):
-            pos_weight = self.loss['pos_weight']
-            if(not pos_weight > 0):
-                raise ValueError('{} has to be > 0 to ensure that loss for positive labels 
-                p_label=1 * log(sigmoid(p_predict)) is > 0'.format(pos_weight))
+            pos_ce_weight = self.loss['pos_ce_weight']
+            if(not pos_ce_weight > 0):
+                raise ValueError('{} has to be > 0 to ensure that loss for positive labels p_label=1 * log(sigmoid(p_predict)) is > 0'.format(pos_ce_weight))
 
-            train_loss = tf.nn.sigmoid_cross_entropy_with_logits(
-                labels=tf.cast(targets, tf.float32), logits=logits, pos_weight=pos_weight)
+            train_loss = tf.nn.weighted_cross_entropy_with_logits(
+                targets=tf.cast(targets, tf.float32), logits=logits, pos_weight=pos_ce_weight)
 
             if self.loss['robust_lambda'] > 0:
                 train_loss = ((1 - self.loss['robust_lambda']) * train_loss +
@@ -406,11 +405,10 @@ class BinaryOutputFeature(BinaryBaseFeature, OutputFeature):
                 'threshold': 0.5,
                 'robust_lambda': 0,
                 'confidence_penalty': 0,
-                'pos_weight': 1
+                'pos_ce_weight': 1,
+                'weight': 1
             }
         )
-#        set_default_value(output_feature, 'threshold', 0.5)
         set_default_value(output_feature, 'dependencies', [])
-#        set_default_value(output_feature, 'weight', 1)
         set_default_value(output_feature, 'reduce_input', SUM)
         set_default_value(output_feature, 'reduce_dependencies', SUM)


### PR DESCRIPTION
The function tf.nn.sigmoid_cross_entropy_with_logits to calculate the cross entropy is replaced by 
tf.nn.weighted_cross_entropy_with_logits to allow for a weighted cross entropy. The default value for pos_weight is 1 meaning that tf.nn.weighted_cross_entropy_with_logits == tf.nn.sigmoid_cross_entropy_with_logits. 
The test 'test_experiment_timeseries' was executed to make sure, everything works as before.
Readme can be updated once change is integrated.

# Code Pull Requests

Please provide the following:

- a clear explanation of what your code dose
- if applicable, a reference to an issue
- a reproducible test for your PR (code, model definition and data sample)

# Documentation Pull Requests

Note that the documentation HTML files are in `docs/` while the Markdown sources are in `mkdocs/docs`.

If you are proposing a modification to the documentation you should change only the Markdown files, then recreate the documentation as explained in the `mkdocs/README.md` file with `mkdocs build`, which will create the HTML files automatically, and only after this create a commit.

`api.md` is automatically generated from the docstrings in the code, so if you want to change something in that file, first modify `ludwig/api.py` docstring, then run `mkdocs/code_docs_autogen.py`, which will create `mkdocs/docs/api.md` and then finally run `mkdocs build` which will generate the HTML in `docs/`.
