### PR TITLE
Refactors the code that uses set_default_value for features

### DIFF
--- a/ludwig/features/audio_feature.py
+++ b/ludwig/features/audio_feature.py
@@ -34,6 +34,7 @@ from ludwig.utils.audio_utils import get_phase_stft_magnitude
 from ludwig.utils.audio_utils import get_stft_magnitude
 from ludwig.utils.data_utils import get_abs_path
 from ludwig.utils.misc import set_default_value
+from ludwig.utils.misc import set_default_values
 
 logger = logging.getLogger(__name__)
 
@@ -359,5 +360,10 @@ class AudioInputFeature(AudioBaseFeature, SequenceInputFeature):
 
     @staticmethod
     def populate_defaults(input_feature):
-        set_default_value(input_feature, 'tied_weights', None)
-        set_default_value(input_feature, 'preprocessing', {})
+        set_default_values(
+            input_feature,
+            {
+                'tied_weights': None,
+                'preprocessing': {}
+            }
+        )

--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -34,6 +34,7 @@ from ludwig.utils.metrics_utils import precision_recall_curve
 from ludwig.utils.metrics_utils import roc_auc_score
 from ludwig.utils.metrics_utils import roc_curve
 from ludwig.utils.misc import set_default_value
+from ludwig.utils.misc import set_default_values
 
 logger = logging.getLogger(__name__)
 
@@ -414,7 +415,12 @@ class BinaryOutputFeature(BinaryBaseFeature, OutputFeature):
                 'weight': 1
             }
         )
-        set_default_value(output_feature, 'threshold', 0.5)
-        set_default_value(output_feature, 'dependencies', [])
-        set_default_value(output_feature, 'reduce_input', SUM)
-        set_default_value(output_feature, 'reduce_dependencies', SUM)
+        set_default_values(
+            output_feature,
+            {
+                'threshold': 0.5,
+                'dependencies': [],
+                'reduce_input': SUM,
+                'reduce_dependencies': SUM
+            }
+        )

--- a/ludwig/features/category_feature.py
+++ b/ludwig/features/category_feature.py
@@ -36,6 +36,7 @@ from ludwig.utils.math_utils import int_type
 from ludwig.utils.math_utils import softmax
 from ludwig.utils.metrics_utils import ConfusionMatrix
 from ludwig.utils.misc import set_default_value
+from ludwig.utils.misc import set_default_values
 from ludwig.utils.strings_utils import UNKNOWN_SYMBOL
 from ludwig.utils.strings_utils import create_vocabulary
 
@@ -663,9 +664,12 @@ class CategoryOutputFeature(CategoryBaseFeature, OutputFeature):
 
     @staticmethod
     def populate_defaults(output_feature):
-        set_default_value(
-            output_feature,
-            LOSS,
+        # If Loss is not defined, set an empty dictionary
+        set_default_value(output_feature, LOSS, {})
+
+        # Populate the default values for LOSS if they aren't defined already
+        set_default_values(
+            output_feature[LOSS],
             {
                 'type': 'softmax_cross_entropy',
                 'sampler': None,
@@ -680,27 +684,32 @@ class CategoryOutputFeature(CategoryBaseFeature, OutputFeature):
                 'weight': 1
             }
         )
-        set_default_value(output_feature[LOSS], 'type', 'softmax_cross_entropy')
 
         if output_feature[LOSS]['type'] == 'sampled_softmax_cross_entropy':
-            set_default_value(output_feature[LOSS], 'sampler', 'log_uniform')
-            set_default_value(output_feature[LOSS], 'negative_samples', 25)
-            set_default_value(output_feature[LOSS], 'distortion', 0.75)
+            set_default_values(
+                output_feature[LOSS],
+                {
+                    'sampler': 'log_uniform',
+                    'negative_samples': 25,
+                    'distortion': 0.75
+                }
+            )
         else:
-            set_default_value(output_feature[LOSS], 'sampler', None)
-            set_default_value(output_feature[LOSS], 'negative_samples', 0)
-            set_default_value(output_feature[LOSS], 'distortion', 1)
+            set_default_values(
+                output_feature[LOSS],
+                {
+                    'sampler': None,
+                    'negative_samples': 0,
+                    'distortion': 1
+                }
+            )
 
-        set_default_value(output_feature[LOSS], 'unique', False)
-        set_default_value(output_feature[LOSS], 'labels_smoothing', 0)
-        set_default_value(output_feature[LOSS], 'class_weights', 1)
-        set_default_value(output_feature[LOSS], 'robust_lambda', 0)
-        set_default_value(output_feature[LOSS], 'confidence_penalty', 0)
-        set_default_value(output_feature[LOSS],
-                          'class_similarities_temperature', 0)
-        set_default_value(output_feature[LOSS], 'weight', 1)
-
-        set_default_value(output_feature, 'top_k', 3)
-        set_default_value(output_feature, 'dependencies', [])
-        set_default_value(output_feature, 'reduce_input', SUM)
-        set_default_value(output_feature, 'reduce_dependencies', SUM)
+        set_default_values(
+            output_feature,
+            {
+                'top_k': 3,
+                'dependencies': [],
+                'reduce_input': SUM,
+                'reduce_dependencies': SUM
+            }
+        )

--- a/ludwig/features/numerical_feature.py
+++ b/ludwig/features/numerical_feature.py
@@ -35,6 +35,7 @@ from ludwig.models.modules.measure_modules import r2 as get_r2
 from ludwig.models.modules.measure_modules import \
     squared_error as get_squared_error
 from ludwig.utils.misc import set_default_value
+from ludwig.utils.misc import set_default_values
 
 
 logger = logging.getLogger(__name__)
@@ -436,7 +437,13 @@ class NumericalOutputFeature(NumericalBaseFeature, OutputFeature):
         )
         set_default_value(output_feature[LOSS], 'type', 'mean_squared_error')
         set_default_value(output_feature[LOSS], 'weight', 1)
-        set_default_value(output_feature, 'clip', None)
-        set_default_value(output_feature, 'dependencies', [])
-        set_default_value(output_feature, 'reduce_input', SUM)
-        set_default_value(output_feature, 'reduce_dependencies', SUM)
+
+        set_default_values(
+            output_feature,
+            {
+                'clip': None,
+                'dependencies': [],
+                'reduce_input': SUM,
+                'reduce_dependencies': SUM
+            }
+        )

--- a/ludwig/features/text_feature.py
+++ b/ludwig/features/text_feature.py
@@ -28,6 +28,7 @@ from ludwig.features.sequence_feature import SequenceOutputFeature
 from ludwig.utils.math_utils import softmax
 from ludwig.utils.metrics_utils import ConfusionMatrix
 from ludwig.utils.misc import set_default_value
+from ludwig.utils.misc import set_default_values
 from ludwig.utils.strings_utils import PADDING_SYMBOL
 from ludwig.utils.strings_utils import UNKNOWN_SYMBOL
 from ludwig.utils.strings_utils import build_sequence_matrix
@@ -235,9 +236,14 @@ class TextInputFeature(TextBaseFeature, SequenceInputFeature):
 
     @staticmethod
     def populate_defaults(input_feature):
-        set_default_value(input_feature, 'tied_weights', None)
-        set_default_value(input_feature, 'encoder', 'parallel_cnn')
-        set_default_value(input_feature, 'level', 'word')
+        set_default_values(
+            input_feature,
+            {
+                'tied_weights': None,
+                'encoder': 'parallel_cnn',
+                'level': 'word'
+            }
+        )
 
 
 class TextOutputFeature(TextBaseFeature, SequenceOutputFeature):
@@ -494,9 +500,12 @@ class TextOutputFeature(TextBaseFeature, SequenceOutputFeature):
     def populate_defaults(output_feature):
         set_default_value(output_feature, 'level', 'word')
 
-        set_default_value(
-            output_feature,
-            LOSS,
+        # If Loss is not defined, set an empty dictionary
+        set_default_value(output_feature, LOSS, {})
+
+        # Populate the default values for LOSS if they aren't defined already
+        set_default_values(
+            output_feature[LOSS],
             {
                 'type': 'softmax_cross_entropy',
                 'sampler': None,
@@ -510,32 +519,37 @@ class TextOutputFeature(TextBaseFeature, SequenceOutputFeature):
                 'weight': 1
             }
         )
-        set_default_value(output_feature[LOSS], 'type', 'softmax_cross_entropy')
-        set_default_value(output_feature[LOSS], 'labels_smoothing', 0)
-        set_default_value(output_feature[LOSS], 'class_weights', 1)
-        set_default_value(output_feature[LOSS], 'robust_lambda', 0)
-        set_default_value(output_feature[LOSS], 'confidence_penalty', 0)
-        set_default_value(output_feature[LOSS],
-                          'class_similarities_temperature', 0)
-        set_default_value(output_feature[LOSS], 'weight', 1)
-        set_default_value(output_feature[LOSS], 'type', 'softmax_cross_entropy')
 
         if output_feature[LOSS]['type'] == 'sampled_softmax_cross_entropy':
-            set_default_value(output_feature[LOSS], 'sampler', 'log_uniform')
-            set_default_value(output_feature[LOSS], 'negative_samples', 25)
-            set_default_value(output_feature[LOSS], 'distortion', 0.75)
+            set_default_values(
+                output_feature[LOSS],
+                {
+                    'sampler': 'log_uniform',
+                    'negative_samples': 25,
+                    'distortion': 0.75
+                }
+            )
         else:
-            set_default_value(output_feature[LOSS], 'sampler', None)
-            set_default_value(output_feature[LOSS], 'negative_samples', 0)
-            set_default_value(output_feature[LOSS], 'distortion', 1)
+            set_default_values(
+                output_feature[LOSS],
+                {
+                    'sampler': None,
+                    'negative_samples': 0,
+                    'distortion': 1
+                }
+            )
 
         set_default_value(output_feature[LOSS], 'unique', False)
-
         set_default_value(output_feature, 'decoder', 'generator')
 
         if output_feature['decoder'] == 'tagger':
             set_default_value(output_feature, 'reduce_input', None)
 
-        set_default_value(output_feature, 'dependencies', [])
-        set_default_value(output_feature, 'reduce_input', SUM)
-        set_default_value(output_feature, 'reduce_dependencies', SUM)
+        set_default_values(
+            output_feature,
+            {
+                'dependencies': [],
+                'reduce_input': SUM,
+                'reduce_dependencies': SUM
+            }
+        )

--- a/ludwig/utils/misc.py
+++ b/ludwig/utils/misc.py
@@ -137,3 +137,9 @@ def get_from_registry(key, registry):
 def set_default_value(dictionary, key, value):
     if key not in dictionary:
         dictionary[key] = value
+
+
+def set_default_values(dictionary, default_value_dictionary):
+    # Set multiple default values
+    for key, value in default_value_dictionary.items():
+        set_default_value(dictionary, key, value)


### PR DESCRIPTION
All the feature modules are using set_default_value to populate default values. But the code is repetitive and confusing. I tried to address this by defining a method set_default_values, which basically repeats set_default_value for each key, value pair in a dictionary. 

One area where I was confused: 
for category_feature, we do these two steps: 
```code
        set_default_value(
            output_feature,
            LOSS,
            {
                'type': 'softmax_cross_entropy',
                'sampler': None,
                'negative_samples': 0,
                'distortion': 1,
                'unique': False,
                'labels_smoothing': 0,
                'class_weights': 1,
                'robust_lambda': 0,
                'confidence_penalty': 0,
                'class_similarities_temperature': 0,
                'weight': 1
            }
        )
```

and then
```code
        set_default_value(output_feature[LOSS], 'unique', False)
        set_default_value(output_feature[LOSS], 'labels_smoothing', 0)
        set_default_value(output_feature[LOSS], 'class_weights', 1)
        set_default_value(output_feature[LOSS], 'robust_lambda', 0)
        set_default_value(output_feature[LOSS], 'confidence_penalty', 0)
        set_default_value(output_feature[LOSS],
                          'class_similarities_temperature', 0)
        set_default_value(output_feature[LOSS], 'weight', 1)

```
Now this logic is only clear if you understand that the first step does nothing if output_feature already has a LOSS value defined. I replaced this with
```code
set_default_value(output_feature, LOSS, {})
set_default_values(output_feature[LOSS], {...})
```

I'll also write unit tests to make sure that the defaults are populated as expected for each feature. That would help us understand what's the expectation around default values for each feature.