### PR TITLE
fix bug when layers is None

### DIFF
--- a/ludwig/models/modules/convolutional_modules.py
+++ b/ludwig/models/modules/convolutional_modules.py
@@ -302,7 +302,7 @@ class ParallelConv1D:
             ]
         else:
             self.layers = layers
-        for layer in layers:
+        for layer in self.layers:
             if 'filter_size' not in layer:
                 layer['filter_size'] = default_filter_size
             if 'num_filters' not in layer:


### PR DESCRIPTION
# Code Pull Requests

When using parallel_cnn encoder, there will throw a `TypeError: 'NoneType' object is not iterable` in `~/ludwig/models/modules/convolutional_modules.py` line 305, and the variable `layers` need write as `self.layers`.