### PR TITLE
fixed AttributeError: 'Model' object has no attribute 'model'

### DIFF
--- a/ludwig/models/model.py
+++ b/ludwig/models/model.py
@@ -1362,7 +1362,7 @@ class Model:
                     input_tensors, output_tensors)
             },
             strip_default_attrs=True,
-            saver=self.model.saver,
+            saver=self.saver,
         )
         builder.save()
 


### PR DESCRIPTION
# Code Pull Requests

Please provide the following:

- a clear explanation of what your code dose - it fixes the AttributeError: 'Model' object has no attribute 'model'
- if applicable, a reference to an issue - no reported issue
- a reproducible test for your PR (code, model definition and data sample) - ludwig_model.save_for_serving(path) fails with an error mentioned above

# Documentation Pull Requests

Note that the documentation HTML files are in `docs/` while the Markdown sources are in `mkdocs/docs`.

If you are proposing a modification to the documentation you should change only the Markdown files, then recreate the documentation as explained in the `mkdocs/README.md` file with `mkdocs build`, which will create the HTML files automatically, and only after this create a commit.

`api.md` is automatically generated from the docstrings in the code, so if you want to change something in that file, first modify `ludwig/api.py` docstring, then run `mkdocs/code_docs_autogen.py`, which will create `mkdocs/docs/api.md` and then finally run `mkdocs build` which will generate the HTML in `docs/`.
