### PR TITLE
Support tensorflow-gpu by ludwig[gpu]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,9 @@ setup(
                       'python-multipart',
                       'soundfile',
                       ],
-
+    extras_require={
+        "gpu": ["tensorflow-gpu==1.14.0"],
+    } ,
     entry_points={
         'console_scripts': [
             'ludwig=ludwig.cli:main'


### PR DESCRIPTION
# Code Pull Requests

The motivation of my PR is to support `tensorflow-gpu`. From my understanding, we need to uninstall `tensorflow` and then install `tensorflow-gpu`, when we want to use GPU with  ludwig. The operation is a little annoying. So, it would be nice to provide a measure to install `tensorflow-gpu` instead of `tensorflow`.

```
# Install `tensorflow`
pip install -U ludwig
# Install `tensorflow-gpu`
pip install -U ludwig[gpu]
```

My concern is ludwig probably cannot use GPU when we install both of `tensorflow` and `tensorflow-gpu`. So, I want to exclude `tensorflow` from `install_requires` when installing `ludwing[gpu]`.