### PR TITLE
Add tracker measures (combined train\validation\test loss and accuracy) in output towards TensorBoard

### DIFF
--- a/ludwig/models/model.py
+++ b/ludwig/models/model.py
@@ -589,6 +589,15 @@ class Model:
                     eval_batch_size,
                     bucketing_field
                 )
+                # Add a graph within TensorBoard showing the overall loss tracked in the same
+                # way as in the CLI
+                validation_loss = progress_tracker.vali_stats['combined'][LOSS][-1]
+                validation_loss_summary = tf.Summary(value=[
+                    tf.Summary.Value(tag="validation_loss", simple_value=validation_loss)
+                ])
+                # progress_tracker.steps has already been incremented before, so to write on the
+                # previous summary, we need to use -1
+                train_writer.add_summary(validation_loss_summary, progress_tracker.steps - 1)
 
             if test_set is not None and test_set.size > 0:
                 # eval measures on test set

--- a/ludwig/models/model.py
+++ b/ludwig/models/model.py
@@ -206,7 +206,7 @@ class Model:
                 self.horovod
             )
 
-            tf.compat.v1.summary.scalar('train_reg_mean_loss', self.train_reg_mean_loss)
+            tf.compat.v1.summary.scalar('batch_combined/train_reg_mean_loss', self.train_reg_mean_loss)
 
             self.merged_summary = tf.compat.v1.summary.merge_all()
             self.graph = graph
@@ -271,7 +271,7 @@ class Model:
         summaries = []
         combined_output_f = stats['combined']
         for metric in combined_output_f:
-            metric_tag = "evaluation/{}_{}".format(prefix, metric)
+            metric_tag = "epoch_combined/{}_{}".format(prefix, metric)
             metric_val = combined_output_f[metric][-1]
             summaries.append(
                 tf.compat.v1.Summary.Value(tag=metric_tag, simple_value=metric_val)

--- a/ludwig/models/model.py
+++ b/ludwig/models/model.py
@@ -589,15 +589,17 @@ class Model:
                     eval_batch_size,
                     bucketing_field
                 )
-                # Add a graph within TensorBoard showing the overall loss tracked in the same
-                # way as in the CLI
-                validation_loss = progress_tracker.vali_stats['combined'][LOSS][-1]
-                validation_loss_summary = tf.Summary(value=[
-                    tf.Summary.Value(tag="validation_loss", simple_value=validation_loss)
-                ])
-                # progress_tracker.steps has already been incremented before, so to write on the
-                # previous summary, we need to use -1
-                train_writer.add_summary(validation_loss_summary, progress_tracker.steps - 1)
+                if is_on_master():
+                    if not skip_save_log:
+                        # Add a graph within TensorBoard showing the overall loss tracked in the same
+                        # way as in the CLI
+                        validation_loss = progress_tracker.vali_stats['combined'][LOSS][-1]
+                        validation_loss_summary = tf.Summary(value=[
+                            tf.Summary.Value(tag="validation_loss", simple_value=validation_loss)
+                        ])
+                        # progress_tracker.steps has already been incremented before, so to write on the
+                        # previous summary, we need to use -1
+                        train_writer.add_summary(validation_loss_summary, progress_tracker.steps - 1)
 
             if test_set is not None and test_set.size > 0:
                 # eval measures on test set


### PR DESCRIPTION
This is the implementation of my own feature request #350 
"works fine on my machine" as usual, and since it's based on the same value calculated for the CLI output, treating it just as a number and adding it to the same step, it has no impact on any of the calculations. It's using the same file_writer, appending a "generated" summary containing only that one value to the corresponding step.