### PR TITLE
open vocab with utf-8

### DIFF
--- a/ludwig/utils/strings_utils.py
+++ b/ludwig/utils/strings_utils.py
@@ -74,7 +74,7 @@ def match_replace(string_to_match, list_regex):
 
 
 def load_vocabulary(vocab_file):
-    with open(vocab_file, 'r') as f:
+    with open(vocab_file, 'r', encoding='utf-8') as f:
         vocabulary = []
         for line in f:
             line = line.strip()


### PR DESCRIPTION
# Open vocabulary file with utf-8 encoding

[load_vocabulary](https://github.com/uber/ludwig/blob/997c6bc02dffcc726efda7ddbb5978e425ffab96/ludwig/utils/strings_utils.py#L76) gives UnicodeEncodeError in RHEL 7.6

- Open the vocab file with utf-8 encoding.