### PR TITLE
pin pydantic version to match fastapi requirement to fix Docker build error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,6 @@ PyYAML>=3.12
 pytest
 gmpy
 fastapi
-pydantic
+pydantic==0.30.0
 uvicorn
 python-multipart


### PR DESCRIPTION
# Code Pull Requests

Please provide the following:
- revise requirements.txt to pin pydantic to 0.30.0 
- Fix #437 
