### PR TITLE
Refactor image_feature

### DIFF
--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -42,6 +42,8 @@ from tests.integration_tests.utils import timeseries_feature
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
+logging.getLogger("ludwig").setLevel(logging.INFO)
+logger.info('hello')
 
 
 def run_experiment(input_features, output_features, **kwargs):
@@ -231,7 +233,8 @@ def test_experiment_image_inputs(csv_filename):
                 'in_memory': True,
                 'height': 8,
                 'width': 8,
-                'num_channels': 3
+                'num_channels': 3,
+                'num_processes': 5
             },
             fc_size=16,
             num_filters=8
@@ -452,7 +455,8 @@ def test_visual_question_answering(csv_filename):
                 'in_memory': True,
                 'height': 8,
                 'width': 8,
-                'num_channels': 3
+                'num_channels': 3,
+                'num_processes': 5
             },
             fc_size=8,
             num_filters=8
@@ -488,7 +492,8 @@ def test_image_resizing_num_channel_handling(csv_filename):
                 'in_memory': True,
                 'height': 8,
                 'width': 8,
-                'num_channels': 3
+                'num_channels': 3,
+                'num_processes': 5
             },
             fc_size=8,
             num_filters=8


### PR DESCRIPTION
Splits up the add_feature_data method for image_feature:
- handle the missing preprocessing parameters by looking at the first image
- Read an image and validate it according to the preprocessing parameters
- Parallelize (multiprocessing) reading and preprocessing the images
  - Pool.map requires a list of arguments. Used functools.partial to write this cleanly
  - It is probably possible to  parallelize this even when writing to .hdf5 but it is not very obvious


Testing:
- Modified the integration tests to use multiple processes
- Trained a model on MNIST to verify that the preprocessing is faster with >1 process and also that the model is trained properly (>99% accuracy)
- Multiprocessing works for both Unix and Windows
- Plan to add unit tests for the image preprocessing methods (will create a separate pr to keep the prs small)

