### PR TITLE
Hack to override in_memory flag for API usage

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -54,6 +54,7 @@ from ludwig.models.model import load_model_and_definition
 from ludwig.predict import calculate_overall_stats
 from ludwig.train import full_train
 from ludwig.train import update_model_definition_with_metadata
+from ludwig.utils.data_utils import override_in_memory_flag
 from ludwig.utils.data_utils import read_csv
 from ludwig.utils.data_utils import save_json
 from ludwig.utils.defaults import default_random_seed
@@ -344,7 +345,7 @@ class LudwigModel:
             debug=False,
             **kwargs
     ):
-        """This function is used to perform a full training of the model on the 
+        """This function is used to perform a full training of the model on the
            specified dataset.
 
         # Inputs
@@ -619,22 +620,22 @@ class LudwigModel:
             gpus=None,
             gpu_fraction=1,
     ):
-        """This function is used to perform one epoch of training of the model 
+        """This function is used to perform one epoch of training of the model
         on the specified dataset.
 
         # Inputs
 
         :param data_df: (DataFrame) dataframe containing data.
         :param data_csv: (string) input data CSV file.
-        :param data_dict: (dict) input data dictionary. It is expected to 
-               contain one key for each field and the values have to be lists of 
-               the same length. Each index in the lists corresponds to one 
-               datapoint. For example a data set consisting of two datapoints 
-               with a text and a class may be provided as the following dict 
+        :param data_dict: (dict) input data dictionary. It is expected to
+               contain one key for each field and the values have to be lists of
+               the same length. Each index in the lists corresponds to one
+               datapoint. For example a data set consisting of two datapoints
+               with a text and a class may be provided as the following dict
                ``{'text_field_name': ['text of the first datapoint', text of the
-               second datapoint'], 'class_filed_name': ['class_datapoints_1', 
+               second datapoint'], 'class_filed_name': ['class_datapoints_1',
                'class_datapoints_2']}`.
-        :param batch_size: (int) the batch size to use for training. By default 
+        :param batch_size: (int) the batch size to use for training. By default
                it's the one specified in the model definition.
         :param learning_rate: (float) the learning rate to use for training. By
                default the values is the one specified in the model definition.
@@ -751,6 +752,16 @@ class LudwigModel:
         else:
             output_features = []
         features_to_load += output_features
+
+        num_overrides = override_in_memory_flag(
+            self.model_definition['input_features'],
+            True
+        )
+        if num_overrides > 0:
+            logger.warning(
+                'Using in_memory = False is not supported for Ludwig API.'
+            )
+
 
         preprocessed_data = build_data(
             data_df,

--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -385,6 +385,14 @@ def add_sequence_feature_column(df, col_name, seq_length):
     df[new_col_name] = new_data
     df[new_col_name] = df[new_col_name].fillna(method='backfill')
 
+def override_in_memory_flag(input_features, override_value):
+    num_overrides = 0
+    for feature in input_features:
+        if 'preprocessing' in feature:
+            if 'in_memory' in feature['preprocessing']:
+                feature['preprocessing']['in_memory'] = override_value
+                num_overrides += 1
+    return num_overrides
 
 class NumpyEncoder(json.JSONEncoder):
     def default(self, obj):


### PR DESCRIPTION
Tested by initializing a pretrained model and then calling predict function of the model API with dataframe and a csv separately.