### PR TITLE
Fix visualize api doc parameter formatting

### DIFF
--- a/ludwig/visualize.py
+++ b/ludwig/visualize.py
@@ -691,10 +691,10 @@ def learning_curves(
     :param train_stats_per_model: (list) List containing train statistics per model
     :param output_feature_name: (string) Name of the output feature that is predicted
            and for which is provided ground truth
-    :param model_names: (list) List of the names of the models to use as labels.
-    :param output_directory: (string) Directory where to save plots.
+    :param model_names: (list, default: None) List of the names of the models to use as labels.
+    :param output_directory: (string, default: None) Directory where to save plots.
              If not specified, plots will be displayed in a window
-    :param file_format: (string) File format of output plots - pdf or png
+    :param file_format: (string, default: 'pdf') File format of output plots - pdf or png
 
     # Return
     :return: (None)
@@ -764,10 +764,10 @@ def compare_performance(
 
     :param test_stats_per_model: (list) List containing train statistics per model
     :param output_feature_name: (string) Name of the output feature that is predicted and for which is provided ground truth
-    :param model_names: (list) List of the names of the models to use as labels.
-    :param output_directory: (string) Directory where to save plots.
+    :param model_names: (list, default: None) List of the names of the models to use as labels.
+    :param output_directory: (string, default: None) Directory where to save plots.
              If not specified, plots will be displayed in a window
-    :param file_format: (string) File format of output plots - pdf or png
+    :param file_format: (string, default: 'pdf') File format of output plots - pdf or png
 
     # Return
 
@@ -852,10 +852,10 @@ def compare_classifiers_performance_from_prob(
     :param top_n_classes: (list) List containing the number of classes to plot
     :param labels_limit: (int) Maximum numbers of labels.
              If labels in dataset are higher than this number, "rare" label
-    :param model_names: (list) List of the names of the models to use as labels.
-    :param output_directory: (string) Directory where to save plots.
+    :param model_names: (list, default: None) List of the names of the models to use as labels.
+    :param output_directory: (string, default: None) Directory where to save plots.
              If not specified, plots will be displayed in a window
-    :param file_format: (string) File format of output plots - pdf or png
+    :param file_format: (string, default: 'pdf') File format of output plots - pdf or png
 
     # Return
 
@@ -1027,10 +1027,10 @@ def compare_classifiers_performance_subset(
     :param top_n_classes: (list) List containing the number of classes to plot
     :param labels_limit: (int) Maximum numbers of labels.
     :param subset: () Type of the subset filtering
-    :param model_names: (list) List of the names of the models to use as labels.
-    :param output_directory: (string) Directory where to save plots.
+    :param model_names: (list, default: None) List of the names of the models to use as labels.
+    :param output_directory: (string, default: None) Directory where to save plots.
              If not specified, plots will be displayed in a window
-    :param file_format: (string) File format of output plots - pdf or png
+    :param file_format: (string, default: 'pdf') File format of output plots - pdf or png
 
     # Return
 
@@ -1142,10 +1142,10 @@ def compare_classifiers_performance_changing_k(
     :param top_k: (int) Number of elements in the ranklist to consider
     :param labels_limit: (int) Maximum numbers of labels.
              If labels in dataset are higher than this number, "rare" label
-    :param model_names: (list) List of the names of the models to use as labels.
-    :param output_directory: (string) Directory where to save plots.
+    :param model_names: (list, default: None) List of the names of the models to use as labels.
+    :param output_directory: (string, default: None) Directory where to save plots.
              If not specified, plots will be displayed in a window
-    :param file_format: (string) File format of output plots - pdf or png
+    :param file_format: (string, default: 'pdf') File format of output plots - pdf or png
 
     # Return
 
@@ -1211,10 +1211,10 @@ def compare_classifiers_multiclass_multimetric(
     :param metadata: () Model's input metadata
     :param output_feature_name: (string) Name of the output feature that is predicted and for which is provided ground truth
     :param top_n_classes: (list) List containing the number of classes to plot
-    :param model_names: (list) List of the names of the models to use as labels.
-    :param output_directory: (string) Directory where to save plots.
+    :param model_names: (list, default: None) List of the names of the models to use as labels.
+    :param output_directory: (string, default: None) Directory where to save plots.
              If not specified, plots will be displayed in a window
-    :param file_format: (string) File format of output plots - pdf or png
+    :param file_format: (string, default: 'pdf') File format of output plots - pdf or png
 
     # Return
     :return: (None)
@@ -1383,10 +1383,10 @@ def compare_classifiers_predictions(
     :param ground_truth: (ndarray) NumPy Array containing ground truth data
     :param labels_limit: (int) Maximum numbers of labels.
              If labels in dataset are higher than this number, "rare" label
-    :param model_names: (list) List of the names of the models to use as labels.
-    :param output_directory: (string) Directory where to save plots.
+    :param model_names: (list, default: None) List of the names of the models to use as labels.
+    :param output_directory: (string, default: None) Directory where to save plots.
              If not specified, plots will be displayed in a window
-    :param file_format: (string) File format of output plots - pdf or png
+    :param file_format: (string, default: 'pdf') File format of output plots - pdf or png
 
     # Return
 
@@ -1520,10 +1520,10 @@ def compare_classifiers_predictions_distribution(
     :param ground_truth: (ndarray) NumPy Array containing ground truth data
     :param labels_limit: (int) Maximum numbers of labels.
              If labels in dataset are higher than this number, "rare" label
-    :param model_names: (list) List of the names of the models to use as labels.
-    :param output_directory: (string) Directory where to save plots.
+    :param model_names: (list, default: None) List of the names of the models to use as labels.
+    :param output_directory: (string, default: None) Directory where to save plots.
              If not specified, plots will be displayed in a window
-    :param file_format: (string) File format of output plots - pdf or png
+    :param file_format: (string, default: 'pdf') File format of output plots - pdf or png
 
     # Return
 
@@ -1587,10 +1587,10 @@ def confidence_thresholding(
     :param ground_truth: (ndarray) NumPy Array containing ground truth data
     :param labels_limit: (int) Maximum numbers of labels.
              If labels in dataset are higher than this number, "rare" label
-    :param model_names: (list) List of the names of the models to use as labels.
+    :param model_names: (list, default: None) List of the names of the models to use as labels.
     :param output_directory: (sting) Directory where to save plots.
              If not specified, plots will be displayed in a window
-    :param file_format: (string) File format of output plots - pdf or png
+    :param file_format: (string, default: 'pdf') File format of output plots - pdf or png
 
     # Return
 
@@ -1676,10 +1676,10 @@ def confidence_thresholding_data_vs_acc(
     :param ground_truth: (ndarray) NumPy Array containing ground truth data
     :param labels_limit:(int) Maximum numbers of labels.
              If labels in dataset are higher than this number, "rare" label
-    :param model_names: (list) List of the names of the models to use as labels.
-    :param output_directory: (string) Directory where to save plots.
+    :param model_names: (list, default: None) List of the names of the models to use as labels.
+    :param output_directory: (string, default: None) Directory where to save plots.
              If not specified, plots will be displayed in a window
-    :param file_format: (string) File format of output plots - pdf or png
+    :param file_format: (string, default: 'pdf') File format of output plots - pdf or png
 
     # Return
     :return: (None)
@@ -1776,10 +1776,10 @@ def confidence_thresholding_data_vs_acc_subset(
     :param top_n_classes: (list) List containing the number of classes to plot
     :param labels_limit: (int) Maximum numbers of labels.
     :param subset: (string) Type of the subset filtering
-    :param model_names: (list) List of the names of the models to use as labels.
-    :param output_directory: (string) Directory where to save plots.
+    :param model_names: (list, default: None) List of the names of the models to use as labels.
+    :param output_directory: (string, default: None) Directory where to save plots.
              If not specified, plots will be displayed in a window
-    :param file_format: (string) File format of output plots - pdf or png
+    :param file_format: (string, default: 'pdf') File format of output plots - pdf or png
 
     # Return
 
@@ -1908,10 +1908,10 @@ def confidence_thresholding_data_vs_acc_subset_per_class(
     :param top_n_classes: (list) List containing the number of classes to plot
     :param labels_limit: (int) Maximum numbers of labels.
     :param subset: (string) Type of the subset filtering
-    :param model_names: (list) List of the names of the models to use as labels.
-    :param output_directory: (string) Directory where to save plots.
+    :param model_names: (list, default: None) List of the names of the models to use as labels.
+    :param output_directory: (string, default: None) Directory where to save plots.
              If not specified, plots will be displayed in a window
-    :param file_format: (string) File format of output plots - pdf or png
+    :param file_format: (string, default: 'pdf') File format of output plots - pdf or png
 
     # Return
     :return: (None)
@@ -2028,9 +2028,9 @@ def confidence_thresholding_2thresholds_2d(
     :param labels_limit: (int) Maximum numbers of labels.
              If labels in dataset are higher than this number, "rare" label
     :param model_names: (string) Name of the model to use as label.
-    :param output_directory: (string) Directory where to save plots.
+    :param output_directory: (string, default: None) Directory where to save plots.
              If not specified, plots will be displayed in a window
-    :param file_format: (string) File format of output plots - pdf or png
+    :param file_format: (string, default: 'pdf') File format of output plots - pdf or png
 
     # Return
 
@@ -2219,9 +2219,9 @@ def confidence_thresholding_2thresholds_3d(
     :param threshold_output_feature_names: (list) List of output_feature_names for 2d threshold
     :param labels_limit: (int) Maximum numbers of labels.
              If labels in dataset are higher than this number, "rare" label
-    :param output_directory: (string) Directory where to save plots.
+    :param output_directory: (string, default: None) Directory where to save plots.
              If not specified, plots will be displayed in a window
-    :param file_format: (string) File format of output plots - pdf or png
+    :param file_format: (string, default: 'pdf') File format of output plots - pdf or png
 
     # Return
 
@@ -2341,10 +2341,10 @@ def binary_threshold_vs_metric(
     :param metrics: metrics to dispay (f1, precision, recall,
                     accuracy)
     :param positive_label: (string) Label of the positive class
-    :param model_names: (list) List of the names of the models to use as labels.
-    :param output_directory: (string) Directory where to save plots.
+    :param model_names: (list, default: None) List of the names of the models to use as labels.
+    :param output_directory: (string, default: None) Directory where to save plots.
              If not specified, plots will be displayed in a window
-    :param file_format: (string) File format of output plots - pdf or png
+    :param file_format: (string, default: 'pdf') File format of output plots - pdf or png
 
     # Return
 
@@ -2455,10 +2455,10 @@ def roc_curves(
     :param probabilities_per_model: (list) List of model probabilities
     :param ground_truth: (list) List of NumPy Arrays containing ground truth data
     :param positive_label: (string) Label of the positive class
-    :param model_names: (list) List of the names of the models to use as labels.
-    :param output_directory: (string) Directory where to save plots.
+    :param model_names: (list, default: None) List of the names of the models to use as labels.
+    :param output_directory: (string, default: None) Directory where to save plots.
              If not specified, plots will be displayed in a window
-    :param file_format: (string) File format of output plots - pdf or png
+    :param file_format: (string, default: 'pdf') File format of output plots - pdf or png
 
     # Return
 
@@ -2511,10 +2511,10 @@ def roc_curves_from_test_statistics(
 
     :param test_stats_per_model: (list) List containing train statistics per model
     :param output_feature_name: (string) Name of the output feature that is predicted and for which is provided ground truth
-    :param model_names: (list) List of the names of the models to use as labels.
-    :param output_directory: (string) Directory where to save plots.
+    :param model_names: (list, default: None) List of the names of the models to use as labels.
+    :param output_directory: (string, default: None) Directory where to save plots.
              If not specified, plots will be displayed in a window
-    :param file_format: (string) File format of output plots - pdf or png
+    :param file_format: (string, default: 'pdf') File format of output plots - pdf or png
 
     # Return
 
@@ -2575,10 +2575,10 @@ def calibration_1_vs_all(
     :param top_n_classes: (list) List containing the number of classes to plot
     :param labels_limit: (int) Maximum numbers of labels.
              If labels in dataset are higher than this number, "rare" label
-    :param model_names: (list) List of the names of the models to use as labels.
-    :param output_directory: (string) Directory where to save plots.
+    :param model_names: (list, default: None) List of the names of the models to use as labels.
+    :param output_directory: (string, default: None) Directory where to save plots.
              If not specified, plots will be displayed in a window
-    :param file_format: (string) File format of output plots - pdf or png
+    :param file_format: (string, default: 'pdf') File format of output plots - pdf or png
 
     # String
 
@@ -2697,10 +2697,10 @@ def calibration_multiclass(
     :param ground_truth: (ndarray) NumPy Array containing ground truth data
     :param labels_limit: (int) Maximum numbers of labels.
              If labels in dataset are higher than this number, "rare" label
-    :param model_names: (list) List of the names of the models to use as labels.
-    :param output_directory: (string) Directory where to save plots.
+    :param model_names: (list, default: None) List of the names of the models to use as labels.
+    :param output_directory: (string, default: None) Directory where to save plots.
              If not specified, plots will be displayed in a window
-    :param file_format: (string) File format of output plots - pdf or png
+    :param file_format: (string, default: 'pdf') File format of output plots - pdf or png
 
     # Return
 
@@ -2809,11 +2809,11 @@ def confusion_matrix(
     :param metadata: () Model's input metadata
     :param output_feature_name: (string) Name of the output feature that is predicted and for which is provided ground truth
     :param top_n_classes: (list) List containing the number of classes to plot
-    :param normalize: (boolean) Flag to normalize rows in confusion matrix
-    :param model_names: (list) List of the names of the models to use as labels.
-    :param output_directory: (string) Directory where to save plots.
+    :param normalize: (bool) Flag to normalize rows in confusion matrix
+    :param model_names: (list, default: None) List of the names of the models to use as labels.
+    :param output_directory: (string, default: None) Directory where to save plots.
              If not specified, plots will be displayed in a window
-    :param file_format: (string) File format of output plots - pdf or png
+    :param file_format: (string, default: 'pdf') File format of output plots - pdf or png
 
     # Return
 
@@ -2936,10 +2936,10 @@ def frequency_vs_f1(
     :param metadata: () Model's input metadata
     :param output_feature_name: (string) Name of the output feature that is predicted and for which is provided ground truth
     :param top_n_classes: (list) List containing the number of classes to plot
-    :param model_names: (list) List of the names of the models to use as labels.
-    :param output_directory: (string) Directory where to save plots.
+    :param model_names: (list, default: None) List of the names of the models to use as labels.
+    :param output_directory: (string, default: None) Directory where to save plots.
              If not specified, plots will be displayed in a window
-    :param file_format: (string) File format of output plots - pdf or png
+    :param file_format: (string, default: 'pdf') File format of output plots - pdf or png
 
     # Return
 

--- a/ludwig/visualize.py
+++ b/ludwig/visualize.py
@@ -682,9 +682,12 @@ def learning_curves(
 ):
     """Show how model measures change over training and validation data epochs.
 
-     For each model and for each output feature and measure of the model,
-     it produces a line plot showing how that measure changed over the course
-     of the epochs of training on the training and validation sets.
+    For each model and for each output feature and measure of the model,
+    it produces a line plot showing how that measure changed over the course
+    of the epochs of training on the training and validation sets.
+
+    # Inputs
+
     :param train_stats_per_model: List containing train statistics per model
     :param output_feature_name: Name of the output feature that is predicted 
            and for which is provided ground truth

--- a/ludwig/visualize.py
+++ b/ludwig/visualize.py
@@ -2835,7 +2835,7 @@ def confusion_matrix(
             test_stats_per_model_list):
         for output_feature_name in output_feature_names:
             if 'confusion_matrix' in test_statistics[output_feature_name]:
-                confusion_matrix = np.array(
+                _confusion_matrix = np.array(
                     test_statistics[output_feature_name]['confusion_matrix']
                 )
                 model_name_name = model_names_list[i] if (
@@ -2847,12 +2847,12 @@ def confusion_matrix(
                         metadata[output_feature_name]:
                     labels = metadata[output_feature_name]['idx2str']
                 else:
-                    labels = list(range(len(confusion_matrix)))
+                    labels = list(range(len(_confusion_matrix)))
 
                 for k in top_n_classes:
-                    k = (min(k, confusion_matrix.shape[0])
-                         if k > 0 else confusion_matrix.shape[0])
-                    cm = confusion_matrix[:k, :k]
+                    k = (min(k, _confusion_matrix.shape[0])
+                         if k > 0 else _confusion_matrix.shape[0])
+                    cm = _confusion_matrix[:k, :k]
                     if normalize:
                         with np.errstate(divide='ignore', invalid='ignore'):
                             cm_norm = np.true_divide(cm,

--- a/ludwig/visualize.py
+++ b/ludwig/visualize.py
@@ -688,14 +688,16 @@ def learning_curves(
 
     # Inputs
 
-    :param train_stats_per_model: List containing train statistics per model
-    :param output_feature_name: Name of the output feature that is predicted 
+    :param train_stats_per_model: (list) List containing train statistics per model
+    :param output_feature_name: (string) Name of the output feature that is predicted
            and for which is provided ground truth
-    :param model_names: List of the names of the models to use as labels.
-    :param output_directory: Directory where to save plots.
+    :param model_names: (list) List of the names of the models to use as labels.
+    :param output_directory: (string) Directory where to save plots.
              If not specified, plots will be displayed in a window
-    :param file_format: File format of output plots - pdf or png
-    :return None:
+    :param file_format: (string) File format of output plots - pdf or png
+
+    # Return
+    :return: (None)
     """
     filename_template = 'learning_curves_{}_{}.' + file_format
     filename_template_path = generate_filename_template_path(
@@ -757,13 +759,19 @@ def compare_performance(
     For each model (in the aligned lists of test_statistics and model_names)
     it produces bars in a bar plot, one for each overall metric available
     in the test_statistics file for the specified output_feature_name.
+
+    # Inputs
+
     :param test_stats_per_model: List containing train statistics per model
     :param output_feature_name: Name of the output feature that is predicted and for which is provided ground truth
     :param model_names: List of the names of the models to use as labels.
     :param output_directory: Directory where to save plots.
              If not specified, plots will be displayed in a window
     :param file_format: File format of output plots - pdf or png
-    :return None:
+
+    # Return
+
+    :return: (None)
     """
     filename_template = 'compare_performance_{}.' + file_format
     filename_template_path = generate_filename_template_path(

--- a/ludwig/visualize.py
+++ b/ludwig/visualize.py
@@ -935,7 +935,7 @@ def compare_classifiers_performance_from_pred(
     :param predictions_per_model: (list) List containing the model predictions
            for the specified output_feature_name
     :param ground_truth: (ndarray) NumPy Array containing ground truth data
-    :param metadata: Model's input metadata
+    :param metadata: (dict) Model's input metadata
     :param output_feature_name: output_feature_name containing ground truth
     :param labels_limit: Maximum numbers of labels.
              If labels in dataset are higher than this number, "rare" label
@@ -1208,7 +1208,7 @@ def compare_classifiers_multiclass_multimetric(
     # Inputs
 
     :param test_stats_per_model: (list) List containing train statistics per model
-    :param metadata: () Model's input metadata
+    :param metadata: (dict) Model's input metadata
     :param output_feature_name: (string) Name of the output feature that is predicted and for which is provided ground truth
     :param top_n_classes: (list) List containing the number of classes to plot
     :param model_names: (list, default: None) List of the names of the models to use as labels.
@@ -1904,7 +1904,7 @@ def confidence_thresholding_data_vs_acc_subset_per_class(
 
     :param probabilities_per_model: (list) List of model probabilities
     :param ground_truth: (ndarray) NumPy Array containing ground truth data
-    :param metadata: () Model's input metadata
+    :param metadata: (dict) Model's input metadata
     :param top_n_classes: (list) List containing the number of classes to plot
     :param labels_limit: (int) Maximum numbers of labels.
     :param subset: (string) Type of the subset filtering
@@ -2806,7 +2806,7 @@ def confusion_matrix(
     # Inputs
 
     :param test_stats_per_model: (string) List containing train statistics per model
-    :param metadata: () Model's input metadata
+    :param metadata: (dict) Model's input metadata
     :param output_feature_name: (string) Name of the output feature that is predicted and for which is provided ground truth
     :param top_n_classes: (list) List containing the number of classes to plot
     :param normalize: (bool) Flag to normalize rows in confusion matrix
@@ -2933,7 +2933,7 @@ def frequency_vs_f1(
     # Inputs
 
     :param test_stats_per_model: (list) List containing train statistics per model
-    :param metadata: () Model's input metadata
+    :param metadata: (dict) Model's input metadata
     :param output_feature_name: (string) Name of the output feature that is predicted and for which is provided ground truth
     :param top_n_classes: (list) List containing the number of classes to plot
     :param model_names: (list, default: None) List of the names of the models to use as labels.

--- a/ludwig/visualize.py
+++ b/ludwig/visualize.py
@@ -762,12 +762,12 @@ def compare_performance(
 
     # Inputs
 
-    :param test_stats_per_model: List containing train statistics per model
-    :param output_feature_name: Name of the output feature that is predicted and for which is provided ground truth
-    :param model_names: List of the names of the models to use as labels.
-    :param output_directory: Directory where to save plots.
+    :param test_stats_per_model: (list) List containing train statistics per model
+    :param output_feature_name: (string) Name of the output feature that is predicted and for which is provided ground truth
+    :param model_names: (list) List of the names of the models to use as labels.
+    :param output_directory: (string) Directory where to save plots.
              If not specified, plots will be displayed in a window
-    :param file_format: File format of output plots - pdf or png
+    :param file_format: (string) File format of output plots - pdf or png
 
     # Return
 
@@ -844,16 +844,22 @@ def compare_classifiers_performance_from_prob(
     For each model it produces bars in a bar plot, one for each overall metric
     computed on the fly from the probabilities of predictions for the specified
     output_feature_name.
-    :param probabilities_per_model: List of model probabilities
-    :param ground_truth: NumPy Array containing ground truth data
-    :param top_n_classes: List containing the number of classes to plot
-    :param labels_limit: Maximum numbers of labels.
+
+    # Inputs
+
+    :param probabilities_per_model: (list) List of model probabilities
+    :param ground_truth: (ndarray) NumPy Array containing ground truth data
+    :param top_n_classes: (list) List containing the number of classes to plot
+    :param labels_limit: (int) Maximum numbers of labels.
              If labels in dataset are higher than this number, "rare" label
-    :param model_names: List of the names of the models to use as labels.
-    :param output_directory: Directory where to save plots.
+    :param model_names: (list) List of the names of the models to use as labels.
+    :param output_directory: (string) Directory where to save plots.
              If not specified, plots will be displayed in a window
-    :param file_format: File format of output plots - pdf or png
-    :return None:
+    :param file_format: (string) File format of output plots - pdf or png
+
+    # Return
+
+    :return: (None)
     """
     top_n_classes_list = convert_to_list(top_n_classes)
     k = top_n_classes_list[0]
@@ -923,9 +929,12 @@ def compare_classifiers_performance_from_pred(
 
     For each model it produces bars in a bar plot, one for each overall metric
     computed on the fly from the predictions for the specified output_feature_name.
-    :param predictions_per_model: List containing the model predictions
+
+    # Inputs
+
+    :param predictions_per_model: (list) List containing the model predictions
            for the specified output_feature_name
-    :param ground_truth: NumPy Array containing ground truth data
+    :param ground_truth: (ndarray) NumPy Array containing ground truth data
     :param metadata: Model's input metadata
     :param output_feature_name: output_feature_name containing ground truth
     :param labels_limit: Maximum numbers of labels.
@@ -934,7 +943,10 @@ def compare_classifiers_performance_from_pred(
     :param output_directory: Directory where to save plots.
              If not specified, plots will be displayed in a window
     :param file_format: File format of output plots - pdf or png
-    :return None:
+
+    # Return
+
+    :return: (None)
     """
     if labels_limit > 0:
         ground_truth[ground_truth > labels_limit] = labels_limit
@@ -1007,16 +1019,22 @@ def compare_classifiers_performance_subset(
      specified output_feature_name, considering only a subset of the full training set.
      The way the subset is obtained is using the top_n_classes and
      subset parameters.
-    :param probabilities_per_model: List of model probabilities
-    :param ground_truth: NumPy Array containing ground truth data
-    :param top_n_classes: List containing the number of classes to plot
-    :param labels_limit: Maximum numbers of labels.
-    :param subset: Type of the subset filtering
-    :param model_names: List of the names of the models to use as labels.
-    :param output_directory: Directory where to save plots.
+
+     # Inputs
+
+    :param probabilities_per_model: (list) List of model probabilities
+    :param ground_truth: (ndarray) NumPy Array containing ground truth data
+    :param top_n_classes: (list) List containing the number of classes to plot
+    :param labels_limit: (int) Maximum numbers of labels.
+    :param subset: () Type of the subset filtering
+    :param model_names: (list) List of the names of the models to use as labels.
+    :param output_directory: (string) Directory where to save plots.
              If not specified, plots will be displayed in a window
-    :param file_format: File format of output plots - pdf or png
-    :return None:
+    :param file_format: (string) File format of output plots - pdf or png
+
+    # Return
+
+    :return: (None)
     """
     top_n_classes_list = convert_to_list(top_n_classes)
     k = top_n_classes_list[0]
@@ -1116,16 +1134,22 @@ def compare_classifiers_performance_changing_k(
     For each model it produces a line plot that shows the Hits@K measure
     (that counts a prediction as correct if the model produces it among the
     first k) while changing k from 1 to top_k for the specified output_feature_name.
-    :param probabilities_per_model: List of model probabilities
-    :param ground_truth: NumPy Array containing ground truth data
-    :param top_k: Number of elements in the ranklist to consider
-    :param labels_limit: Maximum numbers of labels.
+
+    # Inputs
+
+    :param probabilities_per_model: (list) List of model probabilities
+    :param ground_truth: (ndarray) NumPy Array containing ground truth data
+    :param top_k: (int) Number of elements in the ranklist to consider
+    :param labels_limit: (int) Maximum numbers of labels.
              If labels in dataset are higher than this number, "rare" label
-    :param model_names: List of the names of the models to use as labels.
-    :param output_directory: Directory where to save plots.
+    :param model_names: (list) List of the names of the models to use as labels.
+    :param output_directory: (string) Directory where to save plots.
              If not specified, plots will be displayed in a window
-    :param file_format: File format of output plots - pdf or png
-    :return None:
+    :param file_format: (string) File format of output plots - pdf or png
+
+    # Return
+
+    :return: (None)
     """
     k = top_k
     if labels_limit > 0:
@@ -1180,16 +1204,20 @@ def compare_classifiers_multiclass_multimetric(
 
     For each model it produces four plots that show the precision,
     recall and F1 of the model on several classes for the specified output_feature_name.
-    :param test_stats_per_model: List containing train statistics per model
-    :param metadata: Model's input metadata
-    :param output_feature_name: Name of the output feature that is predicted and for which is provided ground truth
-    :param top_n_classes: List containing the number of classes to plot
-    :param model_names: List of the names of the models to use as labels.
-    :param output_directory: Directory where to save plots.
+
+    # Inputs
+
+    :param test_stats_per_model: (list) List containing train statistics per model
+    :param metadata: () Model's input metadata
+    :param output_feature_name: (string) Name of the output feature that is predicted and for which is provided ground truth
+    :param top_n_classes: (list) List containing the number of classes to plot
+    :param model_names: (list) List of the names of the models to use as labels.
+    :param output_directory: (string) Directory where to save plots.
              If not specified, plots will be displayed in a window
-    :param file_format: File format of output plots - pdf or png
-    :return None:
-    :return:
+    :param file_format: (string) File format of output plots - pdf or png
+
+    # Return
+    :return: (None)
     """
     filename_template = 'compare_classifiers_multiclass_multimetric_{}_{}_{}.' \
                         + file_format
@@ -1349,15 +1377,20 @@ def compare_classifiers_predictions(
 ):
     """Show two models comparision of their output_feature_name predictions.
 
-    :param predictions_per_model: List containing the model predictions
-    :param ground_truth: NumPy Array containing ground truth data
-    :param labels_limit: Maximum numbers of labels.
+    # Inputs
+
+    :param predictions_per_model: (list) List containing the model predictions
+    :param ground_truth: (ndarray) NumPy Array containing ground truth data
+    :param labels_limit: (int) Maximum numbers of labels.
              If labels in dataset are higher than this number, "rare" label
-    :param model_names: List of the names of the models to use as labels.
-    :param output_directory: Directory where to save plots.
+    :param model_names: (list) List of the names of the models to use as labels.
+    :param output_directory: (string) Directory where to save plots.
              If not specified, plots will be displayed in a window
-    :param file_format: File format of output plots - pdf or png
-    :return None:
+    :param file_format: (string) File format of output plots - pdf or png
+
+    # Return
+
+    :return: (None)
     """
     model_names_list = convert_to_list(model_names)
     name_c1 = (
@@ -1480,15 +1513,21 @@ def compare_classifiers_predictions_distribution(
 
     This visualization produces a radar plot comparing the distributions of
     predictions of the models for the first 10 classes of the specified output_feature_name.
-    :param predictions_per_model: List containing the model predictions
-    :param ground_truth: NumPy Array containing ground truth data
-    :param labels_limit: Maximum numbers of labels.
+
+    # Inputs
+
+    :param predictions_per_model: (list) List containing the model predictions
+    :param ground_truth: (ndarray) NumPy Array containing ground truth data
+    :param labels_limit: (int) Maximum numbers of labels.
              If labels in dataset are higher than this number, "rare" label
-    :param model_names: List of the names of the models to use as labels.
-    :param output_directory: Directory where to save plots.
+    :param model_names: (list) List of the names of the models to use as labels.
+    :param output_directory: (string) Directory where to save plots.
              If not specified, plots will be displayed in a window
-    :param file_format: File format of output plots - pdf or png
-    :return None:
+    :param file_format: (string) File format of output plots - pdf or png
+
+    # Return
+
+    :return: (None)
     """
     model_names_list = convert_to_list(model_names)
     if labels_limit > 0:
@@ -1541,15 +1580,21 @@ def confidence_thresholding(
     For each model it produces a pair of lines indicating the accuracy of
     the model and the data coverage while increasing a threshold (x axis) on
     the probabilities of predictions for the specified output_feature_name.
-    :param probabilities_per_model: List of model probabilities
-    :param ground_truth: NumPy Array containing ground truth data
-    :param labels_limit: Maximum numbers of labels.
+
+    # Inputs
+
+    :param probabilities_per_model: (list) List of model probabilities
+    :param ground_truth: (ndarray) NumPy Array containing ground truth data
+    :param labels_limit: (int) Maximum numbers of labels.
              If labels in dataset are higher than this number, "rare" label
-    :param model_names: List of the names of the models to use as labels.
-    :param output_directory: Directory where to save plots.
+    :param model_names: (list) List of the names of the models to use as labels.
+    :param output_directory: (sting) Directory where to save plots.
              If not specified, plots will be displayed in a window
-    :param file_format: File format of output plots - pdf or png
-    :return None:
+    :param file_format: (string) File format of output plots - pdf or png
+
+    # Return
+
+    :return: (None)
     """
     if labels_limit > 0:
         ground_truth[ground_truth > labels_limit] = labels_limit
@@ -1624,15 +1669,20 @@ def confidence_thresholding_data_vs_acc(
     confidence_thresholding is that it uses two axes instead of three,
     not visualizing the threshold and having coverage as x axis instead of
     the threshold.
-    :param probabilities_per_model: List of model probabilities
-    :param ground_truth: NumPy Array containing ground truth data
-    :param labels_limit: Maximum numbers of labels.
+
+    # Inputs
+
+    :param probabilities_per_model: (list) List of model probabilities
+    :param ground_truth: (ndarray) NumPy Array containing ground truth data
+    :param labels_limit:(int) Maximum numbers of labels.
              If labels in dataset are higher than this number, "rare" label
-    :param model_names: List of the names of the models to use as labels.
-    :param output_directory: Directory where to save plots.
+    :param model_names: (list) List of the names of the models to use as labels.
+    :param output_directory: (string) Directory where to save plots.
              If not specified, plots will be displayed in a window
-    :param file_format: File format of output plots - pdf or png
-    :return None:
+    :param file_format: (string) File format of output plots - pdf or png
+
+    # Return
+    :return: (None)
     """
     if labels_limit > 0:
         ground_truth[ground_truth > labels_limit] = labels_limit
@@ -1718,16 +1768,22 @@ def confidence_thresholding_data_vs_acc_subset(
      that is within the top n most frequent ones will be considered as test set,
      and the percentage of datapoints that have been kept from the original set
      will be displayed for each model.
-    :param probabilities_per_model: List of model probabilities
-    :param ground_truth: NumPy Array containing ground truth data
-    :param top_n_classes: List containing the number of classes to plot
-    :param labels_limit: Maximum numbers of labels.
-    :param subset: Type of the subset filtering
-    :param model_names: List of the names of the models to use as labels.
-    :param output_directory: Directory where to save plots.
+
+    # Inputs
+
+    :param probabilities_per_model: (list) List of model probabilities
+    :param ground_truth: (ndarray) NumPy Array containing ground truth data
+    :param top_n_classes: (list) List containing the number of classes to plot
+    :param labels_limit: (int) Maximum numbers of labels.
+    :param subset: (string) Type of the subset filtering
+    :param model_names: (list) List of the names of the models to use as labels.
+    :param output_directory: (string) Directory where to save plots.
              If not specified, plots will be displayed in a window
-    :param file_format: File format of output plots - pdf or png
-    :return None:
+    :param file_format: (string) File format of output plots - pdf or png
+
+    # Return
+
+    :return: (None)
     """
     top_n_classes_list = convert_to_list(top_n_classes)
     k = top_n_classes_list[0]
@@ -1843,17 +1899,22 @@ def confidence_thresholding_data_vs_acc_subset_per_class(
 
     The difference with confidence_thresholding_data_vs_acc_subset is that it
     produces one plot per class within the top_n_classes.
-    :param probabilities_per_model: List of model probabilities
-    :param ground_truth: NumPy Array containing ground truth data
-    :param metadata: Model's input metadata
-    :param top_n_classes: List containing the number of classes to plot
-    :param labels_limit: Maximum numbers of labels.
-    :param subset: Type of the subset filtering
-    :param model_names: List of the names of the models to use as labels.
-    :param output_directory: Directory where to save plots.
+
+    # Inputs
+
+    :param probabilities_per_model: (list) List of model probabilities
+    :param ground_truth: (ndarray) NumPy Array containing ground truth data
+    :param metadata: () Model's input metadata
+    :param top_n_classes: (list) List containing the number of classes to plot
+    :param labels_limit: (int) Maximum numbers of labels.
+    :param subset: (string) Type of the subset filtering
+    :param model_names: (list) List of the names of the models to use as labels.
+    :param output_directory: (string) Directory where to save plots.
              If not specified, plots will be displayed in a window
-    :param file_format: File format of output plots - pdf or png
-    :return None:
+    :param file_format: (string) File format of output plots - pdf or png
+
+    # Return
+    :return: (None)
     """
     filename_template = \
         'confidence_thresholding_data_vs_acc_subset_per_class_{}.' + file_format
@@ -1958,16 +2019,22 @@ def confidence_thresholding_2thresholds_2d(
     threshold_output_feature_names  as x and y axes and either the data coverage percentage or
     the accuracy as z axis. Each line represents a slice of the data
     coverage  surface projected onto the accuracy surface.
-    :param probabilities_per_model: List of model probabilities
-    :param ground_truths: List of NumPy Arrays containing ground truth data
-    :param threshold_output_feature_names: List of output_feature_names for 2d threshold
-    :param labels_limit: Maximum numbers of labels.
+
+    # Inputs
+
+    :param probabilities_per_model: (list) List of model probabilities
+    :param ground_truths: (list) List of NumPy Arrays containing ground truth data
+    :param threshold_output_feature_names: (list) List of output_feature_names for 2d threshold
+    :param labels_limit: (int) Maximum numbers of labels.
              If labels in dataset are higher than this number, "rare" label
-    :param model_names: Name of the model to use as label.
-    :param output_directory: Directory where to save plots.
+    :param model_names: (string) Name of the model to use as label.
+    :param output_directory: (string) Directory where to save plots.
              If not specified, plots will be displayed in a window
-    :param file_format: File format of output plots - pdf or png
-    :return None:
+    :param file_format: (string) File format of output plots - pdf or png
+
+    # Return
+
+    :return: (None)
     """
     try:
         validate_conf_treshholds_and_probabilities_2d_3d(
@@ -2144,15 +2211,21 @@ def confidence_thresholding_2thresholds_3d(
     confidence_thresholding_2thresholds_3d that have thresholds on the
     confidence of the predictions of the two threshold_output_feature_names as x and y axes
     and either the data coverage percentage or the accuracy as z axis.
-    :param probabilities_per_model: List of model probabilities
-    :param ground_truths: List of NumPy Arrays containing ground truth data
-    :param threshold_output_feature_names: List of output_feature_names for 2d threshold
-    :param labels_limit: Maximum numbers of labels.
+
+    # Inputs
+
+    :param probabilities_per_model: (list) List of model probabilities
+    :param ground_truths: (list) List of NumPy Arrays containing ground truth data
+    :param threshold_output_feature_names: (list) List of output_feature_names for 2d threshold
+    :param labels_limit: (int) Maximum numbers of labels.
              If labels in dataset are higher than this number, "rare" label
-    :param output_directory: Directory where to save plots.
+    :param output_directory: (string) Directory where to save plots.
              If not specified, plots will be displayed in a window
-    :param file_format: File format of output plots - pdf or png
-    :return None:
+    :param file_format: (string) File format of output plots - pdf or png
+
+    # Return
+
+    :return: (None)
     """
     try:
         validate_conf_treshholds_and_probabilities_2d_3d(
@@ -2260,16 +2333,22 @@ def binary_threshold_vs_metric(
     considered negative. It needs to be an integer, to figure out the
     association between classes and integers check the ground_truth_metadata
     JSON file.
-    :param probabilities_per_model: List of model probabilities
-    :param ground_truth: List of NumPy Arrays containing ground truth data
+
+    # Inputs
+
+    :param probabilities_per_model: (list) List of model probabilities
+    :param ground_truth: (list) List of NumPy Arrays containing ground truth data
     :param metrics: metrics to dispay (f1, precision, recall,
                     accuracy)
-    :param positive_label: Label of the positive class
-    :param model_names: List of the names of the models to use as labels.
-    :param output_directory: Directory where to save plots.
+    :param positive_label: (string) Label of the positive class
+    :param model_names: (list) List of the names of the models to use as labels.
+    :param output_directory: (string) Directory where to save plots.
              If not specified, plots will be displayed in a window
-    :param file_format: File format of output plots - pdf or png
-    :return None:
+    :param file_format: (string) File format of output plots - pdf or png
+
+    # Return
+
+    :return: (None)
     """
     probs = probabilities_per_model
     model_names_list = convert_to_list(model_names)
@@ -2370,14 +2449,20 @@ def roc_curves(
     be considered negative. It needs to be an integer, to figure out the
     association between classes and integers check the ground_truth_metadata
     JSON file.
-    :param probabilities_per_model: List of model probabilities
-    :param ground_truth: List of NumPy Arrays containing ground truth data
-    :param positive_label: Label of the positive class
-    :param model_names: List of the names of the models to use as labels.
-    :param output_directory: Directory where to save plots.
+
+    # Inputs
+
+    :param probabilities_per_model: (list) List of model probabilities
+    :param ground_truth: (list) List of NumPy Arrays containing ground truth data
+    :param positive_label: (string) Label of the positive class
+    :param model_names: (list) List of the names of the models to use as labels.
+    :param output_directory: (string) Directory where to save plots.
              If not specified, plots will be displayed in a window
-    :param file_format: File format of output plots - pdf or png
-    :return None:
+    :param file_format: (string) File format of output plots - pdf or png
+
+    # Return
+
+    :return: (None)
     """
     probs = probabilities_per_model
     model_names_list = convert_to_list(model_names)
@@ -2421,13 +2506,19 @@ def roc_curves_from_test_statistics(
     This visualization uses the output_feature_name, test_statistics and model_names
     parameters. output_feature_name needs to be binary feature. This visualization produces a
     line chart plotting the roc curves for the specified output_feature_name.
-    :param test_stats_per_model: List containing train statistics per model
-    :param output_feature_name: Name of the output feature that is predicted and for which is provided ground truth
-    :param model_names: List of the names of the models to use as labels.
-    :param output_directory: Directory where to save plots.
+
+    # Inputs
+
+    :param test_stats_per_model: (list) List containing train statistics per model
+    :param output_feature_name: (string) Name of the output feature that is predicted and for which is provided ground truth
+    :param model_names: (list) List of the names of the models to use as labels.
+    :param output_directory: (string) Directory where to save plots.
              If not specified, plots will be displayed in a window
-    :param file_format: File format of output plots - pdf or png
-    :return None:
+    :param file_format: (string) File format of output plots - pdf or png
+
+    # Return
+
+    :return: (None)
     """
     model_names_list = convert_to_list(model_names)
     filename_template = 'roc_curves_from_prediction_statistics.' + file_format
@@ -2476,16 +2567,22 @@ def calibration_1_vs_all(
     the  current class to be the true one and all others to be a false one,
     drawing the distribution for each model (in the aligned lists of
     probabilities and model_names).
-    :param probabilities_per_model: List of model probabilities
-    :param ground_truth: NumPy Array containing ground truth data
-    :param top_n_classes: List containing the number of classes to plot
-    :param labels_limit: Maximum numbers of labels.
+
+    # Inputs
+
+    :param probabilities_per_model: (list) List of model probabilities
+    :param ground_truth: (ndarray) NumPy Array containing ground truth data
+    :param top_n_classes: (list) List containing the number of classes to plot
+    :param labels_limit: (int) Maximum numbers of labels.
              If labels in dataset are higher than this number, "rare" label
-    :param model_names: List of the names of the models to use as labels.
-    :param output_directory: Directory where to save plots.
+    :param model_names: (list) List of the names of the models to use as labels.
+    :param output_directory: (string) Directory where to save plots.
              If not specified, plots will be displayed in a window
-    :param file_format: File format of output plots - pdf or png
-    :return None:
+    :param file_format: (string) File format of output plots - pdf or png
+
+    # String
+
+    :return: (None)
     """
     probs = probabilities_per_model
     model_names_list = convert_to_list(model_names)
@@ -2594,15 +2691,20 @@ def calibration_multiclass(
     """Show models probability of predictions for each class of the the
     specified output_feature_name.
 
-    :param probabilities_per_model: List of model probabilities
-    :param ground_truth: NumPy Array containing ground truth data
-    :param labels_limit: Maximum numbers of labels.
+    # Inputs
+
+    :param probabilities_per_model: (list) List of model probabilities
+    :param ground_truth: (ndarray) NumPy Array containing ground truth data
+    :param labels_limit: (int) Maximum numbers of labels.
              If labels in dataset are higher than this number, "rare" label
-    :param model_names: List of the names of the models to use as labels.
-    :param output_directory: Directory where to save plots.
+    :param model_names: (list) List of the names of the models to use as labels.
+    :param output_directory: (string) Directory where to save plots.
              If not specified, plots will be displayed in a window
-    :param file_format: File format of output plots - pdf or png
-    :return None:
+    :param file_format: (string) File format of output plots - pdf or png
+
+    # Return
+
+    :return: (None)
     """
     probs = probabilities_per_model
     model_names_list = convert_to_list(model_names)
@@ -2700,17 +2802,22 @@ def confusion_matrix(
     it  produces a heatmap of the confusion matrix in the predictions for
     each  output_feature_name that has a confusion matrix in test_statistics. The value of
     top_n_classes limits the heatmap to the n most frequent classes.
-    :param test_stats_per_model: List containing train statistics per model
-    :param metadata: Model's input metadata
-    :param output_feature_name: Name of the output feature that is predicted and for which is provided ground truth
-    :param top_n_classes: List containing the number of classes to plot
-    :param normalize: Flag to normalize rows in confusion matrix
-    :param model_names: List of the names of the models to use as labels.
-    :param output_directory: Directory where to save plots.
+
+    # Inputs
+
+    :param test_stats_per_model: (string) List containing train statistics per model
+    :param metadata: () Model's input metadata
+    :param output_feature_name: (string) Name of the output feature that is predicted and for which is provided ground truth
+    :param top_n_classes: (list) List containing the number of classes to plot
+    :param normalize: (boolean) Flag to normalize rows in confusion matrix
+    :param model_names: (list) List of the names of the models to use as labels.
+    :param output_directory: (string) Directory where to save plots.
              If not specified, plots will be displayed in a window
-    :param file_format: File format of output plots - pdf or png
-    :return None:
-    :return:
+    :param file_format: (string) File format of output plots - pdf or png
+
+    # Return
+
+    :return: (None)
     """
     test_stats_per_model_list = test_stats_per_model
     model_names_list = convert_to_list(model_names)
@@ -2822,16 +2929,21 @@ def frequency_vs_f1(
     The second plot has the same structure of the first one,
      but the axes are flipped and the classes on the x axis are sorted by
      frequency.
-    :param test_stats_per_model: List containing train statistics per model
-    :param metadata: Model's input metadata
-    :param output_feature_name: Name of the output feature that is predicted and for which is provided ground truth
-    :param top_n_classes: List containing the number of classes to plot
-    :param model_names: List of the names of the models to use as labels.
-    :param output_directory: Directory where to save plots.
+
+    # Inputs
+
+    :param test_stats_per_model: (list) List containing train statistics per model
+    :param metadata: () Model's input metadata
+    :param output_feature_name: (string) Name of the output feature that is predicted and for which is provided ground truth
+    :param top_n_classes: (list) List containing the number of classes to plot
+    :param model_names: (list) List of the names of the models to use as labels.
+    :param output_directory: (string) Directory where to save plots.
              If not specified, plots will be displayed in a window
-    :param file_format: File format of output plots - pdf or png
-    :return None:
-    :return:
+    :param file_format: (string) File format of output plots - pdf or png
+
+    # Return
+
+    :return: (None)
     """
     test_stats_per_model_list = test_stats_per_model
     model_names_list = convert_to_list(model_names)

--- a/mkdocs/code_doc_autogen.py
+++ b/mkdocs/code_doc_autogen.py
@@ -459,10 +459,13 @@ if __name__ == '__main__':
 
     print('Generating docs for Ludwig %s.' % ludwig.__version__)
     for page_data in PAGES:
+        classes = []
+        functions = []
+        methods = []
         if 'classes' in page_data.keys():
             classes = read_page_data(page_data, 'classes')
         elif 'functions' in page_data.keys():
-            classes = read_page_data(page_data, 'functions')
+            functions = read_page_data(page_data, 'functions')
         else:
             raise TypeError('Invalid type specified in page_data')
 

--- a/mkdocs/code_doc_autogen.py
+++ b/mkdocs/code_doc_autogen.py
@@ -398,17 +398,17 @@ def collect_class_methods(cls, methods):
 
 
 def render_function(function, method=True):
-    subblocks = []
+    _subblocks = []
     _signature = get_function_signature(function, method=method)
     if method:
         _signature = _signature.replace(
             clean_module_name(function.__module__) + '.', '')
-    subblocks.append('## ' + function.__name__ + '\n')
-    subblocks.append(code_snippet(_signature))
+    _subblocks.append('## ' + function.__name__ + '\n')
+    _subblocks.append(code_snippet(_signature))
     _docstring = function.__doc__
     if _docstring:
-        subblocks.append(process_docstring(_docstring))
-    return '\n\n'.join(subblocks)
+        _subblocks.append(process_docstring(_docstring))
+    return '\n\n'.join(_subblocks)
 
 
 def read_page_data(page_data, type):

--- a/mkdocs/code_doc_autogen.py
+++ b/mkdocs/code_doc_autogen.py
@@ -297,17 +297,17 @@ def process_list_block(_docstring, starting_point, section_end,
     return _docstring, block
 
 
-def process_docstring(docstring):
+def process_docstring(_docstring):
     # First, extract code blocks and process them.
     code_blocks = []
-    if '```' in docstring:
-        tmp = docstring[:]
+    if '```' in _docstring:
+        tmp = _docstring[:]
         while '```' in tmp:
             tmp = tmp[tmp.find('```'):]
             index = tmp[3:].find('```') + 6
             snippet = tmp[:index]
             # Place marker in docstring for later reinjection.
-            docstring = docstring.replace(
+            _docstring = _docstring.replace(
                 snippet, '$CODE_BLOCK_%d' % len(code_blocks))
             snippet_lines = snippet.split('\n')
             # Remove leading spaces.
@@ -338,47 +338,47 @@ def process_docstring(docstring):
 
     # Format docstring lists.
     section_regex = r'\n( +)# (.*)\n'
-    section_idx = re.search(section_regex, docstring)
+    section_idx = re.search(section_regex, _docstring)
     shift = 0
     sections = {}
     while section_idx and section_idx.group(2):
         anchor = section_idx.group(2)
         leading_spaces = len(section_idx.group(1))
         shift += section_idx.end()
-        next_section_idx = re.search(section_regex, docstring[shift:])
+        next_section_idx = re.search(section_regex, _docstring[shift:])
         if next_section_idx is None:
             section_end = -1
         else:
             section_end = shift + next_section_idx.start()
         marker = '$' + anchor.replace(' ', '_') + '$'
-        docstring, content = process_list_block(docstring,
-                                                shift,
-                                                section_end,
-                                                leading_spaces,
-                                                marker)
+        _docstring, content = process_list_block(_docstring,
+                                                 shift,
+                                                 section_end,
+                                                 leading_spaces,
+                                                 marker)
         sections[marker] = content
         # `docstring` has changed, so we can't use `next_section_idx` anymore
         # we have to recompute it
-        section_idx = re.search(section_regex, docstring[shift:])
+        section_idx = re.search(section_regex, _docstring[shift:])
 
     # Format docstring section titles.
-    docstring = re.sub(r'\n(\s+)# (.*)\n',
+    _docstring = re.sub(r'\n(\s+)# (.*)\n',
                        r'\n\1__\2__\n\n',
-                       docstring)
+                        _docstring)
 
     # Strip all remaining leading spaces.
-    lines = docstring.split('\n')
-    docstring = '\n'.join([line.lstrip(' ') for line in lines])
+    lines = _docstring.split('\n')
+    _docstring = '\n'.join([line.lstrip(' ') for line in lines])
 
     # Reinject list blocks.
     for marker, content in sections.items():
-        docstring = docstring.replace(marker, content)
+        _docstring = _docstring.replace(marker, content)
 
     # Reinject code blocks.
     for i, code_block in enumerate(code_blocks):
-        docstring = docstring.replace(
+        _docstring = _docstring.replace(
             '$CODE_BLOCK_%d' % i, code_block)
-    return docstring
+    return _docstring
 
 
 def read_file(_path):

--- a/mkdocs/code_doc_autogen.py
+++ b/mkdocs/code_doc_autogen.py
@@ -459,7 +459,12 @@ if __name__ == '__main__':
 
     print('Generating docs for Ludwig %s.' % ludwig.__version__)
     for page_data in PAGES:
-        classes = read_page_data(page_data, 'classes')
+        if 'classes' in page_data.keys():
+            classes = read_page_data(page_data, 'classes')
+        elif 'functions' in page_data.keys():
+            classes = read_page_data(page_data, 'functions')
+        else:
+            raise TypeError('Invalid type specified in page_data')
 
         blocks = []
         for element in classes:

--- a/mkdocs/code_doc_autogen.py
+++ b/mkdocs/code_doc_autogen.py
@@ -397,15 +397,15 @@ def collect_class_methods(cls, methods):
     return methods
 
 
-def render_function(function, method=True):
+def render_function(_function, method=True):
     _subblocks = []
-    _signature = get_function_signature(function, method=method)
+    _signature = get_function_signature(_function, method=method)
     if method:
         _signature = _signature.replace(
-            clean_module_name(function.__module__) + '.', '')
-    _subblocks.append('## ' + function.__name__ + '\n')
+            clean_module_name(_function.__module__) + '.', '')
+    _subblocks.append('## ' + _function.__name__ + '\n')
     _subblocks.append(code_snippet(_signature))
-    _docstring = function.__doc__
+    _docstring = _function.__doc__
     if _docstring:
         _subblocks.append(process_docstring(_docstring))
     return '\n\n'.join(_subblocks)

--- a/mkdocs/code_doc_autogen.py
+++ b/mkdocs/code_doc_autogen.py
@@ -367,8 +367,13 @@ def process_docstring(_docstring):
                         _docstring)
 
     # Strip all remaining leading spaces.
+    # generator function to resolve deepsource.io major issue
+    def strip_leading_spaces(these_lines):
+        for l in these_lines:
+            yield l.lstrip(' ')
+
     lines = _docstring.split('\n')
-    _docstring = '\n'.join([line.lstrip(' ') for line in lines])
+    _docstring = '\n'.join(strip_leading_spaces(lines))
 
     # Reinject list blocks.
     for marker, content in sections.items():
@@ -490,9 +495,13 @@ if __name__ == '__main__':
             if methods:
                 subblocks.append('\n---')
                 subblocks.append('# ' + cls.__name__ + ' methods\n')
-                subblocks.append('\n---\n'.join(
-                    [render_function(method, _method=True) for method in
-                     methods]))
+
+                # generator function to resolve deepsource.io major issue
+                def generate_render_functions(_methods):
+                    for m in _methods:
+                        yield render_function(m, _method=True)
+
+                subblocks.append('\n---\n'.join(generate_render_functions(methods)))
             blocks.append('\n'.join(subblocks))
 
         methods = read_page_data(page_data, 'methods')

--- a/mkdocs/code_doc_autogen.py
+++ b/mkdocs/code_doc_autogen.py
@@ -390,17 +390,17 @@ def collect_class_methods(cls, methods):
     if isinstance(methods, (list, tuple)):
         return [getattr(cls, m) if isinstance(m, str) else m for m in methods]
     methods = []
-    for _, method in inspect.getmembers(cls, predicate=inspect.isroutine):
-        if method.__name__[0] == '_' or method.__name__ in EXCLUDE:
+    for _, _method in inspect.getmembers(cls, predicate=inspect.isroutine):
+        if _method.__name__[0] == '_' or _method.__name__ in EXCLUDE:
             continue
-        methods.append(method)
+        methods.append(_method)
     return methods
 
 
-def render_function(_function, method=True):
+def render_function(_function, _method=True):
     _subblocks = []
-    _signature = get_function_signature(_function, method=method)
-    if method:
+    _signature = get_function_signature(_function, method=_method)
+    if _method:
         _signature = _signature.replace(
             clean_module_name(_function.__module__) + '.', '')
     _subblocks.append('## ' + _function.__name__ + '\n')
@@ -491,19 +491,19 @@ if __name__ == '__main__':
                 subblocks.append('\n---')
                 subblocks.append('# ' + cls.__name__ + ' methods\n')
                 subblocks.append('\n---\n'.join(
-                    [render_function(method, method=True) for method in
+                    [render_function(method, _method=True) for method in
                      methods]))
             blocks.append('\n'.join(subblocks))
 
         methods = read_page_data(page_data, 'methods')
 
         for method in methods:
-            blocks.append(render_function(method, method=True))
+            blocks.append(render_function(method, _method=True))
 
         functions = read_page_data(page_data, 'functions')
 
         for function in functions:
-            blocks.append(render_function(function, method=False))
+            blocks.append(render_function(function, _method=False))
 
         if not blocks:
             raise RuntimeError('Found no content for page ' +

--- a/mkdocs/code_doc_autogen.py
+++ b/mkdocs/code_doc_autogen.py
@@ -224,18 +224,18 @@ def count_leading_spaces(s):
         return 0
 
 
-def process_list_block(docstring, starting_point, section_end,
+def process_list_block(_docstring, starting_point, section_end,
                        leading_spaces, marker):
-    ending_point = docstring.find('\n\n', starting_point)
-    block = docstring[starting_point:(None if ending_point == -1 else
+    ending_point = _docstring.find('\n\n', starting_point)
+    block = _docstring[starting_point:(None if ending_point == -1 else
                                       ending_point - 1)]
     # Place marker for later reinjection.
-    docstring_slice = docstring[
+    docstring_slice = _docstring[
                       starting_point:None if section_end == -1 else section_end].replace(
         block, marker)
-    docstring = (docstring[:starting_point]
+    _docstring = (_docstring[:starting_point]
                  + docstring_slice
-                 + docstring[section_end:])
+                 + _docstring[section_end:])
     lines = block.split('\n')
     # Remove the computed number of leading white spaces from each line.
     lines = [re.sub('^' + ' ' * leading_spaces, '', line) for line in lines]
@@ -294,7 +294,7 @@ def process_list_block(docstring, starting_point, section_end,
             lines[i] = '- __return__{}:{}'.format(inside_brackets, line)
 
     block = '\n'.join(lines)
-    return docstring, block
+    return _docstring, block
 
 
 def process_docstring(docstring):
@@ -381,9 +381,9 @@ def process_docstring(docstring):
     return docstring
 
 
-def read_file(path):
-    with open(path) as f:
-        return f.read()
+def read_file(_path):
+    with open(_path) as _f:
+        return _f.read()
 
 
 def collect_class_methods(_cls, _methods):

--- a/mkdocs/code_doc_autogen.py
+++ b/mkdocs/code_doc_autogen.py
@@ -192,20 +192,20 @@ def clean_module_name(name):
     return name
 
 
-def class_to_docs_link(cls):
-    module_name = clean_module_name(cls.__module__)
+def class_to_docs_link(_cls):
+    module_name = clean_module_name(_cls.__module__)
     module_name = module_name[6:]
-    link = ROOT + module_name.replace('.', '/') + '#' + cls.__name__.lower()
+    link = ROOT + module_name.replace('.', '/') + '#' + _cls.__name__.lower()
     return link
 
 
-def class_to_source_link(cls):
-    module_name = clean_module_name(cls.__module__)
-    path = module_name.replace('.', '/')
-    path += '.py'
-    line = inspect.getsourcelines(cls)[-1]
+def class_to_source_link(_cls):
+    module_name = clean_module_name(_cls.__module__)
+    _path = module_name.replace('.', '/')
+    _path += '.py'
+    line = inspect.getsourcelines(_cls)[-1]
     link = ('https://github.com/uber/'
-            'ludwig/blob/master/' + path + '#L' + str(line))
+            'ludwig/blob/master/' + _path + '#L' + str(line))
     return '[[source]](' + link + ')'
 
 

--- a/mkdocs/code_doc_autogen.py
+++ b/mkdocs/code_doc_autogen.py
@@ -386,15 +386,15 @@ def read_file(path):
         return f.read()
 
 
-def collect_class_methods(cls, methods):
-    if isinstance(methods, (list, tuple)):
-        return [getattr(cls, m) if isinstance(m, str) else m for m in methods]
-    methods = []
-    for _, _method in inspect.getmembers(cls, predicate=inspect.isroutine):
+def collect_class_methods(_cls, _methods):
+    if isinstance(_methods, (list, tuple)):
+        return [getattr(_cls, m) if isinstance(m, str) else m for m in _methods]
+    _methods = []
+    for _, _method in inspect.getmembers(_cls, predicate=inspect.isroutine):
         if _method.__name__[0] == '_' or _method.__name__ in EXCLUDE:
             continue
-        methods.append(_method)
-    return methods
+        _methods.append(_method)
+    return _methods
 
 
 def render_function(_function, _method=True):

--- a/mkdocs/code_doc_autogen.py
+++ b/mkdocs/code_doc_autogen.py
@@ -139,7 +139,7 @@ def get_function_signature(_function, _method=True):
     else:
         _signature = inspect.getargspec(wrapped)
     defaults = _signature.defaults
-    if _method and len(_signature.args) > 0 and _signature.args[0] == 'self':
+    if _method and _signature.args and _signature.args[0] == 'self':
         args = _signature.args[1:]
     else:
         args = _signature.args

--- a/mkdocs/code_doc_autogen.py
+++ b/mkdocs/code_doc_autogen.py
@@ -416,10 +416,10 @@ def render_function(_function, _method=True):
     return '\n\n'.join(_subblocks)
 
 
-def read_page_data(page_data, type):
+def read_page_data(_page_data, type):
     assert type in ['classes', 'functions', 'methods']
-    data = page_data.get(type, [])
-    for module in page_data.get('all_module_{}'.format(type), []):
+    data = _page_data.get(type, [])
+    for module in _page_data.get('all_module_{}'.format(type), []):
         module_data = []
         for name in dir(module):
             if name[0] == '_' or name in EXCLUDE:

--- a/mkdocs/code_doc_autogen.py
+++ b/mkdocs/code_doc_autogen.py
@@ -132,24 +132,24 @@ ROOT = 'http://ludwig.ai/'
 OUTPUT_DIR = 'docs'
 
 
-def get_function_signature(function, method=True):
-    wrapped = getattr(function, '_original_function', None)
+def get_function_signature(_function, _method=True):
+    wrapped = getattr(_function, '_original_function', None)
     if wrapped is None:
-        signature = inspect.getargspec(function)
+        _signature = inspect.getargspec(_function)
     else:
-        signature = inspect.getargspec(wrapped)
-    defaults = signature.defaults
-    if method and len(signature.args) > 0 and signature.args[0] == 'self':
-        args = signature.args[1:]
+        _signature = inspect.getargspec(wrapped)
+    defaults = _signature.defaults
+    if _method and len(_signature.args) > 0 and _signature.args[0] == 'self':
+        args = _signature.args[1:]
     else:
-        args = signature.args
+        args = _signature.args
     if defaults:
         kwargs = zip(args[-len(defaults):], defaults)
         args = args[:-len(defaults)]
     else:
         kwargs = []
     st = '%s.%s(\n' % (
-        clean_module_name(function.__module__), function.__name__)
+        clean_module_name(_function.__module__), _function.__name__)
 
     for a in args:
         st += '  {},\n'.format(str(a))
@@ -158,32 +158,32 @@ def get_function_signature(function, method=True):
             v = '\'' + v + '\''
         st += '  {}={},\n'.format(str(a), str(v))
     if kwargs or args:
-        signature = st[:-2] + '\n)'
+        _signature = st[:-2] + '\n)'
     else:
-        signature = st + ')'
-    return post_process_signature(signature)
+        _signature = st + ')'
+    return post_process_signature(_signature)
 
 
-def get_class_signature(cls):
+def get_class_signature(_cls):
     try:
-        class_signature = get_function_signature(cls.__init__)
-        class_signature = class_signature.replace('__init__', cls.__name__)
+        class_signature = get_function_signature(_cls.__init__)
+        class_signature = class_signature.replace('__init__', _cls.__name__)
     except (TypeError, AttributeError):
         # in case the class inherits from object and does not
         # define __init__
         class_signature = "{clean_module_name}.{cls_name}()".format(
-            clean_module_name=clean_module_name(cls.__module__),
-            cls_name=cls.__name__
+            clean_module_name=clean_module_name(_cls.__module__),
+            cls_name=_cls.__name__
         )
     return post_process_signature(class_signature)
 
 
-def post_process_signature(signature):
-    parts = re.split(r'\.(?!\d)', signature)
+def post_process_signature(_signature):
+    parts = re.split(r'\.(?!\d)', _signature)
     if len(parts) >= 4:
         if parts[1] == 'api':
-            signature = 'ludwig.' + '.'.join(parts[2:])
-    return signature
+            _signature = 'ludwig.' + '.'.join(parts[2:])
+    return _signature
 
 
 def clean_module_name(name):
@@ -399,7 +399,7 @@ def collect_class_methods(_cls, _methods):
 
 def render_function(_function, _method=True):
     _subblocks = []
-    _signature = get_function_signature(_function, method=_method)
+    _signature = get_function_signature(_function, _method=_method)
     if _method:
         _signature = _signature.replace(
             clean_module_name(_function.__module__) + '.', '')

--- a/mkdocs/code_doc_autogen.py
+++ b/mkdocs/code_doc_autogen.py
@@ -135,9 +135,9 @@ OUTPUT_DIR = 'docs'
 def get_function_signature(_function, _method=True):
     wrapped = getattr(_function, '_original_function', None)
     if wrapped is None:
-        _signature = inspect.getargspec(_function)
+        _signature = inspect.getfullargspec(_function)
     else:
-        _signature = inspect.getargspec(wrapped)
+        _signature = inspect.getfullargspec(wrapped)
     defaults = _signature.defaults
     if _method and _signature.args and _signature.args[0] == 'self':
         args = _signature.args[1:]

--- a/mkdocs/code_doc_autogen.py
+++ b/mkdocs/code_doc_autogen.py
@@ -399,15 +399,15 @@ def collect_class_methods(cls, methods):
 
 def render_function(function, method=True):
     subblocks = []
-    signature = get_function_signature(function, method=method)
+    _signature = get_function_signature(function, method=method)
     if method:
-        signature = signature.replace(
+        _signature = _signature.replace(
             clean_module_name(function.__module__) + '.', '')
     subblocks.append('## ' + function.__name__ + '\n')
-    subblocks.append(code_snippet(signature))
-    docstring = function.__doc__
-    if docstring:
-        subblocks.append(process_docstring(docstring))
+    subblocks.append(code_snippet(_signature))
+    _docstring = function.__doc__
+    if _docstring:
+        subblocks.append(process_docstring(_docstring))
     return '\n\n'.join(subblocks)
 
 

--- a/mkdocs/docs/api/LudwigModel.md
+++ b/mkdocs/docs/api/LudwigModel.md
@@ -15,8 +15,8 @@ __Inputs__
 
 
 - __model_definition__ (dict): a dictionary containing information needed
-   to build a model. Refer to the [User Guide](http://ludwig.ai/user_guide/#model-definition) 
-   for details.
+   to build a model. Refer to the [User Guide]
+   (http://ludwig.ai/user_guide/#model-definition) for details.
 - __model_definition_file__ (string, optional, default: `None`): path to
    a YAML file containing the model definition. If available it will be
    used instead of the model_definition dict.

--- a/mkdocs/docs/api/LudwigModel.md
+++ b/mkdocs/docs/api/LudwigModel.md
@@ -15,8 +15,8 @@ __Inputs__
 
 
 - __model_definition__ (dict): a dictionary containing information needed
-   to build a model. Refer to the [User Guide]
-   (http://ludwig.ai/user_guide/#model-definition) for details.
+   to build a model. Refer to the [User Guide](http://ludwig.ai/user_guide/#model-definition) 
+   for details.
 - __model_definition_file__ (string, optional, default: `None`): path to
    a YAML file containing the model definition. If available it will be
    used instead of the model_definition dict.

--- a/mkdocs/docs/api/LudwigModel.md
+++ b/mkdocs/docs/api/LudwigModel.md
@@ -3,7 +3,7 @@
 
 ```python
 ludwig.api.LudwigModel(
-  model_definition,
+  model_definition=None,
   model_definition_file=None,
   logging_level=40
 )
@@ -15,8 +15,8 @@ __Inputs__
 
 
 - __model_definition__ (dict): a dictionary containing information needed
-   to build a model. Refer to the [User Guide](http://ludwig.ai/user_guide/#model-definition) 
-   for details.
+   to build a model. Refer to the [User Guide]
+   (http://ludwig.ai/user_guide/#model-definition) for details.
 - __model_definition_file__ (string, optional, default: `None`): path to
    a YAML file containing the model definition. If available it will be
    used instead of the model_definition dict.

--- a/mkdocs/docs/api/visualization.md
+++ b/mkdocs/docs/api/visualization.md
@@ -17,15 +17,22 @@ Show how model measures change over training and validation data epochs.
 For each model and for each output feature and measure of the model,
 it produces a line plot showing how that measure changed over the course
 of the epochs of training on the training and validation sets.
-:param train_stats_per_model: List containing train statistics per model
-:param output_feature_name: Name of the output feature that is predicted 
-and for which is provided ground truth
-:param model_names: List of the names of the models to use as labels.
-:param output_directory: Directory where to save plots.
-If not specified, plots will be displayed in a window
-:param file_format: File format of output plots - pdf or png
-:return None:
 
+__Inputs__
+
+
+- __train_stats_per_model__ (list): List containing train statistics per model
+- __output_feature_name__ (string): Name of the output feature that is predicted
+   and for which is provided ground truth
+- __model_names__ (list, default: None): List of the names of the models to use as labels.
+- __output_directory__ (string, default: None): Directory where to save plots.
+     If not specified, plots will be displayed in a window
+- __file_format__ (string, default: 'pdf'): File format of output plots - pdf or png
+
+__Return__
+
+- __return__ (None):
+ 
 ----
 
 ## compare_performance
@@ -48,14 +55,22 @@ Produces model comparision barplot visualization for each overall metric
 For each model (in the aligned lists of test_statistics and model_names)
 it produces bars in a bar plot, one for each overall metric available
 in the test_statistics file for the specified output_feature_name.
-:param test_stats_per_model: List containing train statistics per model
-:param output_feature_name: Name of the output feature that is predicted and for which is provided ground truth
-:param model_names: List of the names of the models to use as labels.
-:param output_directory: Directory where to save plots.
-If not specified, plots will be displayed in a window
-:param file_format: File format of output plots - pdf or png
-:return None:
 
+__Inputs__
+
+
+- __test_stats_per_model__ (list): List containing train statistics per model
+- __output_feature_name__ (string): Name of the output feature that is predicted and for which is provided ground truth
+- __model_names__ (list, default: None): List of the names of the models to use as labels.
+- __output_directory__ (string, default: None): Directory where to save plots.
+     If not specified, plots will be displayed in a window
+- __file_format__ (string, default: 'pdf'): File format of output plots - pdf or png
+
+__Return__
+
+
+- __return__ (None):
+ 
 ----
 
 ## compare_classifiers_performance_from_prob
@@ -79,17 +94,25 @@ Produces model comparision barplot visualization from probabilities.
 For each model it produces bars in a bar plot, one for each overall metric
 computed on the fly from the probabilities of predictions for the specified
 output_feature_name.
-:param probabilities_per_model: List of model probabilities
-:param ground_truth: NumPy Array containing ground truth data
-:param top_n_classes: List containing the number of classes to plot
-:param labels_limit: Maximum numbers of labels.
-If labels in dataset are higher than this number, "rare" label
-:param model_names: List of the names of the models to use as labels.
-:param output_directory: Directory where to save plots.
-If not specified, plots will be displayed in a window
-:param file_format: File format of output plots - pdf or png
-:return None:
 
+__Inputs__
+
+
+- __probabilities_per_model__ (list): List of model probabilities
+- __ground_truth__ (ndarray): NumPy Array containing ground truth data
+- __top_n_classes__ (list): List containing the number of classes to plot
+- __labels_limit__ (int): Maximum numbers of labels.
+     If labels in dataset are higher than this number, "rare" label
+- __model_names__ (list, default: None): List of the names of the models to use as labels.
+- __output_directory__ (string, default: None): Directory where to save plots.
+     If not specified, plots will be displayed in a window
+- __file_format__ (string, default: 'pdf'): File format of output plots - pdf or png
+
+__Return__
+
+
+- __return__ (None):
+ 
 ----
 
 ## compare_classifiers_performance_from_pred
@@ -113,19 +136,27 @@ Produces model comparision barplot visualization from predictions.
 
 For each model it produces bars in a bar plot, one for each overall metric
 computed on the fly from the predictions for the specified output_feature_name.
-:param predictions_per_model: List containing the model predictions
-for the specified output_feature_name
-:param ground_truth: NumPy Array containing ground truth data
-:param metadata: Model's input metadata
-:param output_feature_name: output_feature_name containing ground truth
-:param labels_limit: Maximum numbers of labels.
-If labels in dataset are higher than this number, "rare" label
-:param model_names: List of the names of the models to use as labels.
-:param output_directory: Directory where to save plots.
-If not specified, plots will be displayed in a window
-:param file_format: File format of output plots - pdf or png
-:return None:
 
+__Inputs__
+
+
+- __predictions_per_model__ (list): List containing the model predictions
+   for the specified output_feature_name
+- __ground_truth__ (ndarray): NumPy Array containing ground truth data
+- __metadata__ (dict): Model's input metadata
+- __output_feature_name__ (output_feature_name: output_feature_name containing ground trut):output_feature_name: output_feature_name containing ground truth
+- __labels_limit__ (labels_limit: Maximum numbers of labels):labels_limit: Maximum numbers of labels.
+     If labels in dataset are higher than this number, "rare" label
+- __model_names__ (model_names: List of the names of the models to use as labels):model_names: List of the names of the models to use as labels.
+- __output_directory__ (output_directory: Directory where to save plots):output_directory: Directory where to save plots.
+     If not specified, plots will be displayed in a window
+- __file_format__ (file_format: File format of output plots - pdf or p):file_format: File format of output plots - pdf or png
+
+__Return__
+
+
+- __return__ (None):
+ 
 ----
 
 ## compare_classifiers_performance_subset
@@ -152,17 +183,25 @@ computed on the fly from the probabilities predictions for the
 specified output_feature_name, considering only a subset of the full training set.
 The way the subset is obtained is using the top_n_classes and
 subset parameters.
-:param probabilities_per_model: List of model probabilities
-:param ground_truth: NumPy Array containing ground truth data
-:param top_n_classes: List containing the number of classes to plot
-:param labels_limit: Maximum numbers of labels.
-:param subset: Type of the subset filtering
-:param model_names: List of the names of the models to use as labels.
-:param output_directory: Directory where to save plots.
-If not specified, plots will be displayed in a window
-:param file_format: File format of output plots - pdf or png
-:return None:
 
+__Inputs__
+
+
+- __probabilities_per_model__ (list): List of model probabilities
+- __ground_truth__ (ndarray): NumPy Array containing ground truth data
+- __top_n_classes__ (list): List containing the number of classes to plot
+- __labels_limit__ (int): Maximum numbers of labels.
+- __subset__ (): Type of the subset filtering
+- __model_names__ (list, default: None): List of the names of the models to use as labels.
+- __output_directory__ (string, default: None): Directory where to save plots.
+    If not specified, plots will be displayed in a window
+- __file_format__ (string, default: 'pdf'): File format of output plots - pdf or png
+
+__Return__
+
+
+- __return__ (None):
+ 
 ----
 
 ## compare_classifiers_performance_changing_k
@@ -187,17 +226,25 @@ Produce lineplot that show Hits@K measure while k goes from 1 to top_k.
 For each model it produces a line plot that shows the Hits@K measure
 (that counts a prediction as correct if the model produces it among the
 first k) while changing k from 1 to top_k for the specified output_feature_name.
-:param probabilities_per_model: List of model probabilities
-:param ground_truth: NumPy Array containing ground truth data
-:param top_k: Number of elements in the ranklist to consider
-:param labels_limit: Maximum numbers of labels.
-If labels in dataset are higher than this number, "rare" label
-:param model_names: List of the names of the models to use as labels.
-:param output_directory: Directory where to save plots.
-If not specified, plots will be displayed in a window
-:param file_format: File format of output plots - pdf or png
-:return None:
 
+__Inputs__
+
+
+- __probabilities_per_model__ (list): List of model probabilities
+- __ground_truth__ (ndarray): NumPy Array containing ground truth data
+- __top_k__ (int): Number of elements in the ranklist to consider
+- __labels_limit__ (int): Maximum numbers of labels.
+     If labels in dataset are higher than this number, "rare" label
+- __model_names__ (list, default: None): List of the names of the models to use as labels.
+- __output_directory__ (string, default: None): Directory where to save plots.
+     If not specified, plots will be displayed in a window
+- __file_format__ (string, default: 'pdf'): File format of output plots - pdf or png
+
+__Return__
+
+
+- __return__ (None):
+ 
 ----
 
 ## compare_classifiers_multiclass_multimetric
@@ -220,17 +267,23 @@ Show the precision, recall and F1 of the model for the specified output_feature_
 
 For each model it produces four plots that show the precision,
 recall and F1 of the model on several classes for the specified output_feature_name.
-:param test_stats_per_model: List containing train statistics per model
-:param metadata: Model's input metadata
-:param output_feature_name: Name of the output feature that is predicted and for which is provided ground truth
-:param top_n_classes: List containing the number of classes to plot
-:param model_names: List of the names of the models to use as labels.
-:param output_directory: Directory where to save plots.
-If not specified, plots will be displayed in a window
-:param file_format: File format of output plots - pdf or png
-:return None:
-:return:
 
+__Inputs__
+
+
+- __test_stats_per_model__ (list): List containing train statistics per model
+- __metadata__ (dict): Model's input metadata
+- __output_feature_name__ (string): Name of the output feature that is predicted and for which is provided ground truth
+- __top_n_classes__ (list): List containing the number of classes to plot
+- __model_names__ (list, default: None): List of the names of the models to use as labels.
+- __output_directory__ (string, default: None): Directory where to save plots.
+     If not specified, plots will be displayed in a window
+- __file_format__ (string, default: 'pdf'): File format of output plots - pdf or png
+
+__Return__
+
+- __return__ (None):
+ 
 ----
 
 ## compare_classifiers_predictions
@@ -250,16 +303,23 @@ ludwig.visualize.compare_classifiers_predictions(
 
 Show two models comparision of their output_feature_name predictions.
 
-:param predictions_per_model: List containing the model predictions
-:param ground_truth: NumPy Array containing ground truth data
-:param labels_limit: Maximum numbers of labels.
-If labels in dataset are higher than this number, "rare" label
-:param model_names: List of the names of the models to use as labels.
-:param output_directory: Directory where to save plots.
-If not specified, plots will be displayed in a window
-:param file_format: File format of output plots - pdf or png
-:return None:
+__Inputs__
 
+
+- __predictions_per_model__ (list): List containing the model predictions
+- __ground_truth__ (ndarray): NumPy Array containing ground truth data
+- __labels_limit__ (int): Maximum numbers of labels.
+     If labels in dataset are higher than this number, "rare" label
+- __model_names__ (list, default: None): List of the names of the models to use as labels.
+- __output_directory__ (string, default: None): Directory where to save plots.
+     If not specified, plots will be displayed in a window
+- __file_format__ (string, default: 'pdf'): File format of output plots - pdf or png
+
+__Return__
+
+
+- __return__ (None):
+ 
 ----
 
 ## confidence_thresholding_2thresholds_2d
@@ -286,17 +346,25 @@ thresholds on the confidence of the predictions of the two
 threshold_output_feature_names  as x and y axes and either the data coverage percentage or
 the accuracy as z axis. Each line represents a slice of the data
 coverage  surface projected onto the accuracy surface.
-:param probabilities_per_model: List of model probabilities
-:param ground_truths: List of NumPy Arrays containing ground truth data
-:param threshold_output_feature_names: List of output_feature_names for 2d threshold
-:param labels_limit: Maximum numbers of labels.
-If labels in dataset are higher than this number, "rare" label
-:param model_names: Name of the model to use as label.
-:param output_directory: Directory where to save plots.
-If not specified, plots will be displayed in a window
-:param file_format: File format of output plots - pdf or png
-:return None:
 
+__Inputs__
+
+
+- __probabilities_per_model__ (list): List of model probabilities
+- __ground_truths__ (list): List of NumPy Arrays containing ground truth data
+- __threshold_output_feature_names__ (list): List of output_feature_names for 2d threshold
+- __labels_limit__ (int): Maximum numbers of labels.
+     If labels in dataset are higher than this number, "rare" label
+- __model_names__ (string): Name of the model to use as label.
+- __output_directory__ (string, default: None): Directory where to save plots.
+     If not specified, plots will be displayed in a window
+- __file_format__ (string, default: 'pdf'): File format of output plots - pdf or png
+
+__Return__
+
+
+- __return__ (None):
+ 
 ----
 
 ## confidence_thresholding_2thresholds_3d
@@ -320,16 +388,24 @@ The plot shows the 3d surfaces displayed by
 confidence_thresholding_2thresholds_3d that have thresholds on the
 confidence of the predictions of the two threshold_output_feature_names as x and y axes
 and either the data coverage percentage or the accuracy as z axis.
-:param probabilities_per_model: List of model probabilities
-:param ground_truths: List of NumPy Arrays containing ground truth data
-:param threshold_output_feature_names: List of output_feature_names for 2d threshold
-:param labels_limit: Maximum numbers of labels.
-If labels in dataset are higher than this number, "rare" label
-:param output_directory: Directory where to save plots.
-If not specified, plots will be displayed in a window
-:param file_format: File format of output plots - pdf or png
-:return None:
 
+__Inputs__
+
+
+- __probabilities_per_model__ (list): List of model probabilities
+- __ground_truths__ (list): List of NumPy Arrays containing ground truth data
+- __threshold_output_feature_names__ (list): List of output_feature_names for 2d threshold
+- __labels_limit__ (int): Maximum numbers of labels.
+     If labels in dataset are higher than this number, "rare" label
+- __output_directory__ (string, default: None): Directory where to save plots.
+     If not specified, plots will be displayed in a window
+- __file_format__ (string, default: 'pdf'): File format of output plots - pdf or png
+
+__Return__
+
+
+- __return__ (None):
+ 
 ----
 
 ## confidence_thresholding
@@ -352,16 +428,24 @@ Show models accuracy and data coverage while increasing treshold
 For each model it produces a pair of lines indicating the accuracy of
 the model and the data coverage while increasing a threshold (x axis) on
 the probabilities of predictions for the specified output_feature_name.
-:param probabilities_per_model: List of model probabilities
-:param ground_truth: NumPy Array containing ground truth data
-:param labels_limit: Maximum numbers of labels.
-If labels in dataset are higher than this number, "rare" label
-:param model_names: List of the names of the models to use as labels.
-:param output_directory: Directory where to save plots.
-If not specified, plots will be displayed in a window
-:param file_format: File format of output plots - pdf or png
-:return None:
 
+__Inputs__
+
+
+- __probabilities_per_model__ (list): List of model probabilities
+- __ground_truth__ (ndarray): NumPy Array containing ground truth data
+- __labels_limit__ (int): Maximum numbers of labels.
+     If labels in dataset are higher than this number, "rare" label
+- __model_names__ (list, default: None): List of the names of the models to use as labels.
+- __output_directory__ (sting): Directory where to save plots.
+     If not specified, plots will be displayed in a window
+- __file_format__ (string, default: 'pdf'): File format of output plots - pdf or png
+
+__Return__
+
+
+- __return__ (None):
+ 
 ----
 
 ## confidence_thresholding_data_vs_acc
@@ -387,16 +471,23 @@ of predictions for the specified output_feature_name. The difference with
 confidence_thresholding is that it uses two axes instead of three,
 not visualizing the threshold and having coverage as x axis instead of
 the threshold.
-:param probabilities_per_model: List of model probabilities
-:param ground_truth: NumPy Array containing ground truth data
-:param labels_limit: Maximum numbers of labels.
-If labels in dataset are higher than this number, "rare" label
-:param model_names: List of the names of the models to use as labels.
-:param output_directory: Directory where to save plots.
-If not specified, plots will be displayed in a window
-:param file_format: File format of output plots - pdf or png
-:return None:
 
+__Inputs__
+
+
+- __probabilities_per_model__ (list): List of model probabilities
+- __ground_truth__ (ndarray): NumPy Array containing ground truth data
+- __labels_limit__ (int): Maximum numbers of labels.
+     If labels in dataset are higher than this number, "rare" label
+- __model_names__ (list, default: None): List of the names of the models to use as labels.
+- __output_directory__ (string, default: None): Directory where to save plots.
+     If not specified, plots will be displayed in a window
+- __file_format__ (string, default: 'pdf'): File format of output plots - pdf or png
+
+__Return__
+
+- __return__ (None):
+ 
 ----
 
 ## confidence_thresholding_data_vs_acc_subset
@@ -436,17 +527,25 @@ predictions, then only datapoints where the the model predicts a class
 that is within the top n most frequent ones will be considered as test set,
 and the percentage of datapoints that have been kept from the original set
 will be displayed for each model.
-:param probabilities_per_model: List of model probabilities
-:param ground_truth: NumPy Array containing ground truth data
-:param top_n_classes: List containing the number of classes to plot
-:param labels_limit: Maximum numbers of labels.
-:param subset: Type of the subset filtering
-:param model_names: List of the names of the models to use as labels.
-:param output_directory: Directory where to save plots.
-If not specified, plots will be displayed in a window
-:param file_format: File format of output plots - pdf or png
-:return None:
 
+__Inputs__
+
+
+- __probabilities_per_model__ (list): List of model probabilities
+- __ground_truth__ (ndarray): NumPy Array containing ground truth data
+- __top_n_classes__ (list): List containing the number of classes to plot
+- __labels_limit__ (int): Maximum numbers of labels.
+- __subset__ (string): Type of the subset filtering
+- __model_names__ (list, default: None): List of the names of the models to use as labels.
+- __output_directory__ (string, default: None): Directory where to save plots.
+     If not specified, plots will be displayed in a window
+- __file_format__ (string, default: 'pdf'): File format of output plots - pdf or png
+
+__Return__
+
+
+- __return__ (None):
+ 
 ----
 
 ## binary_threshold_vs_metric
@@ -475,17 +574,25 @@ the class to be considered positive class and all the others will be
 considered negative. It needs to be an integer, to figure out the
 association between classes and integers check the ground_truth_metadata
 JSON file.
-:param probabilities_per_model: List of model probabilities
-:param ground_truth: List of NumPy Arrays containing ground truth data
-:param metrics: metrics to dispay (f1, precision, recall,
-accuracy)
-:param positive_label: Label of the positive class
-:param model_names: List of the names of the models to use as labels.
-:param output_directory: Directory where to save plots.
-If not specified, plots will be displayed in a window
-:param file_format: File format of output plots - pdf or png
-:return None:
 
+__Inputs__
+
+
+- __probabilities_per_model__ (list): List of model probabilities
+- __ground_truth__ (list): List of NumPy Arrays containing ground truth data
+- __metrics__ (f1, precision, recall):metrics: metrics to dispay (f1, precision, recall,
+            accuracy)
+- __positive_label__ (string): Label of the positive class
+- __model_names__ (list, default: None): List of the names of the models to use as labels.
+- __output_directory__ (string, default: None): Directory where to save plots.
+     If not specified, plots will be displayed in a window
+- __file_format__ (string, default: 'pdf'): File format of output plots - pdf or png
+
+__Return__
+
+
+- __return__ (None):
+ 
 ----
 
 ## roc_curves
@@ -511,15 +618,23 @@ which is the class to be considered positive class and all the others will
 be considered negative. It needs to be an integer, to figure out the
 association between classes and integers check the ground_truth_metadata
 JSON file.
-:param probabilities_per_model: List of model probabilities
-:param ground_truth: List of NumPy Arrays containing ground truth data
-:param positive_label: Label of the positive class
-:param model_names: List of the names of the models to use as labels.
-:param output_directory: Directory where to save plots.
-If not specified, plots will be displayed in a window
-:param file_format: File format of output plots - pdf or png
-:return None:
 
+__Inputs__
+
+
+- __probabilities_per_model__ (list): List of model probabilities
+- __ground_truth__ (list): List of NumPy Arrays containing ground truth data
+- __positive_label__ (string): Label of the positive class
+- __model_names__ (list, default: None): List of the names of the models to use as labels.
+- __output_directory__ (string, default: None): Directory where to save plots.
+     If not specified, plots will be displayed in a window
+- __file_format__ (string, default: 'pdf'): File format of output plots - pdf or png
+
+__Return__
+
+
+- __return__ (None):
+ 
 ----
 
 ## roc_curves_from_test_statistics
@@ -541,14 +656,22 @@ Show the roc curves for the specified models output binary output_feature_name.
 This visualization uses the output_feature_name, test_statistics and model_names
 parameters. output_feature_name needs to be binary feature. This visualization produces a
 line chart plotting the roc curves for the specified output_feature_name.
-:param test_stats_per_model: List containing train statistics per model
-:param output_feature_name: Name of the output feature that is predicted and for which is provided ground truth
-:param model_names: List of the names of the models to use as labels.
-:param output_directory: Directory where to save plots.
-If not specified, plots will be displayed in a window
-:param file_format: File format of output plots - pdf or png
-:return None:
 
+__Inputs__
+
+
+- __test_stats_per_model__ (list): List containing train statistics per model
+- __output_feature_name__ (string): Name of the output feature that is predicted and for which is provided ground truth
+- __model_names__ (list, default: None): List of the names of the models to use as labels.
+- __output_directory__ (string, default: None): Directory where to save plots.
+     If not specified, plots will be displayed in a window
+- __file_format__ (string, default: 'pdf'): File format of output plots - pdf or png
+
+__Return__
+
+
+- __return__ (None):
+ 
 ----
 
 ## calibration_1_vs_all
@@ -582,17 +705,25 @@ The second plot shows the distributions of the predictions considering
 the  current class to be the true one and all others to be a false one,
 drawing the distribution for each model (in the aligned lists of
 probabilities and model_names).
-:param probabilities_per_model: List of model probabilities
-:param ground_truth: NumPy Array containing ground truth data
-:param top_n_classes: List containing the number of classes to plot
-:param labels_limit: Maximum numbers of labels.
-If labels in dataset are higher than this number, "rare" label
-:param model_names: List of the names of the models to use as labels.
-:param output_directory: Directory where to save plots.
-If not specified, plots will be displayed in a window
-:param file_format: File format of output plots - pdf or png
-:return None:
 
+__Inputs__
+
+
+- __probabilities_per_model__ (list): List of model probabilities
+- __ground_truth__ (ndarray): NumPy Array containing ground truth data
+- __top_n_classes__ (list): List containing the number of classes to plot
+- __labels_limit__ (int): Maximum numbers of labels.
+     If labels in dataset are higher than this number, "rare" label
+- __model_names__ (list, default: None): List of the names of the models to use as labels.
+- __output_directory__ (string, default: None): Directory where to save plots.
+     If not specified, plots will be displayed in a window
+- __file_format__ (string, default: 'pdf'): File format of output plots - pdf or png
+
+__String__
+
+
+- __return__ (None):
+ 
 ----
 
 ## calibration_multiclass
@@ -613,16 +744,23 @@ ludwig.visualize.calibration_multiclass(
 Show models probability of predictions for each class of the the
 specified output_feature_name.
 
-:param probabilities_per_model: List of model probabilities
-:param ground_truth: NumPy Array containing ground truth data
-:param labels_limit: Maximum numbers of labels.
-If labels in dataset are higher than this number, "rare" label
-:param model_names: List of the names of the models to use as labels.
-:param output_directory: Directory where to save plots.
-If not specified, plots will be displayed in a window
-:param file_format: File format of output plots - pdf or png
-:return None:
+__Inputs__
 
+
+- __probabilities_per_model__ (list): List of model probabilities
+- __ground_truth__ (ndarray): NumPy Array containing ground truth data
+- __labels_limit__ (int): Maximum numbers of labels.
+     If labels in dataset are higher than this number, "rare" label
+- __model_names__ (list, default: None): List of the names of the models to use as labels.
+- __output_directory__ (string, default: None): Directory where to save plots.
+     If not specified, plots will be displayed in a window
+- __file_format__ (string, default: 'pdf'): File format of output plots - pdf or png
+
+__Return__
+
+
+- __return__ (None):
+ 
 ----
 
 ## confusion_matrix
@@ -648,18 +786,25 @@ For each model (in the aligned lists of test_statistics and model_names)
 it  produces a heatmap of the confusion matrix in the predictions for
 each  output_feature_name that has a confusion matrix in test_statistics. The value of
 top_n_classes limits the heatmap to the n most frequent classes.
-:param test_stats_per_model: List containing train statistics per model
-:param metadata: Model's input metadata
-:param output_feature_name: Name of the output feature that is predicted and for which is provided ground truth
-:param top_n_classes: List containing the number of classes to plot
-:param normalize: Flag to normalize rows in confusion matrix
-:param model_names: List of the names of the models to use as labels.
-:param output_directory: Directory where to save plots.
-If not specified, plots will be displayed in a window
-:param file_format: File format of output plots - pdf or png
-:return None:
-:return:
 
+__Inputs__
+
+
+- __test_stats_per_model__ (string): List containing train statistics per model
+- __metadata__ (dict): Model's input metadata
+- __output_feature_name__ (string): Name of the output feature that is predicted and for which is provided ground truth
+- __top_n_classes__ (list): List containing the number of classes to plot
+- __normalize__ (bool): Flag to normalize rows in confusion matrix
+- __model_names__ (list, default: None): List of the names of the models to use as labels.
+- __output_directory__ (string, default: None): Directory where to save plots.
+     If not specified, plots will be displayed in a window
+- __file_format__ (string, default: 'pdf'): File format of output plots - pdf or png
+
+__Return__
+
+
+- __return__ (None):
+ 
 ----
 
 ## frequency_vs_f1
@@ -692,13 +837,21 @@ f1 score.
 The second plot has the same structure of the first one,
 but the axes are flipped and the classes on the x axis are sorted by
 frequency.
-:param test_stats_per_model: List containing train statistics per model
-:param metadata: Model's input metadata
-:param output_feature_name: Name of the output feature that is predicted and for which is provided ground truth
-:param top_n_classes: List containing the number of classes to plot
-:param model_names: List of the names of the models to use as labels.
-:param output_directory: Directory where to save plots.
-If not specified, plots will be displayed in a window
-:param file_format: File format of output plots - pdf or png
-:return None:
-:return:
+
+__Inputs__
+
+
+- __test_stats_per_model__ (list): List containing train statistics per model
+- __metadata__ (dict): Model's input metadata
+- __output_feature_name__ (string): Name of the output feature that is predicted and for which is provided ground truth
+- __top_n_classes__ (list): List containing the number of classes to plot
+- __model_names__ (list, default: None): List of the names of the models to use as labels.
+- __output_directory__ (string, default: None): Directory where to save plots.
+     If not specified, plots will be displayed in a window
+- __file_format__ (string, default: 'pdf'): File format of output plots - pdf or png
+
+__Return__
+
+
+- __return__ (None):
+ 


### PR DESCRIPTION

# Documentation Pull Requests

Fix #547

Note that the documentation HTML files are in `docs/` while the Markdown sources are in `mkdocs/docs`.

If you are proposing a modification to the documentation you should change only the Markdown files.

`api.md` is automatically generated from the docstrings in the code, so if you want to change something in that file, first modify `ludwig/api.py` docstring, then run `mkdocs/code_docs_autogen.py`, which will create `mkdocs/docs/api.md` .

## Notes:
@w4nderlust  As noted in my posting from #547, I had to modify both the docstrings in `ludwig/visualize.py` and `mkdocs/code_doc_autogen.py` to correctly recreate `mkdocs/docs/api/visualization.md`

Per instructions in `mkdocs/README.md`, I tested the changes locally using the `mkdocs serve` command.  The visualization api documentation page rendered correctly.  I spot check several other pages that were not change to ensure correct rendering of the content.


