### PR TITLE
Miscellaneous user guide updates

### DIFF
--- a/mkdocs/docs/user_guide.md
+++ b/mkdocs/docs/user_guide.md
@@ -1947,7 +1947,7 @@ reduce_output: last
 #### BERT Encoder
 
 The [BERT](https://arxiv.org/abs/1810.04805) encoder allows for loading a pre-trained bert model.
-Models are available on [GitHube](https://github.com/google-research/bert) for download.
+Models are available on [GitHub](https://github.com/google-research/bert) for download.
 The downloaded pretrained model directory contains:
 - `bert_config.json` which holds the hyperparameters of the bert architecture,
 - `vocab.txt` which contains the vocabulary of BPE word pieces the model was trained on,

--- a/mkdocs/docs/user_guide.md
+++ b/mkdocs/docs/user_guide.md
@@ -2347,6 +2347,7 @@ All images in the dataset should have the same size.
 If they have different sizes, a `resize_method`, together with a target `width` and `height`, must be specified in the feature preprocessing parameters.
 
 - `in_memory` (default `true`): defines whether image dataset will reside in memory during the training process or will be dynamically fetched from disk (useful for large datasets). In the latter case a training batch of input images will be fetched from disk each training iteration.
+- `num_processes` (default 1): specifies the number of processes to run for preprocessing images.
 - `resize_method` (default `crop_or_pad`): available options: `crop_or_pad` - crops images larger than the specified `width` and `height` to the desired size or pads smalled images using edge padding; `interpolate` - uses interpolation to resize images to the specified `width` and `height`.
 - `height` (default `null`): image height in pixels, must be set if resizing is required
 - `width` (default `null`): image width in pixels, must be set if resizing is required


### PR DESCRIPTION
# Documentation Pull Requests

Corrected spelling of `GitHube` to `GitHub` in User Guide in the section related to BERT Encoder.

Added missing `num_processes` parameter definition for image preprocessing