### PR TITLE
Auto-detect field separator for read_csv

### DIFF
--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -55,8 +55,12 @@ def read_csv(data_fp, header=0):
     
     separator=','
     with open(data_fp, 'r') as csvfile:
-        dialect = csv.Sniffer().sniff(csvfile.read(1024*100))
-        separator=dialect.delimiter
+        try:
+            dialect = csv.Sniffer().sniff(csvfile.read(1024*100), delimiters=[',' , '\t', '|', ' '])
+            separator=dialect.delimiter
+        except csv.Error:
+            # Could not conclude the delimiter, defaulting to comma
+            pass
     
     try:
         df = pd.read_csv(data_fp, sep=separator, header=header)

--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -52,12 +52,18 @@ def read_csv(data_fp, header=0):
     :param header: header argument for pandas to read the csv
     :return: Pandas dataframe with the data
     """
+    
+    separator=','
+    with open(data_fp, 'r') as csvfile:
+        dialect = csv.Sniffer().sniff(csvfile.read(1024*100))
+        separator=dialect.delimiter
+    
     try:
-        df = pd.read_csv(data_fp, header=header)
+        df = pd.read_csv(data_fp, sep=separator, header=header)
     except ParserError:
         logger.warning('Failed to parse the CSV with pandas default way,'
                        ' trying \\ as escape character.')
-        df = pd.read_csv(data_fp, header=header, escapechar='\\')
+        df = pd.read_csv(data_fp, sep=separator, header=header, escapechar='\\')
 
     return df
 


### PR DESCRIPTION
- Auto-detect field separator by sampling the first 100kB of a CSV file
- Support for other than comma-separated files, including TSVs.

# Code Pull Requests

Please provide the following:

- a clear explanation of what your code dose
- if applicable, a reference to an issue
- a reproducible test for your PR (code, model definition and data sample)

# Documentation Pull Requests

Note that the documentation HTML files are in `docs/` while the Markdown sources are in `mkdocs/docs`.

If you are proposing a modification to the documentation you should change only the Markdown files.

`api.md` is automatically generated from the docstrings in the code, so if you want to change something in that file, first modify `ludwig/api.py` docstring, then run `mkdocs/code_docs_autogen.py`, which will create `mkdocs/docs/api.md` .
