### PR TITLE
fix(value): Incorrectly specifies `fill_value` when it should be `fill_with_const`

### DIFF
--- a/mkdocs/docs/user_guide.md
+++ b/mkdocs/docs/user_guide.md
@@ -2589,9 +2589,9 @@ preprocessing:
 
 ### Date Input Features and Encoders
 
-Input image features are transformed into a int valued tensors of size `N x 8` (where `N` is the size of the dataset and the 8 dimensions contain year, month, day, weekday, yearday, hour, minute and second) and added to HDF5 with a key that reflects the name of column in the CSV.
+Input date features are transformed into a int valued tensors of size `N x 8` (where `N` is the size of the dataset and the 8 dimensions contain year, month, day, weekday, yearday, hour, minute and second) and added to HDF5 with a key that reflects the name of column in the CSV.
 
-Currently there are two encoders supported for images: Convolutional Stack Encoder and ResNet encoder which can be set by setting `encoder` parameter to `stacked_cnn` or `resnet` in the input feature dictionary in the model definition (`stacked_cnn` is the default one).
+Currently there are two encoders supported for dates: Embed Encoder and Wave encoder which can be set by setting `encoder` parameter to `embed` or `wave` in the input feature dictionary in the model definition (`embed` is the default one).
 
 #### Embed Encoder
 

--- a/mkdocs/docs/user_guide.md
+++ b/mkdocs/docs/user_guide.md
@@ -1051,7 +1051,7 @@ No additional information about them is available in the JSON metadata file.
 The parameters available for preprocessing are
 
 - `missing_value_strategy` (default `fill_with_const`): what strategy to follow when there's a missing value in a binary column. The value should be one of `fill_with_const`  (replaces the missing value with a specific value specified with the `fill_value` parameter), `fill_with_mode` (replaces the missing values with the most frequent value in the column), `fill_with_mean` (replaces the missing values with the mean of the values in the column), `backfill` (replaces the missing values with the next valid value).
-- `fill_value` (default `0`): the value to replace the missing values with in case the `missing_value_strategy` is `fill-value`.
+- `fill_value` (default `0`): the value to replace the missing values with in case the `missing_value_strategy` is `fill_with_const`.
 
 ### Binary Input Features and Encoders
 


### PR DESCRIPTION
…e missing values with the value specified in the `fill_value` parameter..

# Code Pull Requests

Please provide the following:

- a clear explanation of what your code dose
- if applicable, a reference to an issue
- a reproducible test for your PR (code, model definition and data sample)

# Documentation Pull Requests

Note that the documentation HTML files are in `docs/` while the Markdown sources are in `mkdocs/docs`.

If you are proposing a modification to the documentation you should change only the Markdown files.

`api.md` is automatically generated from the docstrings in the code, so if you want to change something in that file, first modify `ludwig/api.py` docstring, then run `mkdocs/code_docs_autogen.py`, which will create `mkdocs/docs/api.md` .
