### PR TITLE
Fix in memory

### DIFF
--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -502,8 +502,10 @@ def preprocess_for_training_by_type(
                         'hdf5'
                     ),
                     test_fp=replace_file_extension(test_fp, 'hdf5'),
-                    train_set_metadata_json=replace_file_extension(all_data_fp,
-                                                                   'json'),
+                    train_set_metadata_json=replace_file_extension(
+                        train_fp,
+                        'json'
+                    ),
                     skip_save_processed_input=skip_save_processed_input,
                     preprocessing_params=preprocessing_params,
                     random_seed=random_seed

--- a/ludwig/experiment.py
+++ b/ludwig/experiment.py
@@ -239,7 +239,6 @@ def experiment(
             print_test_results(test_results)
             save_prediction_outputs(postprocessed_output, experiment_dir_name)
             save_test_statistics(test_results, experiment_dir_name)
-
     model.close_session()
 
     if is_on_master():

--- a/ludwig/experiment.py
+++ b/ludwig/experiment.py
@@ -239,7 +239,7 @@ def experiment(
             print_test_results(test_results)
             save_prediction_outputs(postprocessed_output, experiment_dir_name)
             save_test_statistics(test_results, experiment_dir_name)
-    
+
     model.close_session()
 
     if is_on_master():

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -81,7 +81,7 @@ def run_experiment(input_features, output_features, **kwargs):
     args.update(kwargs)
 
     exp_dir_name = experiment(**args)
-    # shutil.rmtree(exp_dir_name, ignore_errors=True)
+    shutil.rmtree(exp_dir_name, ignore_errors=True)
 
 
 def test_experiment_seq_seq(csv_filename):
@@ -252,7 +252,7 @@ def test_experiment_image_inputs(csv_filename):
     rel_path = generate_data(input_features, output_features, csv_filename)
     run_experiment(input_features, output_features, data_csv=rel_path)
 
-    # # Stacked CNN encoder
+    # Stacked CNN encoder
     input_features[0]['encoder'] = 'stacked_cnn'
     rel_path = generate_data(input_features, output_features, csv_filename)
     run_experiment(input_features, output_features, data_csv=rel_path)

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -81,7 +81,7 @@ def run_experiment(input_features, output_features, **kwargs):
     args.update(kwargs)
 
     exp_dir_name = experiment(**args)
-    shutil.rmtree(exp_dir_name, ignore_errors=True)
+    # shutil.rmtree(exp_dir_name, ignore_errors=True)
 
 
 def test_experiment_seq_seq(csv_filename):
@@ -252,7 +252,7 @@ def test_experiment_image_inputs(csv_filename):
     rel_path = generate_data(input_features, output_features, csv_filename)
     run_experiment(input_features, output_features, data_csv=rel_path)
 
-    # Stacked CNN encoder
+    # # Stacked CNN encoder
     input_features[0]['encoder'] = 'stacked_cnn'
     rel_path = generate_data(input_features, output_features, csv_filename)
     run_experiment(input_features, output_features, data_csv=rel_path)
@@ -260,7 +260,12 @@ def test_experiment_image_inputs(csv_filename):
     # Stacked CNN encoder, in_memory = False
     input_features[0]['preprocessing']['in_memory'] = False
     rel_path = generate_data(input_features, output_features, csv_filename)
-    run_experiment(input_features, output_features, data_csv=rel_path)
+    run_experiment(
+        input_features,
+        output_features,
+        data_csv=rel_path,
+        skip_save_processed_input=False,
+    )
 
     # Delete the temporary data created
     shutil.rmtree(image_dest_folder)


### PR DESCRIPTION
Fixes errors when calling experiment with input image features and with data_[train|validation|test]_csv and specifying in_memory=False.

Preprocessing function saves preprocessed image dataset in the _train.hdf5 file.
Dataset objects created for validation and test datasets need to point there.

Also fixing an integration test which was calling experiment on images with in_memory=False but skip_save_preprocessed_input=True which is not an intended functionality.

Tested by running all integration tests and also with the following command on the mnist dataset:
python -m ludwig.experiment --data_csv ~/Documents/ludwig/datasets/mnist_png/mnist_png/mnist_train.csv  --model_definition_file ~/Documents/ludwig/datasets/mnist_png/mnist_png/model_def.yaml

input_features:
    -
        name: image_path
        type: image
        preprocessing:
            in_memory: false

output_features:
    -
        name: label
        type: category
