### PR TITLE
Bypass multiprocessing.Pool.map for faster execution

### DIFF
--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -313,7 +313,7 @@ class ImageBaseFeature(BaseFeature):
             # image just use this faster shortcut, bypassing multiprocessing.Pool.map
             else:
                 logger.warning(
-                        'No pooling applied. Using one process for preprocessing images'
+                        'No process pool initialized. Using one process for preprocessing images'
                 )
                 img = read_image_and_resize(all_file_paths[0])
                 data[feature['name']] = np.array([img])

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -296,15 +296,27 @@ class ImageBaseFeature(BaseFeature):
                 (num_images, height, width, num_channels),
                 dtype=np.uint8
             )
-            with Pool(num_processes) as pool:
-                logger.warning(
-                    'Using {} processes for preprocessing images'.format(
-                        num_processes
+            # Split the dataset into pools only if we have an explicit request to use
+            # multiple processes. In case we have multiple input images use the
+            # standard code anyway.
+            if num_processes > 1 or num_images > 1:
+                with Pool(num_processes) as pool:
+                    logger.warning(
+                        'Using {} processes for preprocessing images'.format(
+                            num_processes
+                        )
                     )
+                    data[feature['name']] = np.array(
+                        pool.map(read_image_and_resize, all_file_paths)
+                    )
+            # If we're not running multiple processes and we are only processing one
+            # image just use this faster shortcut, bypassing multiprocessing.Pool.map
+            else:
+                logger.warning(
+                        'No pooling applied. Using one process for preprocessing images'
                 )
-                data[feature['name']] = np.array(
-                    pool.map(read_image_and_resize, all_file_paths)
-                )
+                img = read_image_and_resize(all_file_paths[0])
+                data[feature['name']] = np.array([img])
         else:
             data_fp = os.path.splitext(dataset_df.csv)[0] + '.hdf5'
             mode = 'w'


### PR DESCRIPTION
After the introduction of multiprocessing management, inferring time has been really slow when working with a single image.
This workaround bypasses the pooling when inferring on a single image and using only one process.

There is for sure a way to implement this to cover more cases (single process, multiple images). But this is way less invasive and immediately effective.