### PR TITLE
adds support for data_train_dict, data_test_dict etc. in api.py

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -271,6 +271,9 @@ class LudwigModel:
             data_validation_hdf5=None,
             data_test_hdf5=None,
             data_dict=None,
+            data_train_dict=None,
+            data_test_dict=None,
+            data_validation_dict=None,
             train_set_metadata_json=None,
             experiment_name='api_experiment',
             model_name='run',
@@ -328,6 +331,33 @@ class LudwigModel:
                the same length. Each index in the lists corresponds to one
                datapoint. For example a data set consisting of two datapoints
                with a text and a class may be provided as the following dict
+               ``{'text_field_name': ['text of the first datapoint', text of the
+               second datapoint'], 'class_filed_name': ['class_datapoints_1',
+               'class_datapoints_2']}`.
+        :param data_train_dict: (dict) input training data dictionary. It is
+               expected to contain one key for each field and the values have
+               to be lists of the same length. Each index in the lists
+               corresponds to one datapoint. For example a data set consisting
+               of two datapoints with a text and a class may be provided as the
+               following dict:
+               ``{'text_field_name': ['text of the first datapoint', text of the
+               second datapoint'], 'class_filed_name': ['class_datapoints_1',
+               'class_datapoints_2']}`.
+        :param data_test_dict: (dict) input test data dictionary. It is
+               expected to contain one key for each field and the values have
+               to be lists of the same length. Each index in the lists
+               corresponds to one datapoint. For example a data set consisting
+               of two datapoints with a text and a class may be provided as the
+               following dict:
+               ``{'text_field_name': ['text of the first datapoint', text of the
+               second datapoint'], 'class_filed_name': ['class_datapoints_1',
+               'class_datapoints_2']}`.
+        :param data_validation_dict: (dict) input validation data dictionary. It
+               is expected to contain one key for each field and the values have
+               to be lists of the same length. Each index in the lists
+               corresponds to one datapoint. For example a data set consisting
+               of two datapoints with a text and a class may be provided as the
+               following dict:
                ``{'text_field_name': ['text of the first datapoint', text of the
                second datapoint'], 'class_filed_name': ['class_datapoints_1',
                'class_datapoints_2']}`.
@@ -411,6 +441,15 @@ class LudwigModel:
 
         if data_df is None and data_dict is not None:
             data_df = pd.DataFrame(data_dict)
+
+        if data_train_df is None and data_train_dict is not None:
+            data_train_df = pd.DataFrame(data_train_dict)
+
+        if data_validation_df is None and data_validation_dict is not None:
+            data_validation_df = pd.DataFrame(data_validation_dict)
+
+        if data_test_df is None and data_test_dict is not None:
+            data_test_df = pd.DataFrame(data_test_dict)
 
         (
             self.model,


### PR DESCRIPTION
Adds support for data_(train/test/validation)_dict in api.py.

(Piero asked to include this for the sake of completeness)