### PR TITLE
addresses the logging issues

### DIFF
--- a/ludwig/__init__.py
+++ b/ludwig/__init__.py
@@ -19,4 +19,16 @@ import logging
 from ludwig.globals import LUDWIG_VERSION as __version__
 
 
-logging.basicConfig(level=logging.INFO, stream=sys.stdout, format='%(message)s')
+logger = logging.getLogger(__name__)
+# Default logging level for the project
+logger.setLevel(logging.INFO)
+
+# Configure stream handler
+ch = logging.StreamHandler(sys.stdout)
+ch.setLevel(logging.DEBUG)
+
+# Set formatter
+formatter = logging.Formatter('%(message)s')
+ch.setFormatter(formatter)
+
+logger.addHandler(ch)

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -61,7 +61,7 @@ from ludwig.utils.print_utils import logging_level_registry
 
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+# logger.setLevel(logging.INFO)
 
 
 class LudwigModel:
@@ -653,7 +653,7 @@ class LudwigModel:
                 'bucketing_field'
             ]
 
-        logging.debug('Preprocessing {} datapoints'.format(len(data_df)))
+        logger.debug('Preprocessing {} datapoints'.format(len(data_df)))
         features_to_load = (self.model_definition['input_features'] +
                             self.model_definition['output_features'])
         preprocessed_data = build_data(
@@ -674,7 +674,7 @@ class LudwigModel:
             None
         )
 
-        logging.debug('Training batch')
+        logger.debug('Training batch')
         self.model.train_online(
             dataset,
             batch_size=batch_size,
@@ -708,7 +708,7 @@ class LudwigModel:
         if data_df is None:
             data_df = self._read_data(data_csv, data_dict)
 
-        logging.debug('Preprocessing {} datapoints'.format(len(data_df)))
+        logger.debug('Preprocessing {} datapoints'.format(len(data_df)))
         features_to_load = self.model_definition['input_features']
         if evaluate_performance:
             output_features = self.model_definition['output_features']
@@ -733,7 +733,7 @@ class LudwigModel:
             None
         )
 
-        logging.debug('Predicting')
+        logger.debug('Predicting')
         predict_results = self.model.predict(
             dataset,
             batch_size,
@@ -750,7 +750,7 @@ class LudwigModel:
                 self.train_set_metadata
             )
 
-        logging.debug('Postprocessing')
+        logger.debug('Postprocessing')
         if (
                 return_type == 'dict' or
                 return_type == 'dictionary' or
@@ -772,7 +772,7 @@ class LudwigModel:
                 self.train_set_metadata
             )
         else:
-            logging.warning(
+            logger.warning(
                 'Unrecognized return_type: {}. '
                 'Returning DataFrame.'.format(return_type)
             )
@@ -969,7 +969,7 @@ def test_train(
         debug=debug
     )
 
-    logging.critical(train_stats)
+    logger.critical(train_stats)
 
     # predict
     predictions = ludwig_model.predict(
@@ -981,7 +981,7 @@ def test_train(
     )
 
     ludwig_model.close()
-    logging.critical(predictions)
+    logger.critical(predictions)
 
 
 def test_train_online(
@@ -1032,7 +1032,7 @@ def test_train_online(
         logging_level=logging_level
     )
     ludwig_model.close()
-    logging.critical(predictions)
+    logger.critical(predictions)
 
 
 def test_predict(
@@ -1058,7 +1058,7 @@ def test_predict(
     )
 
     ludwig_model.close()
-    logging.critical(predictions)
+    logger.critical(predictions)
 
     predictions = ludwig_model.predict(
         data_csv=data_csv,
@@ -1068,7 +1068,7 @@ def test_predict(
         logging_level=logging_level
     )
 
-    logging.critical(predictions)
+    logger.critical(predictions)
 
 
 def main(sys_argv):
@@ -1150,6 +1150,7 @@ def main(sys_argv):
     args = parser.parse_args(sys_argv)
     args.logging_level = logging_level_registry[args.logging_level]
 
+    """
     logging.basicConfig(
         stream=sys.stdout,
         # filename='log.log',
@@ -1157,6 +1158,7 @@ def main(sys_argv):
         level=args.logging_level,
         format='%(message)s'
     )
+    """
 
     if args.test == 'train':
         test_train(**vars(args))
@@ -1165,7 +1167,7 @@ def main(sys_argv):
     elif args.test == 'predict':
         test_predict(**vars(args))
     else:
-        logging.info('Unsupported test type')
+        logger.info('Unsupported test type')
 
 
 if __name__ == '__main__':

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -132,7 +132,7 @@ class LudwigModel:
             model_definition_file=None,
             logging_level=logging.ERROR
     ):
-        logging.getLogger().setLevel(logging_level)
+        logging.getLogger('ludwig').setLevel(logging_level)
         if model_definition_file is not None:
             with open(model_definition_file, 'r') as def_file:
                 self.model_definition = merge_with_defaults(
@@ -192,7 +192,7 @@ class LudwigModel:
 
         """
 
-        logging.getLogger().setLevel(logging_level)
+        logging.getLogger('ludwig').setLevel(logging_level)
         if logging_level in {logging.WARNING, logging.ERROR, logging.CRITICAL}:
             set_disable_progressbar(True)
 
@@ -435,7 +435,7 @@ class LudwigModel:
         output feature containing loss and measures values for each epoch.
 
         """
-        logging.getLogger().setLevel(logging_level)
+        logging.getLogger('ludwig').setLevel(logging_level)
         if logging_level in {logging.WARNING, logging.ERROR, logging.CRITICAL}:
             set_disable_progressbar(True)
 
@@ -531,7 +531,7 @@ class LudwigModel:
                be printed.
         :param debug: (bool, default: `False`) enables debugging mode
         """
-        logging.getLogger().setLevel(logging_level)
+        logging.getLogger('ludwig').setLevel(logging_level)
         if logging_level in {logging.WARNING, logging.ERROR, logging.CRITICAL}:
             set_disable_progressbar(True)
 
@@ -626,7 +626,7 @@ class LudwigModel:
         text of the second datapoint'], 'class_filed_name':
         ['class_datapoints_1', 'class_datapoints_2']}`.
         """
-        logging.getLogger().setLevel(logging_level)
+        logging.getLogger('ludwig').setLevel(logging_level)
         if logging_level in {logging.WARNING, logging.ERROR, logging.CRITICAL}:
             set_disable_progressbar(True)
 
@@ -697,7 +697,7 @@ class LudwigModel:
             evaluate_performance=False,
             logging_level=logging.ERROR,
     ):
-        logging.getLogger().setLevel(logging_level)
+        logging.getLogger('ludwig').setLevel(logging_level)
         if logging_level in {logging.WARNING, logging.ERROR, logging.CRITICAL}:
             set_disable_progressbar(True)
 

--- a/ludwig/collect.py
+++ b/ludwig/collect.py
@@ -37,7 +37,6 @@ from ludwig.utils.strings_utils import make_safe_filename
 
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 def collect_activations(
@@ -277,7 +276,9 @@ def cli_collect_activations(sys_argv):
 
     args = parser.parse_args(sys_argv)
 
-    logger.setLevel(logging_level_registry[args.logging_level])
+    logging.getLogger('ludwig').setLevel(
+        logging_level_registry[args.logging_level]
+    )
 
     print_ludwig('Collect Activations', LUDWIG_VERSION)
 
@@ -348,7 +349,9 @@ def cli_collect_weights(sys_argv):
 
     args = parser.parse_args(sys_argv)
 
-    logger.setLevel(logging_level_registry[args.logging_level])
+    logging.getLogger('ludwig').setLevel(
+        logging_level_registry[args.logging_level]
+    )
     print_ludwig('Collect Weights', LUDWIG_VERSION)
     collect_weights(**vars(args))
 

--- a/ludwig/experiment.py
+++ b/ludwig/experiment.py
@@ -37,7 +37,6 @@ from ludwig.utils.print_utils import print_ludwig
 
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 def experiment(
@@ -461,7 +460,9 @@ def cli(sys_argv):
 
     args = parser.parse_args(sys_argv)
 
-    logger.setLevel(logging_level_registry[args.logging_level])
+    logging.getLogger('ludwig').setLevel(
+        logging_level_registry[args.logging_level]
+    )
 
     set_on_master(args.use_horovod)
 

--- a/ludwig/features/sequence_feature.py
+++ b/ludwig/features/sequence_feature.py
@@ -147,7 +147,7 @@ class SequenceInputFeature(SequenceBaseFeature, InputFeature):
             **kwargs
     ):
         placeholder = self._get_input_placeholder()
-        logging.debug('  placeholder: {0}'.format(placeholder))
+        logger.debug('  placeholder: {0}'.format(placeholder))
 
         return self.build_sequence_input(
             placeholder,
@@ -171,7 +171,7 @@ class SequenceInputFeature(SequenceBaseFeature, InputFeature):
             dropout_rate=dropout_rate,
             is_training=is_training
         )
-        logging.debug('  feature_representation: {0}'.format(
+        logger.debug('  feature_representation: {0}'.format(
             feature_representation))
 
         feature_representation = {

--- a/ludwig/predict.py
+++ b/ludwig/predict.py
@@ -360,7 +360,9 @@ def cli(sys_argv):
     args = parser.parse_args(sys_argv)
     args.evaluate_performance = False
 
-    logger.setLevel(logging_level_registry[args.logging_level])
+    logging.getLogger('ludwig').setLevel(
+        logging_level_registry[args.logging_level]
+    )
     set_on_master(args.use_horovod)
 
     if is_on_master():

--- a/ludwig/test_performance.py
+++ b/ludwig/test_performance.py
@@ -153,7 +153,9 @@ def cli(sys_argv):
     args = parser.parse_args(sys_argv)
     args.evaluate_performance = True
 
-    logger.setLevel(logging_level_registry[args.logging_level])
+    logging.getLogger('ludwig').setLevel(
+        logging_level_registry[args.logging_level]
+    )
     set_on_master(args.use_horovod)
 
     if is_on_master():

--- a/ludwig/train.py
+++ b/ludwig/train.py
@@ -755,7 +755,9 @@ def cli(sys_argv):
 
     args = parser.parse_args(sys_argv)
 
-    logger.setLevel(logging_level_registry[args.logging_level])
+    logging.getLogger('ludwig').setLevel(
+        logging_level_registry[args.logging_level]
+    )
     set_on_master(args.use_horovod)
 
     if is_on_master():

--- a/ludwig/visualize.py
+++ b/ludwig/visualize.py
@@ -584,24 +584,24 @@ def compare_classifiers_multiclass_multimetric(
                     filename=filename
                 )
 
-                logging.info('\n')
-                logging.info(model_name_name)
+                logger.info('\n')
+                logger.info(model_name_name)
                 tmp_str = '{0} best 5 classes: '.format(field)
                 tmp_str += '{}'
-                logging.info(tmp_str.format(higher_f1s))
-                logging.info(f1_np[higher_f1s])
+                logger.info(tmp_str.format(higher_f1s))
+                logger.info(f1_np[higher_f1s])
                 tmp_str = '{0} worst 5 classes: '.format(field)
                 tmp_str += '{}'
-                logging.info(tmp_str.format(lower_f1s))
-                logging.info(f1_np[lower_f1s])
+                logger.info(tmp_str.format(lower_f1s))
+                logger.info(f1_np[lower_f1s])
                 tmp_str = '{0} number of classes with f1 score > 0: '.format(
                     field)
                 tmp_str += '{}'
-                logging.info(tmp_str.format(np.sum(f1_np > 0)))
+                logger.info(tmp_str.format(np.sum(f1_np > 0)))
                 tmp_str = '{0} number of classes with f1 score = 0: '.format(
                     field)
                 tmp_str += '{}'
-                logging.info(tmp_str.format(np.sum(f1_np == 0)))
+                logger.info(tmp_str.format(np.sum(f1_np == 0)))
 
 
 def compare_classifiers_predictions(

--- a/ludwig/visualize.py
+++ b/ludwig/visualize.py
@@ -37,6 +37,7 @@ from ludwig.utils.print_utils import logging_level_registry
 
 logger = logging.getLogger(__name__)
 
+
 def learning_curves(
         training_statistics,
         field,
@@ -2184,7 +2185,9 @@ def cli(sys_argv):
     )
 
     args = parser.parse_args(sys_argv)
-    logger.setLevel(logging_level_registry[args.logging_level])
+    logging.getLogger('ludwig').setLevel(
+        logging_level_registry[args.logging_level]
+    )
 
     if args.visualization == 'compare_performance':
         compare_performance(**vars(args))


### PR DESCRIPTION
1. Modifies the logging configuration to top level instead of root level in ludwig/__init__.py
2. User's desired logging level is set at the project level instead of module level


Verified that the user's setting is reflected across the project by trying different levels.
However, I couldn't suppress tensorflow's warning messages. It's probably using tf.logging or something. 
