### PR TITLE
fix: failure in generating learning curves plot due to early stopping

### DIFF
--- a/ludwig/utils/visualization_utils.py
+++ b/ludwig/utils/visualization_utils.py
@@ -90,11 +90,11 @@ def learning_curves_plot(
         name_prefix = algorithm_names[
                           i] + ' ' if algorithm_names is not None and i < len(
             algorithm_names) else ''
-        ax.plot(xs, train_values[i], label=name_prefix + 'training',
+        ax.plot(xs[:len(train_values[i])], train_values[i], label=name_prefix + 'training',
                 color=colors[i * 2], linewidth=3)
         if i < len(vali_values) and vali_values[i] is not None and len(
                 vali_values[i]) > 0:
-            ax.plot(xs, vali_values[i], label=name_prefix + 'validation',
+            ax.plot(xs[:len(vali_values[i])], vali_values[i], label=name_prefix + 'validation',
                     color=colors[i * 2 + 1], linewidth=3)
 
     ax.legend()


### PR DESCRIPTION
# Code Pull Requests

Fix Issue #585.

The reproducible example from #585 no longer fails.  

These are the generated learning curve plots after implementing the proposed fix:
![learning_curves_y_accuracy](https://user-images.githubusercontent.com/1425269/69924868-6ff3c100-147b-11ea-8990-a15565e54323.png)

![learning_curves_y_loss](https://user-images.githubusercontent.com/1425269/69924875-78e49280-147b-11ea-9d13-d8c48e86970f.png)



