### PR TITLE
Fix inverted confusion_matrix axis

### DIFF
--- a/ludwig/utils/metrics_utils.py
+++ b/ludwig/utils/metrics_utils.py
@@ -48,8 +48,8 @@ class ConfusionMatrix:
             self.idx2label = {idx: str(label) for idx, label in
                               enumerate(np.unique(
                                   [self.predictions, self.conditions]))}
-        self.cm = confusion_matrix(self.predictions,
-                                   self.conditions,
+        self.cm = confusion_matrix(self.conditions,
+                                   self.predictions,
                                    labels=labels,
                                    sample_weight=sample_weight)
 


### PR DESCRIPTION
This is related to issue #565 

confusion_matrix accepts two arrays, but the first one should be the true value, the second one should be the predictions made to be compared. It was inverted right here.