### PR TITLE
Add regression model in k-fold cv unit test

### DIFF
--- a/tests/integration_tests/test_kfold_cv.py
+++ b/tests/integration_tests/test_kfold_cv.py
@@ -153,7 +153,7 @@ def test_kfold_cv_api_in_memory():
         ]
 
         output_features = [
-            category_feature(vocab_size=2, reduce_input='sum')
+            numerical_feature()
         ]
 
         generate_data(input_features, output_features, training_data_fp)


### PR DESCRIPTION
# Code Pull Requests

Currently the three tests in test_kfold_cv.py are classification models.  Converted one of the models to be a regression model to ensure ability to capture regression related metrics.

