### PR TITLE
add server to cli

### DIFF
--- a/ludwig/cli.py
+++ b/ludwig/cli.py
@@ -46,6 +46,7 @@ Available sub-commands:
    experiment            Runs a full experiment training a model and testing it
    train                 Trains a model
    predict               Predicts using a pretrained model
+   serve                 Serves a pretrained model
    test                  Tests a pretrained model
    visualize             Visualizes experimental results
    collect_weights       Collects tensors containing a pretrained model weights
@@ -76,6 +77,11 @@ Available sub-commands:
         from ludwig import predict
         ludwig.contrib.contrib_command("predict", *sys.argv)
         predict.cli(sys.argv[2:])
+
+    def serve(self):
+        from ludwig import serve
+        ludwig.contrib.contrib_command("serve", *sys.argv)
+        serve.cli(sys.argv[2:])
 
     def test(self):
         from ludwig import test_performance

--- a/ludwig/serve.py
+++ b/ludwig/serve.py
@@ -44,9 +44,7 @@ COULD_NOT_RUN_INFERENCE_ERROR = {
     "error": "Unexpected Error: could not run inference on model"}
 
 
-def server(
-    model,
-):
+def server(model):
     app = FastAPI()
 
     input_features = {
@@ -95,6 +93,12 @@ def convert_input(form):
             new_input[k] = v
 
     return (files, new_input)
+
+
+def run_server(model_path, host, port):
+    model = LudwigModel.load(model_path)
+    app = server(model)
+    uvicorn.run(app, host=host, port=port)
 
 
 def cli(sys_argv):
@@ -146,9 +150,7 @@ def cli(sys_argv):
         logging_level_registry[args.logging_level]
     )
 
-    model = LudwigModel.load(args.model_path)
-    app = server(model)
-    uvicorn.run(app, host=args.host, port=args.port)
+    run_server(args.model_path, args.host, args.port)
 
 
 if __name__ == '__main__':

--- a/ludwig/serve.py
+++ b/ludwig/serve.py
@@ -57,6 +57,7 @@ def server(
     async def predict(request: Request):
         form = await request.form()
         files, entry = convert_input(form)
+
         try:
             if (entry.keys() & input_features) != input_features:
                 return JSONResponse(ALL_FEATURES_PRESENT_ERROR,

--- a/ludwig/serve.py
+++ b/ludwig/serve.py
@@ -1,0 +1,129 @@
+#! /usr/bin/env python
+# coding=utf-8
+# Copyright (c) 2019 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import argparse
+import logging
+import sys
+
+from ludwig.contrib import contrib_command
+from ludwig.utils.print_utils import logging_level_registry
+import pandas as pd
+import json
+
+from ludwig.api import LudwigModel
+
+
+logger = logging.getLogger(__name__)
+
+
+def start_server(
+    model_path,
+    logging_level,
+    host,
+    port
+):
+    from starlette.applications import Starlette
+    from starlette.responses import JSONResponse
+    import uvicorn
+
+    app = Starlette(debug=True)
+
+    global model
+    model = LudwigModel.load(model_path)
+
+    global input_features
+    input_features = set([
+        f['name'] for f in model.model_definition['input_features']
+    ])
+
+    @app.route('/predict', methods=["POST"])
+    async def endpoint(request):
+        data_json = await request.body()
+        entries = json.loads(data_json)
+
+        for entry in entries:
+            if (entry.keys() & input_features) != input_features:
+                return JSONResponse({"error": "entries must contain all input features"}, status_code=400)
+
+        try:
+            resp = model.predict(data_dict=entries).to_dict('records')
+            return JSONResponse(resp)
+        except Exception as e:
+            logger.error("Error: {}".format(str(e)))
+            return JSONResponse({"error": "Unexpected Error: could not run inference on model"}, status_code=500)
+
+    uvicorn.run(app, host=host, port=port)
+
+
+def cli(sys_argv):
+    parser = argparse.ArgumentParser(
+        description='This script serves a pretrained model',
+        prog='ludwig serve',
+        usage='%(prog)s [options]'
+    )
+
+    # ----------------
+    # Model parameters
+    # ----------------
+    parser.add_argument(
+        '-m',
+        '--model_path',
+        help='model to load',
+        required=True
+    )
+
+    parser.add_argument(
+        '-l',
+        '--logging_level',
+        default='info',
+        help='the level of logging to use',
+        choices=['critical', 'error', 'warning', 'info', 'debug', 'notset']
+    )
+
+    # ----------------
+    # Server parameters
+    # ----------------
+    parser.add_argument(
+        '-p',
+        '--port',
+        help='port for server',
+        default=8000,
+        type=int,
+    )
+
+    parser.add_argument(
+        '-H',
+        '--host',
+        help='host for server',
+        default='0.0.0.0'
+    )
+
+    args = parser.parse_args(sys_argv)
+
+    logging.getLogger('ludwig').setLevel(
+        logging_level_registry[args.logging_level]
+    )
+
+    start_server(**vars(args))
+
+
+if __name__ == '__main__':
+    contrib_command("serve", *sys.argv)
+    cli(sys.argv[1:])

--- a/ludwig/serve.py
+++ b/ludwig/serve.py
@@ -128,7 +128,7 @@ def cli(sys_argv):
     parser.add_argument(
         '-p',
         '--port',
-        help='port for server',
+        help='port for server (default: 8000)',
         default=8000,
         type=int,
     )
@@ -136,7 +136,7 @@ def cli(sys_argv):
     parser.add_argument(
         '-H',
         '--host',
-        help='host for server',
+        help='host for server (default: 0.0.0.0)',
         default='0.0.0.0'
     )
 

--- a/ludwig/serve.py
+++ b/ludwig/serve.py
@@ -24,7 +24,6 @@ import sys
 
 from ludwig.contrib import contrib_command
 from ludwig.utils.print_utils import logging_level_registry
-import pandas as pd
 import json
 
 from ludwig.api import LudwigModel
@@ -49,9 +48,9 @@ def start_server(
     model = LudwigModel.load(model_path)
 
     global input_features
-    input_features = set([
+    input_features = {
         f['name'] for f in model.model_definition['input_features']
-    ])
+    }
 
     @app.route('/predict', methods=["POST"])
     async def endpoint(request):
@@ -60,14 +59,16 @@ def start_server(
 
         for entry in entries:
             if (entry.keys() & input_features) != input_features:
-                return JSONResponse({"error": "entries must contain all input features"}, status_code=400)
+                return JSONResponse({"error": "entries must contain all input features"},
+                                    status_code=400)
 
         try:
             resp = model.predict(data_dict=entries).to_dict('records')
             return JSONResponse(resp)
         except Exception as e:
             logger.error("Error: {}".format(str(e)))
-            return JSONResponse({"error": "Unexpected Error: could not run inference on model"}, status_code=500)
+            return JSONResponse({"error": "Unexpected Error: could not run inference on model"},
+                                status_code=500)
 
     uvicorn.run(app, host=host, port=port)
 

--- a/ludwig/serve.py
+++ b/ludwig/serve.py
@@ -38,11 +38,13 @@ def start_server(
     host,
     port
 ):
-    from starlette.applications import Starlette
+
+    from fastapi import FastAPI
+    from starlette.requests import Request
     from starlette.responses import JSONResponse
     import uvicorn
 
-    app = Starlette(debug=True)
+    app = FastAPI()
 
     global model
     model = LudwigModel.load(model_path)
@@ -52,8 +54,8 @@ def start_server(
         f['name'] for f in model.model_definition['input_features']
     }
 
-    @app.route('/predict', methods=["POST"])
-    async def endpoint(request):
+    @app.post('/predict')
+    async def predict(request: Request):
         data_json = await request.body()
         entries = json.loads(data_json)
 

--- a/mkdocs/docs/user_guide.md
+++ b/mkdocs/docs/user_guide.md
@@ -560,6 +560,58 @@ In order to figure out the names fo the tensors containing the weights you want 
 tensorboard --logdir /path/to/model/log
 ```
 
+
+
+serve
+---------------
+
+This command lets you load a pre-trained model and serve it on an http server.
+
+You can call it with:
+
+```
+ludwig serve [options]
+```
+
+or with
+
+```
+python -m ludwig.serve [options]
+```
+
+from within Ludwig's main directory.
+
+These are the available arguments:
+```
+usage: ludwig serve [options]
+
+This script serves a pretrained model
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -m MODEL_PATH, --model_path MODEL_PATH
+                        model to load
+  -l {critical,error,warning,info,debug,notset}, --logging_level {critical,error,warning,info,debug,notset}
+                        the level of logging to use
+  -p PORT, --port PORT  port for server (default: 8000)
+  -H HOST, --host HOST  host for server (default: 0.0.0.0)
+```
+
+The most important argument is `--model_path` where you have to specify the path of the model to load. 
+
+Once running, you can make a POST request on the `/predict` endpoint to run inference on the form data submitted. 
+
+#### Example curl
+##### File
+`curl http://0.0.0.0:8000/predict -X POST -F 'image_path=@path_to_image/example.png'`
+
+##### Text
+`curl http://0.0.0.0:8000/predict -X POST -F 'english_text=words to be translated'`
+
+##### Both Text and File
+`curl http://0.0.0.0:8000/predict -X POST -F 'text=mixed together with' -F 'image=@path_to_image/example.png'`
+
+
 collect_activations
 -------------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ tabulate>=0.7
 tensorflow==1.13.1
 PyYAML>=3.12
 pytest
-starlette
+fastapi
+pydantic
 uvicorn
 python-multipart

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,6 @@ tabulate>=0.7
 tensorflow==1.13.1
 PyYAML>=3.12
 pytest
+starlette
+uvicorn
+python-multipart

--- a/tests/integration_tests/test_server.py
+++ b/tests/integration_tests/test_server.py
@@ -1,0 +1,149 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2019 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import shutil
+
+from ludwig.api import LudwigModel
+from ludwig.utils.data_utils import read_csv
+from tests.integration_tests.utils import ENCODERS
+from tests.integration_tests.utils import image_feature
+from tests.integration_tests.utils import text_feature
+from tests.integration_tests.utils import categorical_feature
+from tests.integration_tests.utils import numerical_feature
+from tests.integration_tests.utils import generate_data
+from tests.integration_tests.utils import sequence_feature
+from tests.integration_tests.utils import random_string
+
+
+# The following imports are pytest fixtures, required for running the tests
+from tests.fixtures.filenames import csv_filename
+from ludwig.serve import server, ALL_FEATURES_PRESENT_ERROR
+from starlette.testclient import TestClient
+import os
+
+
+def train_model(input_features, output_features, data_csv):
+    """
+    Helper method to avoid code repetition in running an experiment
+    :param input_features: input schema
+    :param output_features: output schema
+    :param data_csv: path to data
+    :return: None
+    """
+    model_definition = {
+        'input_features': input_features,
+        'output_features': output_features,
+        'combiner': {'type': 'concat', 'fc_size': 14},
+        'training': {'epochs': 2}
+    }
+
+    model = LudwigModel(model_definition)
+
+    # Training with csv
+    model.train(
+        data_csv=data_csv,
+        skip_save_processed_input=True,
+        skip_save_progress=True,
+        skip_save_unprocessed_output=True
+    )
+
+    model.predict(data_csv=data_csv)
+
+    # Remove results/intermediate data saved to disk
+    shutil.rmtree(model.exp_dir_name, ignore_errors=True)
+
+    # Training with dataframe
+    data_df = read_csv(data_csv)
+    model.train(
+        data_df=data_df,
+        skip_save_processed_input=True,
+        skip_save_progress=True,
+        skip_save_unprocessed_output=True
+    )
+    model.predict(data_df=data_df)
+    return model
+
+
+def example_input(input_features):
+    data = {}
+    for i in input_features:
+        name = i['name']
+        if i['type'] in ['image', 'video', 'audio']:
+            data[name] = random_string()
+        else:
+            data[name] = random_string()
+    return data
+
+
+def output_keys_for(output_features):
+    keys = []
+    for f in output_features:
+        name = f['name']
+        if f['type'] == 'category':
+            keys.append("{}_predictions".format(name))
+            keys.append("{}_probability".format(name))
+            keys.append("{}_probabilities_<UNK>".format(name))
+            for category in f['idx2str']:
+                keys.append(
+                    "{}_probabilities_{}".format(name, category))
+
+        elif f['type'] == 'numerical':
+            keys.append("{}_predictions".format(name))
+        else:
+            raise NotImplementedError
+    return keys
+
+
+def test_server_integration(csv_filename):
+     # Image Inputs
+    image_dest_folder = os.path.join(os.getcwd(), 'generated_images')
+
+    # Resnet encoder
+    input_features = [
+        image_feature(
+            folder=image_dest_folder,
+            encoder='resnet',
+            preprocessing={
+                'in_memory': True,
+                'height': 8,
+                'width': 8,
+                'num_channels': 3
+            },
+            fc_size=16,
+            num_filters=8
+        ),
+        text_feature(encoder='embed', min_len=1),
+        numerical_feature(normalization='zscore')
+    ]
+    output_features = [
+        categorical_feature(vocab_size=2, reduce_input='sum'),
+        numerical_feature()
+    ]
+
+    rel_path = generate_data(input_features, output_features, csv_filename)
+    model = train_model(input_features, output_features, data_csv=rel_path)
+
+    app = server(model)
+    client = TestClient(app)
+    response = client.post('/predict')
+    assert response.json() == ALL_FEATURES_PRESENT_ERROR
+
+    data_df = read_csv(rel_path)
+    response = client.post('/predict', data=data_df.T.to_dict()[0])
+    response_keys = sorted(list(response.json().keys()))
+    assert response_keys == sorted(output_keys_for(output_features))
+
+    shutil.rmtree(model.exp_dir_name, ignore_errors=True)

--- a/tests/integration_tests/test_server.py
+++ b/tests/integration_tests/test_server.py
@@ -161,3 +161,4 @@ def test_server_integration(csv_filename):
     assert response_keys == sorted(output_keys_for(output_features))
 
     shutil.rmtree(model.exp_dir_name, ignore_errors=True)
+    shutil.rmtree(image_dest_folder)

--- a/tests/integration_tests/test_server.py
+++ b/tests/integration_tests/test_server.py
@@ -78,30 +78,19 @@ def train_model(input_features, output_features, data_csv):
     return model
 
 
-def example_input(input_features):
-    data = {}
-    for i in input_features:
-        name = i['name']
-        if i['type'] in ['image', 'video', 'audio']:
-            data[name] = random_string()
-        else:
-            data[name] = random_string()
-    return data
-
-
 def output_keys_for(output_features):
     keys = []
-    for f in output_features:
-        name = f['name']
-        if f['type'] == 'category':
+    for feature in output_features:
+        name = feature['name']
+        if feature['type'] == 'category':
             keys.append("{}_predictions".format(name))
             keys.append("{}_probability".format(name))
             keys.append("{}_probabilities_<UNK>".format(name))
-            for category in f['idx2str']:
+            for category in feature['idx2str']:
                 keys.append(
                     "{}_probabilities_{}".format(name, category))
 
-        elif f['type'] == 'numerical':
+        elif feature['type'] == 'numerical':
             keys.append("{}_predictions".format(name))
         else:
             raise NotImplementedError
@@ -113,7 +102,9 @@ def convert_to_form(entry):
     files = []
     for k, v in entry.items():
         if type(v) == str and os.path.exists(v):
-            files.append((k, (v, open(v, 'rb'), 'image/jpeg')))
+            file = open(v, 'rb')
+            files.append((k, (v, file.read(), 'image/jpeg')))
+            file.close()
         else:
             data[k] = v
     return data, files

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -51,22 +51,22 @@ def generate_data(
     return filename
 
 
-def random_name(length=5):
+def random_string(length=5):
     return uuid.uuid4().hex[:length].upper()
 
 
 def numerical_feature(normalization=None):
-    return {'name': 'num_' + random_name(), 'type': 'numerical',
+    return {'name': 'num_' + random_string(), 'type': 'numerical',
             'preprocessing': {
                 'normalization': normalization
-            }
+    }
     }
 
 
 def categorical_feature(**kwargs):
     cat_feature = {
         'type': 'category',
-        'name': 'category_' + random_name(),
+        'name': 'category_' + random_string(),
         'vocab_size': 10,
         'embedding_size': 5
     }
@@ -77,7 +77,7 @@ def categorical_feature(**kwargs):
 
 def text_feature(**kwargs):
     feature = {
-        'name': 'text_' + random_name(),
+        'name': 'text_' + random_string(),
         'type': 'text',
         'reduce_input': 'null',
         'vocab_size': 5,
@@ -93,7 +93,7 @@ def text_feature(**kwargs):
 def set_feature(**kwargs):
     feature = {
         'type': 'set',
-        'name': 'set_' + random_name(),
+        'name': 'set_' + random_string(),
         'vocab_size': 10,
         'max_len': 5,
         'embedding_size': 5
@@ -105,7 +105,7 @@ def set_feature(**kwargs):
 def sequence_feature(**kwargs):
     seq_feature = {
         'type': 'sequence',
-        'name': 'sequence_' + random_name(),
+        'name': 'sequence_' + random_string(),
         'vocab_size': 10,
         'max_len': 7,
         'encoder': 'embed',
@@ -121,7 +121,7 @@ def sequence_feature(**kwargs):
 def image_feature(folder, **kwargs):
     img_feature = {
         'type': 'image',
-        'name': 'image_' + random_name(),
+        'name': 'image_' + random_string(),
         'encoder': 'resnet',
         'preprocessing': {
             'in_memory': True,
@@ -140,7 +140,7 @@ def image_feature(folder, **kwargs):
 
 def timeseries_feature(**kwargs):
     ts_feature = {
-        'name': 'timeseries_' + random_name(),
+        'name': 'timeseries_' + random_string(),
         'type': 'timeseries',
         'max_len': 7
     }
@@ -150,14 +150,14 @@ def timeseries_feature(**kwargs):
 
 def binary_feature():
     return {
-        'name': 'binary_' + random_name(),
+        'name': 'binary_' + random_string(),
         'type': 'binary'
     }
 
 
 def bag_feature(**kwargs):
     feature = {
-        'name': 'bag_' + random_name(),
+        'name': 'bag_' + random_string(),
         'type': 'bag',
         'max_len': 5,
         'vocab_size': 10,

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -56,10 +56,12 @@ def random_string(length=5):
 
 
 def numerical_feature(normalization=None):
-    return {'name': 'num_' + random_string(), 'type': 'numerical',
-            'preprocessing': {
-                'normalization': normalization
-    }
+    return {
+        'name': 'num_' + random_string(),
+        'type': 'numerical',
+        'preprocessing': {
+            'normalization': normalization
+        }
     }
 
 


### PR DESCRIPTION
# Code Pull Requests
This code adds an inference server to models trained by ludwig. https://github.com/uber/ludwig/issues/87
`ludwig serve --model_path path/to/model --port 8000 --host 0.0.0.0`
` curl http://localhost:8000/predict -X POST -d "[{\"text\": \"test\"}]"`
I went with Starlette over something like Flask because it has a more modern API that supports async await which will come in handy for file uploads later. 
Still haven't implemented image inference. Want to get some feedback on the approach before moving forward with that. 
Could either do multipart form uploads or base64 encoding in the request body. I imagine the latter would be more costly but form uploads are generally a worse API for inference on tabular data and NLP. 

# Documentation Pull Requests
Will do after settling on an approach.
<!--
Note that the documentation HTML files are in `docs/` while the Markdown sources are in `mkdocs/docs`.

If you are proposing a modification to the documentation you should change only the Markdown files, then recreate the documentation as explained in the `mkdocs/README.md` file with `mkdocs build`, which will create the HTML files automatically, and only after this create a commit.

`api.md` is automatically generated from the docstrings in the code, so if you want to change something in that file, first modify `ludwig/api.py` docstring, then run `mkdocs/code_docs_autogen.py`, which will create `mkdocs/docs/api.md` and then finally run `mkdocs build` which will generate the HTML in `docs/`.
-=>