### PR TITLE
fix(docker): missing dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM tensorflow/tensorflow:latest-py3
 
 RUN apt-get install -y --no-install-recommends \
-        git
+        git libgmp3-dev
 RUN git clone --depth=1 https://github.com/uber/ludwig.git \
     && cd ludwig/ \
     && pip install -r requirements.txt \


### PR DESCRIPTION
Add missing libgmp3-dev when building on OSX

When building on OSX with `docker build . -t ludwig` i had this error. this fix adds the necessary `libgmp3-dev` to the docker container.

```sh
  Running setup.py install for gmpy: started
    Running setup.py install for gmpy: finished with status 'error'
    ERROR: Complete output from command /usr/bin/python3 -u -c 'import setuptools, tokenize;__file__='"'"'/tmp/pip-install-vlfrjt08/gmpy/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-8lu49ntg/install-record.txt --single-version-externally-managed --compile:
    ERROR: running install
    running build
    running build_ext
    building 'gmpy' extension
    creating build
    creating build/temp.linux-x86_64-3.6
    creating build/temp.linux-x86_64-3.6/src
    x86_64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -I./src -I/usr/include/python3.6m -c src/gmpy.c -o build/temp.linux-x86_64-3.6/src/gmpy.o
    In file included from src/gmpy.c:251:0:
    src/gmpy.h:30:10: fatal error: gmp.h: No such file or directory
     #include "gmp.h"
              ^~~~~~~
    compilation terminated.
    error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
    ----------------------------------------
ERROR: Command "/usr/bin/python3 -u -c 'import setuptools, tokenize;__file__='"'"'/tmp/pip-install-vlfrjt08/gmpy/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-8lu49ntg/install-record.txt --single-version-externally-managed --compile" failed with error code 1 in /tmp/pip-install-vlfrjt08/gmpy/
The command '/bin/sh -c git clone --depth=1 https://github.com/uber/ludwig.git     && cd ludwig/     && pip install -r requirements.txt     && python -m spacy download en     && python setup.py install' returned a non-zero code: 1
```