### PR TITLE
Add contrib.train_epoch_end hook

### DIFF
--- a/ludwig/models/model.py
+++ b/ludwig/models/model.py
@@ -37,6 +37,7 @@ from tabulate import tabulate
 from tensorflow.python import debug as tf_debug
 from tqdm import tqdm
 
+from ludwig.contrib import contrib_command
 from ludwig.constants import *
 from ludwig.features.feature_registries import output_type_registry
 from ludwig.features.feature_utils import SEQUENCE_TYPES
@@ -662,6 +663,7 @@ class Model:
                         )
 
             if is_on_master():
+                contrib_command("train_epoch_end", progress_tracker)
                 logger.info('')
 
         if train_writer is not None:


### PR DESCRIPTION
This PR adds the "train_epoch_end" hook for contribs. In addition, it adds the code for the 3rd-party contrib from Comet to handle epoch end metric logging. An example experiment can be found here:

https://www.comet.ml/dsblank/ludwig/b919068a27014a1b941a1de11c707a0b
