### PR TITLE
Preprocessing with strategy pattern

### DIFF
--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -472,15 +472,15 @@ def preprocess_for_training_strategy_pattern(
                     validation_set,
                     train_set_metadata
                 ) = _preprocess_csv_for_training(
-                    features,
-                    all_data_fp,
-                    None,
-                    None,
-                    None,
-                    train_set_metadata_json,
-                    skip_save_processed_input,
-                    preprocessing_params,
-                    random_seed
+                    features=features,
+                    data_csv=all_data_fp,
+                    data_train_csv=None,
+                    data_validation_csv=None,
+                    data_test_csv=None,
+                    train_set_metadata_json=train_set_metadata_json,
+                    skip_save_processed_input=skip_save_processed_input,
+                    preprocessing_params=preprocessing_params,
+                    random_seed=random_seed
                 )
         else:
             if (file_exists_in_diff_format(train_fp, 'hdf5') and
@@ -510,19 +510,18 @@ def preprocess_for_training_strategy_pattern(
                    validation_set,
                    train_set_metadata
                 ) = _preprocess_csv_for_training(
-                    features,
-                    None,
-                    train_fp,
-                    validation_fp,
-                    test_fp,
-                    train_set_metadata_json,
-                    skip_save_processed_input,
-                    preprocessing_params,
-                    random_seed
+                    features=features,
+                    data_csv=None,
+                    data_train_csv=train_fp,
+                    data_validation_csv=validation_fp,
+                    data_test_csv=test_fp,
+                    train_set_metadata_json=train_set_metadata_json,
+                    skip_save_processed_input=skip_save_processed_input,
+                    preprocessing_params=preprocessing_params,
+                    random_seed=random_seed
                 )
     else:
         raise RuntimeError('Insufficient input parameters')
-
 
     replace_text_feature_level(
         model_definition['input_features'] +

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -283,6 +283,76 @@ def load_metadata(metadata_file_path):
     return data_utils.load_json(metadata_file_path)
 
 
+def preprocess_for_training(
+        model_definition,
+        data_df=None,
+        data_train_df=None,
+        data_validation_df=None,
+        data_test_df=None,
+        data_csv=None,
+        data_train_csv=None,
+        data_validation_csv=None,
+        data_test_csv=None,
+        data_hdf5=None,
+        data_train_hdf5=None,
+        data_validation_hdf5=None,
+        data_test_hdf5=None,
+        train_set_metadata_json=None,
+        skip_save_processed_input=False,
+        preprocessing_params=default_preprocessing_parameters,
+        random_seed=default_random_seed
+):
+    # Sanity Check to make sure some data source is provided
+    data_sources_provided = [data_df, data_train_df, data_csv, data_train_csv,
+                             data_hdf5, data_train_hdf5]
+    data_sources_not_none = [x is not None for x in data_sources_provided]
+    if not any(data_sources_not_none):
+        raise ValueError('No training data is provided!')
+
+    if data_df is not None or data_train_df is not None:
+        return preprocess_for_tr(
+            model_definition,
+            'pandas',
+            all_data_df=data_df,
+            train_df=data_train_df,
+            validation_df=data_validation_df,
+            test_df=data_test_df,
+            train_set_metadata_json=train_set_metadata_json,
+            skip_save_processed_input=skip_save_processed_input,
+            preprocessing_params=preprocessing_params,
+            random_seed=random_seed
+        )
+    elif data_csv is not None or data_train_csv is not None:
+        return preprocess_for_tr(
+            model_definition,
+            'csv',
+            all_data_fp=data_csv,
+            train_fp=data_train_csv,
+            validation_fp=data_validation_csv,
+            test_fp=data_test_csv,
+            train_set_metadata_json=train_set_metadata_json,
+            skip_save_processed_input=skip_save_processed_input,
+            preprocessing_params=preprocessing_params,
+            random_seed=random_seed
+        )
+    elif data_hdf5 is not None or data_train_hdf5 is not None:
+        return preprocess_for_tr(
+            model_definition,
+            'hdf5',
+            all_data_fp=data_hdf5,
+            train_fp=data_train_hdf5,
+            validation_fp=data_validation_hdf5,
+            test_fp=data_test_hdf5,
+            train_set_metadata_json=train_set_metadata_json,
+            skip_save_processed_input=skip_save_processed_input,
+            preprocessing_params=preprocessing_params,
+            random_seed=random_seed
+        )
+    else:
+        raise ValueError('Invalid type of data provided or Invalid usage of '
+                         'datasets. Please review your command')
+
+
 def preprocess_for_tr(
     model_definition,
     data_type,
@@ -290,6 +360,7 @@ def preprocess_for_tr(
     train_fp=None,
     validation_fp=None,
     test_fp=None,
+    all_data_df=None,
     train_df=None,
     validation_df=None,
     test_df=None,
@@ -298,9 +369,8 @@ def preprocess_for_tr(
     preprocessing_params=default_preprocessing_parameters,
     random_seed=default_random_seed
 ):
-    if all_data_fp is None and train_fp is None:
-        raise ValueError('No training data is provided!')
-    elif all_data_fp is not None and train_fp is not None:
+
+    if all_data_fp is not None and train_fp is not None:
         raise ValueError('Use either one file for all data or 3 files for '
                          'train, test or validation')
 
@@ -321,7 +391,7 @@ def preprocess_for_tr(
             train_set_metadata
         ) = _preprocess_df_for_training(
             features,
-            all_data_fp,
+            all_data_df,
             train_df,
             validation_df,
             test_df,

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -31,10 +31,10 @@ from ludwig.features.feature_registries import base_type_registry
 from ludwig.globals import MODEL_HYPERPARAMETERS_FILE_NAME
 from ludwig.utils import data_utils
 from ludwig.utils.data_utils import collapse_rare_labels
+from ludwig.utils.data_utils import file_exists_with_diff_extension
 from ludwig.utils.data_utils import load_json
 from ludwig.utils.data_utils import read_csv
 from ludwig.utils.data_utils import replace_file_extension
-from ludwig.utils.data_utils import file_exists_in_diff_format
 from ludwig.utils.data_utils import split_dataset_tvt
 from ludwig.utils.data_utils import text_feature_data_field
 from ludwig.utils.defaults import default_preprocessing_parameters
@@ -448,8 +448,8 @@ def preprocess_for_training_strategy_pattern(
         model_definition['data_hdf5_fp'] = data_hdf5_fp
 
         if all_data_fp is not None:
-            if (file_exists_in_diff_format(all_data_fp, 'hdf5') and
-                    file_exists_in_diff_format(all_data_fp, 'json')):
+            if (file_exists_with_diff_extension(all_data_fp, 'hdf5') and
+                    file_exists_with_diff_extension(all_data_fp, 'json')):
                 # use hdf5 data instead
                 logger.info(
                     'Found hdf5 and json with the same filename '
@@ -483,10 +483,10 @@ def preprocess_for_training_strategy_pattern(
                     random_seed=random_seed
                 )
         else:
-            if (file_exists_in_diff_format(train_fp, 'hdf5') and
-                    file_exists_in_diff_format(train_fp, 'json') and
-                    file_exists_in_diff_format(validation_fp, 'hdf5') and
-                    file_exists_in_diff_format(test_fp, 'hdf5')):
+            if (file_exists_with_diff_extension(train_fp, 'hdf5') and
+                    file_exists_with_diff_extension(train_fp, 'json') and
+                    file_exists_with_diff_extension(validation_fp, 'hdf5') and
+                    file_exists_with_diff_extension(test_fp, 'hdf5')):
                 logger.info(
                     'Found hdf5 and json with the same filename '
                     'of the csvs, using them instead.'

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -310,7 +310,7 @@ def preprocess_for_training(
         raise ValueError('No training data is provided!')
 
     if data_df is not None or data_train_df is not None:
-        return preprocess_for_tr(
+        return preprocess_for_training_strategy_pattern(
             model_definition,
             'pandas',
             all_data_df=data_df,
@@ -323,7 +323,7 @@ def preprocess_for_training(
             random_seed=random_seed
         )
     elif data_csv is not None or data_train_csv is not None:
-        return preprocess_for_tr(
+        return preprocess_for_training_strategy_pattern(
             model_definition,
             'csv',
             all_data_fp=data_csv,
@@ -336,7 +336,7 @@ def preprocess_for_training(
             random_seed=random_seed
         )
     elif data_hdf5 is not None or data_train_hdf5 is not None:
-        return preprocess_for_tr(
+        return preprocess_for_training_strategy_pattern(
             model_definition,
             'hdf5',
             all_data_fp=data_hdf5,
@@ -353,7 +353,7 @@ def preprocess_for_training(
                          'datasets. Please review your command')
 
 
-def preprocess_for_tr(
+def preprocess_for_training_strategy_pattern(
     model_definition,
     data_type,
     all_data_fp=None,
@@ -372,7 +372,7 @@ def preprocess_for_tr(
 
     if all_data_fp is not None and train_fp is not None:
         raise ValueError('Use either one file for all data or 3 files for '
-                         'train, test or validation')
+                         'train, test and validation')
 
     if data_type not in ['hdf5', 'csv', 'pandas']:
         raise ValueError('Invalid type of data provided')
@@ -455,7 +455,7 @@ def preprocess_for_tr(
                     'Found hdf5 and json with the same filename '
                     'of the csv, using them instead'
                 )
-                return preprocess_for_tr(
+                return preprocess_for_training_strategy_pattern(
                     model_definition,
                     'hdf5',
                     all_data_fp=replace_file_extension(all_data_fp, 'hdf5'),
@@ -491,7 +491,7 @@ def preprocess_for_tr(
                     'Found hdf5 and json with the same filename '
                     'of the csvs, using them instead.'
                 )
-                return preprocess_for_tr(
+                return preprocess_for_training_strategy_pattern(
                     model_definition,
                     'hdf5',
                     train_fp=replace_file_extension(train_fp, 'hdf5'),

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -442,6 +442,11 @@ def preprocess_for_tr(
                 )
 
     elif data_type == 'csv':
+        data_hdf5_fp = replace_file_extension(
+            all_data_fp, 'hdf5'
+        )
+        model_definition['data_hdf5_fp'] = data_hdf5_fp
+
         if all_data_fp is not None:
             if (file_exists_in_diff_format(all_data_fp, 'hdf5') and
                     file_exists_in_diff_format(all_data_fp, 'json')):
@@ -517,6 +522,7 @@ def preprocess_for_tr(
                 )
     else:
         raise RuntimeError('Insufficient input parameters')
+
 
     replace_text_feature_level(
         model_definition['input_features'] +

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -310,7 +310,7 @@ def preprocess_for_training(
         raise ValueError('No training data is provided!')
 
     if data_df is not None or data_train_df is not None:
-        return preprocess_for_training_strategy_pattern(
+        return preprocess_for_training_by_type(
             model_definition,
             'pandas',
             all_data_df=data_df,
@@ -323,7 +323,7 @@ def preprocess_for_training(
             random_seed=random_seed
         )
     elif data_csv is not None or data_train_csv is not None:
-        return preprocess_for_training_strategy_pattern(
+        return preprocess_for_training_by_type(
             model_definition,
             'csv',
             all_data_fp=data_csv,
@@ -336,7 +336,7 @@ def preprocess_for_training(
             random_seed=random_seed
         )
     elif data_hdf5 is not None or data_train_hdf5 is not None:
-        return preprocess_for_training_strategy_pattern(
+        return preprocess_for_training_by_type(
             model_definition,
             'hdf5',
             all_data_fp=data_hdf5,
@@ -353,7 +353,7 @@ def preprocess_for_training(
                          'datasets. Please review your command')
 
 
-def preprocess_for_training_strategy_pattern(
+def preprocess_for_training_by_type(
     model_definition,
     data_type,
     all_data_fp=None,
@@ -455,7 +455,7 @@ def preprocess_for_training_strategy_pattern(
                     'Found hdf5 and json with the same filename '
                     'of the csv, using them instead'
                 )
-                return preprocess_for_training_strategy_pattern(
+                return preprocess_for_training_by_type(
                     model_definition,
                     'hdf5',
                     all_data_fp=replace_file_extension(all_data_fp, 'hdf5'),
@@ -491,7 +491,7 @@ def preprocess_for_training_strategy_pattern(
                     'Found hdf5 and json with the same filename '
                     'of the csvs, using them instead.'
                 )
-                return preprocess_for_training_strategy_pattern(
+                return preprocess_for_training_by_type(
                     model_definition,
                     'hdf5',
                     train_fp=replace_file_extension(train_fp, 'hdf5'),

--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -326,6 +326,7 @@ def load_from_file(file_name, field=None, dtype=int, ground_truth_split=2):
         array = load_matrix(file_name, dtype)
     return array
 
+
 def replace_file_extension(file_path, desired_format):
     """
     Return a file path for a file with same name but different format.
@@ -335,11 +336,17 @@ def replace_file_extension(file_path, desired_format):
     :param desired_format: desired file format
     :return: file path with same name but different format
     """
+    if file_path is None:
+        return None
     if '.' in desired_format:
         # Handle the case if the user calls with '.hdf5' instead of 'hdf5'
         desired_format = desired_format.replace('.', '').strip()
 
     return os.path.splitext(file_path)[0] + '.' + desired_format
+
+
+def file_exists_in_diff_format(file_path, desired_format):
+    return os.path.isfile(replace_file_extension(file_path, desired_format))
 
 
 def add_sequence_feature_column(df, col_name, seq_length):

--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -328,27 +328,27 @@ def load_from_file(file_name, field=None, dtype=int, ground_truth_split=2):
     return array
 
 
-def replace_file_extension(file_path, desired_format):
+def replace_file_extension(file_path, extension):
     """
     Return a file path for a file with same name but different format.
     a.csv, json -> a.json
     a.csv, hdf5 -> a.hdf5
     :param file_path: original file path
-    :param desired_format: desired file format
+    :param extension: file extension
     :return: file path with same name but different format
     """
     if file_path is None:
         return None
-    if '.' in desired_format:
+    if '.' in extension:
         # Handle the case if the user calls with '.hdf5' instead of 'hdf5'
-        desired_format = desired_format.replace('.', '').strip()
+        extension = extension.replace('.', '').strip()
 
-    return os.path.splitext(file_path)[0] + '.' + desired_format
+    return os.path.splitext(file_path)[0] + '.' + extension
 
 
-def file_exists_in_diff_format(file_path, desired_format):
+def file_exists_with_diff_extension(file_path, extension):
     return file_path is None or \
-           os.path.isfile(replace_file_extension(file_path, desired_format))
+           os.path.isfile(replace_file_extension(file_path, extension))
 
 
 def add_sequence_feature_column(df, col_name, seq_length):

--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -36,6 +36,7 @@ def get_abs_path(data_csv_path, file_path):
     else:
         return file_path
 
+
 def load_csv(data_fp):
     data = []
     with open(data_fp, 'rb') as f:
@@ -346,7 +347,8 @@ def replace_file_extension(file_path, desired_format):
 
 
 def file_exists_in_diff_format(file_path, desired_format):
-    return os.path.isfile(replace_file_extension(file_path, desired_format))
+    return file_path is None or \
+           os.path.isfile(replace_file_extension(file_path, desired_format))
 
 
 def add_sequence_feature_column(df, col_name, seq_length):


### PR DESCRIPTION
- Updates our preprocessing logic using a strategy pattern
- The code is cleaner and makes it easier to add new file formats that can be supported
- Should be easier to test
- Makes the high level flow slightly simpler for csvs
    - When csv data is provided, we check if the same data is already available in hdf5
    -  If the hdf5 data is available, I'm calling the same method recursively to avoid repeating the logic of processing hdf5 data. 

Tests pass. 



