### PR TITLE
Change deprecated references to tf.compat.v1 counterparts

### DIFF
--- a/ludwig/features/category_feature.py
+++ b/ludwig/features/category_feature.py
@@ -136,7 +136,7 @@ class CategoryInputFeature(CategoryBaseFeature, InputFeature):
         input_feature['vocab'] = feature_metadata['idx2str']
 
     def _get_input_placeholder(self):
-        return tf.placeholder(
+        return tf.compat.v1.placeholder(
             tf.int32,
             shape=[None],  # None is for dealing with variable batch size
             name='{}_placeholder'.format(self.name)
@@ -224,7 +224,7 @@ class CategoryOutputFeature(CategoryBaseFeature, OutputFeature):
     ])
 
     def _get_output_placeholder(self):
-        return tf.placeholder(
+        return tf.compat.v1.placeholder(
             tf.int64,
             [None],  # None is for dealing with variable batch size
             name='{}_placeholder'.format(self.name)
@@ -239,16 +239,16 @@ class CategoryOutputFeature(CategoryBaseFeature, OutputFeature):
         if not self.regularize:
             regularizer = None
 
-        with tf.variable_scope('predictions_{}'.format(self.name)):
+        with tf.compat.v1.variable_scope('predictions_{}'.format(self.name)):
             initializer_obj = get_initializer(self.initializer)
-            weights = tf.get_variable(
+            weights = tf.compat.v1.get_variable(
                 'weights',
                 initializer=initializer_obj([hidden_size, self.num_classes]),
                 regularizer=regularizer
             )
             logger.debug('  class_weights: {0}'.format(weights))
 
-            biases = tf.get_variable(
+            biases = tf.compat.v1.get_variable(
                 'biases',
                 [self.num_classes]
             )
@@ -293,7 +293,7 @@ class CategoryOutputFeature(CategoryBaseFeature, OutputFeature):
             class_weights,
             class_biases
     ):
-        with tf.variable_scope('loss_{}'.format(self.name)):
+        with tf.compat.v1.variable_scope('loss_{}'.format(self.name)):
             if ('class_similarities' in self.loss and
                     self.loss['class_similarities'] is not None):
 
@@ -388,7 +388,7 @@ class CategoryOutputFeature(CategoryBaseFeature, OutputFeature):
         return train_mean_loss, eval_loss
 
     def _get_measures(self, targets, predictions, logits):
-        with tf.variable_scope('measures_{}'.format(self.name)):
+        with tf.compat.v1.variable_scope('measures_{}'.format(self.name)):
             accuracy_val, correct_predictions = get_accuracy(
                 targets,
                 predictions,
@@ -448,11 +448,11 @@ class CategoryOutputFeature(CategoryBaseFeature, OutputFeature):
         output_tensors[MEAN_HITS_AT_K + '_' + self.name] = mean_hits_at_k
 
         if 'sampled' not in self.loss['type']:
-            tf.summary.scalar(
+            tf.compat.v1.summary.scalar(
                 'train_batch_accuracy_{}'.format(self.name),
                 accuracy
             )
-            tf.summary.scalar(
+            tf.compat.v1.summary.scalar(
                 'train_batch_mean_hits_at_k_{}'.format(self.name),
                 mean_hits_at_k
             )
@@ -470,7 +470,7 @@ class CategoryOutputFeature(CategoryBaseFeature, OutputFeature):
         output_tensors[EVAL_LOSS + '_' + self.name] = eval_loss
         output_tensors[TRAIN_MEAN_LOSS + '_' + self.name] = train_mean_loss
 
-        tf.summary.scalar(
+        tf.compat.v1.summary.scalar(
             'train_mean_loss_{}'.format(self.name),
             train_mean_loss
         )

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -297,7 +297,7 @@ class ImageInputFeature(ImageBaseFeature, InputFeature):
 
     def _get_input_placeholder(self):
         # None dimension is for dealing with variable batch size
-        return tf.placeholder(
+        return tf.compat.v1.placeholder(
             tf.float32,
             shape=[None, self.height, self.width, self.num_channels],
             name=self.name,

--- a/ludwig/features/numerical_feature.py
+++ b/ludwig/features/numerical_feature.py
@@ -169,7 +169,7 @@ class NumericalOutputFeature(NumericalBaseFeature, OutputFeature):
         _ = self.overwrite_defaults(feature)
 
     def _get_output_placeholder(self):
-        return tf.placeholder(
+        return tf.compat.v1.placeholder(
             tf.float32,
             [None],  # None is for dealing with variable batch size
             name='{}_placeholder'.format(self.name)
@@ -184,16 +184,16 @@ class NumericalOutputFeature(NumericalBaseFeature, OutputFeature):
         if not self.regularize:
             regularizer = None
 
-        with tf.variable_scope('predictions_{}'.format(self.name)):
+        with tf.compat.v1.variable_scope('predictions_{}'.format(self.name)):
             initializer_obj = get_initializer(self.initializer)
-            weights = tf.get_variable(
+            weights = tf.compat.v1.get_variable(
                 'weights',
                 initializer=initializer_obj([hidden_size, 1]),
                 regularizer=regularizer
             )
             logger.debug('  regression_weights: {0}'.format(weights))
 
-            biases = tf.get_variable('biases', [1])
+            biases = tf.compat.v1.get_variable('biases', [1])
             logger.debug('  regression_biases: {0}'.format(biases))
 
             predictions = tf.reshape(
@@ -224,9 +224,9 @@ class NumericalOutputFeature(NumericalBaseFeature, OutputFeature):
         return predictions
 
     def _get_loss(self, targets, predictions):
-        with tf.variable_scope('loss_{}'.format(self.name)):
+        with tf.compat.v1.variable_scope('loss_{}'.format(self.name)):
             if self.loss['type'] == 'mean_squared_error':
-                train_loss = tf.losses.mean_squared_error(
+                train_loss = tf.compat.v1.losses.mean_squared_error(
                     labels=targets,
                     predictions=predictions,
                     reduction=Reduction.NONE)
@@ -252,7 +252,7 @@ class NumericalOutputFeature(NumericalBaseFeature, OutputFeature):
 
     def _get_measures(self, targets, predictions):
 
-        with tf.variable_scope('measures_{}'.format(self.name)):
+        with tf.compat.v1.variable_scope('measures_{}'.format(self.name)):
             error_val = get_error(
                 targets,
                 predictions,
@@ -309,15 +309,15 @@ class NumericalOutputFeature(NumericalBaseFeature, OutputFeature):
         output_tensors[R2 + '_' + self.name] = r2
 
         if 'sampled' not in self.loss['type']:
-            tf.summary.scalar(
+            tf.compat.v1.summary.scalar(
                 'train_batch_mean_squared_error_{}'.format(self.name),
                 tf.reduce_mean(squared_error)
             )
-            tf.summary.scalar(
+            tf.compat.v1.summary.scalar(
                 'train_batch_mean_absolute_error_{}'.format(self.name),
                 tf.reduce_mean(absolute_error)
             )
-            tf.summary.scalar(
+            tf.compat.v1.summary.scalar(
                 'train_batch_mean_r2_{}'.format(self.name),
                 tf.reduce_mean(r2)
             )
@@ -329,7 +329,7 @@ class NumericalOutputFeature(NumericalBaseFeature, OutputFeature):
         output_tensors[
             TRAIN_MEAN_LOSS + '_' + self.name] = train_mean_loss
 
-        tf.summary.scalar(
+        tf.compat.v1.summary.scalar(
             'train_mean_loss_{}'.format(self.name),
             train_mean_loss,
         )

--- a/ludwig/models/combiners.py
+++ b/ludwig/models/combiners.py
@@ -81,7 +81,7 @@ class ConcatCombiner:
             representations_size += fe_properties['size']
 
         scope_name = 'concat_combiner'
-        with tf.variable_scope(scope_name):
+        with tf.compat.v1.variable_scope(scope_name):
             # ================ Concat ================
             hidden = tf.concat(representations, 1)
             hidden_size = representations_size

--- a/ludwig/models/inputs.py
+++ b/ludwig/models/inputs.py
@@ -57,7 +57,7 @@ def build_single_input(input_feature,
     if input_feature.get('tied_weights', None) is not None:
         scope_name = input_feature['tied_weights']
 
-    with tf.variable_scope(scope_name, reuse=tf.AUTO_REUSE):
+    with tf.compat.v1.variable_scope(scope_name, reuse=tf.compat.v1.AUTO_REUSE):
         input_feature_class = get_from_registry(
             input_feature['type'],
             input_type_registry

--- a/ludwig/models/model.py
+++ b/ludwig/models/model.py
@@ -134,26 +134,26 @@ class Model:
         if self.horovod:
             self.horovod.init()
 
-        tf.reset_default_graph()
+        tf.compat.v1.reset_default_graph()
         graph = tf.Graph()
         with graph.as_default():
             # ================ Setup ================
-            tf.set_random_seed(random_seed)
+            tf.compat.v1.set_random_seed(random_seed)
 
             self.global_step = tf.Variable(0, trainable=False)
-            self.regularization_lambda = tf.placeholder(
+            self.regularization_lambda = tf.compat.v1.placeholder(
                 tf.float32,
                 name='regularization_lambda'
             )
             regularizer = regularizer_registry[training['regularizer']]
             self.regularizer = regularizer(self.regularization_lambda)
 
-            self.learning_rate = tf.placeholder(
+            self.learning_rate = tf.compat.v1.placeholder(
                 tf.float32,
                 name='learning_rate'
             )
-            self.dropout_rate = tf.placeholder(tf.float32, name='dropout_rate')
-            self.is_training = tf.placeholder(tf.bool, [], name='is_training')
+            self.dropout_rate = tf.compat.v1.placeholder(tf.float32, name='dropout_rate')
+            self.is_training = tf.compat.v1.placeholder(tf.bool, [], name='is_training')
 
             # ================ Inputs ================
             feature_encodings = build_inputs(
@@ -206,19 +206,19 @@ class Model:
                 self.horovod
             )
 
-            tf.summary.scalar('train_reg_mean_loss', self.train_reg_mean_loss)
+            tf.compat.v1.summary.scalar('train_reg_mean_loss', self.train_reg_mean_loss)
 
-            self.merged_summary = tf.summary.merge_all()
+            self.merged_summary = tf.compat.v1.summary.merge_all()
             self.graph = graph
-            self.graph_initialize = tf.global_variables_initializer()
+            self.graph_initialize = tf.compat.v1.global_variables_initializer()
             if self.horovod:
                 self.broadcast_op = self.horovod.broadcast_global_variables(0)
-            self.saver = tf.train.Saver()
+            self.saver = tf.compat.v1.train.Saver()
 
     def initialize_session(self, gpus=None, gpu_fraction=1):
         if self.session is None:
 
-            self.session = tf.Session(
+            self.session = tf.compat.v1.Session(
                 config=get_tf_config(gpus, gpu_fraction, self.horovod),
                 graph=self.graph
             )

--- a/ludwig/models/model.py
+++ b/ludwig/models/model.py
@@ -419,7 +419,7 @@ class Model:
         train_writer = None
         if is_on_master():
             if not skip_save_log:
-                train_writer = tf.summary.FileWriter(
+                train_writer = tf.compat.v1.summary.FileWriter(
                     os.path.join(save_path, 'log', 'train'),
                     session.graph
                 )

--- a/ludwig/models/modules/convolutional_modules.py
+++ b/ludwig/models/modules/convolutional_modules.py
@@ -920,7 +920,7 @@ class ResNet(object):
         """
         inputs = input_image
 
-        with tf.variable_scope('resnet'):
+        with tf.compat.v1.variable_scope('resnet'):
             inputs = conv2d_fixed_padding(
                 inputs=inputs, filters=self.num_filters,
                 kernel_size=self.kernel_size,

--- a/ludwig/models/modules/embedding_modules.py
+++ b/ludwig/models/modules/embedding_modules.py
@@ -64,14 +64,14 @@ def embedding_matrix(
                     {'type': 'uniform', 'minval': -1.0, 'maxval': 1.0})
             initializer_obj = initializer_obj_ref([vocab_size, embedding_size])
 
-        embeddings = tf.get_variable('embeddings',
+        embeddings = tf.compat.v1.get_variable('embeddings',
                                      initializer=initializer_obj,
                                      trainable=embeddings_trainable,
                                      regularizer=regularizer)
 
     elif representation == 'sparse':
         embedding_size = vocab_size
-        embeddings = tf.get_variable('embeddings',
+        embeddings = tf.compat.v1.get_variable('embeddings',
                                      initializer=get_initializer('identity')(
                                          [vocab_size, embedding_size]),
                                      trainable=False)

--- a/ludwig/models/modules/fully_connected_modules.py
+++ b/ludwig/models/modules/fully_connected_modules.py
@@ -43,7 +43,7 @@ def fc_layer(inputs, in_count, out_count,
                 initializer = get_initializer('glorot_uniform')
             # if initializer is None, tensorFlow seems to be using
             # a glorot uniform initializer
-            weights = tf.get_variable(
+            weights = tf.compat.v1.get_variable(
                 'weights',
                 [in_count, out_count],
                 regularizer=regularizer,
@@ -53,7 +53,7 @@ def fc_layer(inputs, in_count, out_count,
     logger.debug('  fc_weights: {}'.format(weights))
 
     if biases is None:
-        biases = tf.get_variable('biases', [out_count],
+        biases = tf.compat.v1.get_variable('biases', [out_count],
                                  initializer=tf.constant_initializer(0.01))
     logger.debug('  fc_biases: {}'.format(biases))
 
@@ -121,7 +121,7 @@ class FCStack:
     ):
         hidden = inputs
         for i, layer in enumerate(self.layers):
-            with tf.variable_scope('fc_' + str(i)):
+            with tf.compat.v1.variable_scope('fc_' + str(i)):
                 hidden = fc_layer(
                     hidden,
                     inputs_size,

--- a/ludwig/models/modules/initializer_modules.py
+++ b/ludwig/models/modules/initializer_modules.py
@@ -31,10 +31,10 @@ initializers_registry = {
     'glorot_uniform': tf.initializers.glorot_uniform,
     'xavier_normal': tf.initializers.glorot_normal,
     'xavier_uniform': tf.initializers.glorot_uniform,
-    'he_normal': tf.initializers.he_normal,
-    'he_uniform': tf.initializers.he_uniform,
-    'lecun_normal': tf.initializers.lecun_normal,
-    'lecun_uniform': tf.initializers.lecun_uniform,
+    'he_normal': tf.compat.v1.initializers.he_normal,
+    'he_uniform': tf.compat.v1.initializers.he_uniform,
+    'lecun_normal': tf.compat.v1.initializers.lecun_normal,
+    'lecun_uniform': tf.compat.v1.initializers.lecun_uniform,
     None: tf.initializers.glorot_uniform
 }
 

--- a/ludwig/models/modules/loss_modules.py
+++ b/ludwig/models/modules/loss_modules.py
@@ -288,7 +288,7 @@ def weighted_softmax_cross_entropy(logits, vector_labels, loss):
             loss['labels_smoothing']
         )
     else:
-        train_loss = tf.losses.softmax_cross_entropy(
+        train_loss = tf.compat.v1.losses.softmax_cross_entropy(
             onehot_labels=vector_labels,
             logits=logits,
             label_smoothing=loss[

--- a/ludwig/models/modules/optimization_modules.py
+++ b/ludwig/models/modules/optimization_modules.py
@@ -24,15 +24,15 @@ def optimize(
         horovod=None
 ):
     if training_parameters is not None and training_parameters['decay'] is True:
-        learning_rate = tf.train.exponential_decay(
+        learning_rate = tf.compat.v1.train.exponential_decay(
             learning_rate, global_step,
             training_parameters['decay_steps'],
             training_parameters['decay_rate'],
             staircase=training_parameters['staircase'])
 
-    update_ops = tf.get_collection(tf.GraphKeys.UPDATE_OPS)
+    update_ops = tf.compat.v1.get_collection(tf.compat.v1.GraphKeys.UPDATE_OPS)
 
-    with tf.variable_scope('optimizer'):
+    with tf.compat.v1.variable_scope('optimizer'):
         if training_parameters is not None:
             optimizer_args = dict(training_parameters['optimizer'])
             optimizer_type = optimizer_args.pop('type')
@@ -81,7 +81,7 @@ def get_optimizer_fun(optimizer_type):
     ):
         return tf.train.GradientDescentOptimizer
     elif optimizer_type == 'adam':
-        return tf.train.AdamOptimizer
+        return tf.compat.v1.train.AdamOptimizer
     elif optimizer_type == 'adadelta':
         return tf.train.AdadeltaOptimizer
     elif optimizer_type == 'adagrad':

--- a/ludwig/models/modules/recurrent_modules.py
+++ b/ludwig/models/modules/recurrent_modules.py
@@ -57,7 +57,7 @@ def get_cell_fun(cell_type):
     return cell_fn
 
 
-class Projection(tf.layers.Layer):
+class Projection(tf.compat.v1.layers.Layer):
     def __init__(self, projection_weights, projection_biases, name=None,
                  **kwargs):
         super(Projection, self).__init__(name=name, **kwargs)

--- a/ludwig/models/outputs.py
+++ b/ludwig/models/outputs.py
@@ -52,8 +52,8 @@ def build_outputs(output_features, hidden, hidden_size, regularizer,
     train_combined_mean_loss = tf.reduce_sum(tf.stack(output_train_losses),
                                              name='train_combined_mean_loss')
     if regularizer is not None:
-        regularization_losses = tf.get_collection(
-            tf.GraphKeys.REGULARIZATION_LOSSES)
+        regularization_losses = tf.compat.v1.get_collection(
+            tf.compat.v1.GraphKeys.REGULARIZATION_LOSSES)
         if regularization_losses:
             regularization_loss = tf.add_n(regularization_losses)
             logger.debug('- Regularization losses: {0}'.format(
@@ -80,7 +80,7 @@ def build_single_output(output_feature, feature_hidden, feature_hidden_size,
         output_feature['type'],
         output_feature['name']
     ))
-    with tf.variable_scope(output_feature['name']):
+    with tf.compat.v1.variable_scope(output_feature['name']):
         feature_class = get_from_registry(
             output_feature['type'],
             output_type_registry

--- a/ludwig/utils/tf_utils.py
+++ b/ludwig/utils/tf_utils.py
@@ -68,7 +68,7 @@ def get_tf_config(gpus=None, gpu_fraction=1, horovod=None,
                                    inter_op_parallelism_threads=inter_op_parallelism_threads,
                                    gpu_options=gpu_options)
     else:
-        tf_config = tf.ConfigProto(allow_soft_placement=True,
+        tf_config = tf.compat.v1.ConfigProto(allow_soft_placement=True,
                                    log_device_placement=False,
                                    intra_op_parallelism_threads=intra_op_parallelism_threads,
                                    inter_op_parallelism_threads=inter_op_parallelism_threads)


### PR DESCRIPTION
Since we're requiring tensorflow-1.14.0 I changed all the references that were giving out deprecation warnings. Those functions do the exact same thing as the "old" ones, so no actual code change is necessary.
This is more a graphic fix than a code fix, and they are not the only ones for sure, but it's a start.