### PR TITLE
Missing .format placeholder in train logger output

### DIFF
--- a/ludwig/train.py
+++ b/ludwig/train.py
@@ -339,7 +339,7 @@ def full_train(
             key=lambda pair: pair[1]
         )
         logger.info(
-            'Best validation model epoch:'.format(epoch_best_vali_measure+1)
+            'Best validation model epoch: {0}'.format(epoch_best_vali_measure+1)
         )
         logger.info(
            'Best validation model {0} on validation set {1}: {2}'.format(


### PR DESCRIPTION
Was not outputting best validation model epoch number due to missing {0} placeholder