### PR TITLE
Correct formatting of `kfold_cross_validate()` api documentation

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -1017,22 +1017,23 @@ def kfold_cross_validate(
     
     :param k_fold: (int) number of folds to create for the cross-validation
     :param model_definition: (dict, default: None) a dictionary containing
-             information needed to build a model. Refer to the [User Guide]
-            (http://ludwig.ai/user_guide/#model-definition) for details.
+           information needed to build a model. Refer to the
+           [User Guide](http://ludwig.ai/user_guide/#model-definition)
+           for details.
     :param model_definition_file: (string, optional, default: `None`) path to
-            a YAML file containing the model definition. If available it will be
-            used instead of the model_definition dict.
+           a YAML file containing the model definition. If available it will be
+           used instead of the model_definition dict.
     :param data_csv: (dataframe, default: None)
     :param data_csv: (string, default: None)
     :param output_directory: (string, default: 'results')
     :param random_seed: (int) Random seed used k-fold splits.
-    
+
     # Return
 
-    :return: kfold_cv_stats, kfold_split_indices (tuple of dict):
-             kfold_cv_stats contains metrics from cv run.
-             kfold_split_indices: indices to split training data into
-                training fold and test fold.
+    :return: (tuple(kfold_cv_stats, kfold_split_indices), dict) a tuple of
+            dictionaries `kfold_cv_stats`: contains metrics from cv run.
+             `kfold_split_indices`: indices to split training data into
+             training fold and test fold.
     """
 
     (kfold_cv_stats,

--- a/mkdocs/code_doc_autogen.py
+++ b/mkdocs/code_doc_autogen.py
@@ -91,7 +91,7 @@ PAGES = [
             (LudwigModel, "*")
         ],
         'functions': [
-            kfold_cross_validate
+            ludwig.api.kfold_cross_validate
         ]
     },
     {

--- a/mkdocs/code_doc_autogen.py
+++ b/mkdocs/code_doc_autogen.py
@@ -27,6 +27,7 @@ import os
 import re
 import sys
 
+from ludwig.api import kfold_cross_validate
 from ludwig.visualize import learning_curves, compare_performance, \
     compare_classifiers_performance_from_prob, \
     compare_classifiers_performance_from_pred, \
@@ -89,6 +90,9 @@ PAGES = [
         'classes': [
             (LudwigModel, "*")
         ],
+        'functions': [
+            kfold_cross_validate
+        ]
     },
     {
         'page': 'api/visualization.md',

--- a/mkdocs/code_doc_autogen.py
+++ b/mkdocs/code_doc_autogen.py
@@ -91,7 +91,7 @@ PAGES = [
             (LudwigModel, "*")
         ],
         'functions': [
-            ludwig.api.kfold_cross_validate
+            kfold_cross_validate
         ]
     },
     {
@@ -514,6 +514,9 @@ if __name__ == '__main__':
             blocks.append(render_function(method, _method=True))
 
         functions = read_page_data(page_data, 'functions')
+
+        if functions:
+            blocks.append('# Module functions\n')
 
         for function in functions:
             blocks.append(render_function(function, _method=False))

--- a/mkdocs/docs/api/LudwigModel.md
+++ b/mkdocs/docs/api/LudwigModel.md
@@ -656,6 +656,10 @@ text of the second datapoint'], 'class_filed_name':
 
 ----
 
+# Module functions
+
+----
+
 ## kfold_cross_validate
 
 

--- a/mkdocs/docs/api/LudwigModel.md
+++ b/mkdocs/docs/api/LudwigModel.md
@@ -1,4 +1,4 @@
-<span style="float:right;">[[source]](https://github.com/uber/ludwig/blob/master/ludwig/api.py#L66)</span>
+<span style="float:right;">[[source]](https://github.com/uber/ludwig/blob/master/ludwig/api.py#L69)</span>
 # LudwigModel class
 
 ```python
@@ -444,7 +444,7 @@ train(
 ```
 
 
-This function is used to perform a full training of the model on the 
+This function is used to perform a full training of the model on the
 specified dataset.
 
 __Inputs__
@@ -587,8 +587,7 @@ __Return__
 
 - __return__ (dict): a dictionary containing training statistics for each
 output feature containing loss and measures values for each epoch.
-
-
+ 
 ---
 ## train_online
 
@@ -609,7 +608,7 @@ train_online(
 ```
 
 
-This function is used to perform one epoch of training of the model 
+This function is used to perform one epoch of training of the model
 on the specified dataset.
 
 __Inputs__
@@ -617,15 +616,15 @@ __Inputs__
 
 - __data_df__ (DataFrame): dataframe containing data.
 - __data_csv__ (string): input data CSV file.
-- __data_dict__ (dict): input data dictionary. It is expected to 
-   contain one key for each field and the values have to be lists of 
-   the same length. Each index in the lists corresponds to one 
-   datapoint. For example a data set consisting of two datapoints 
-   with a text and a class may be provided as the following dict 
+- __data_dict__ (dict): input data dictionary. It is expected to
+   contain one key for each field and the values have to be lists of
+   the same length. Each index in the lists corresponds to one
+   datapoint. For example a data set consisting of two datapoints
+   with a text and a class may be provided as the following dict
    ``{'text_field_name': ['text of the first datapoint', text of the
-   second datapoint'], 'class_filed_name': ['class_datapoints_1', 
+   second datapoint'], 'class_filed_name': ['class_datapoints_1',
    'class_datapoints_2']}`.
-- __batch_size__ (int): the batch size to use for training. By default 
+- __batch_size__ (int): the batch size to use for training. By default
    it's the one specified in the model definition.
 - __learning_rate__ (float): the learning rate to use for training. By
    default the values is the one specified in the model definition.
@@ -654,3 +653,47 @@ consisting of two datapoints with a text and a class may be provided as
 the following dict ``{'text_field_name}: ['text of the first datapoint',
 text of the second datapoint'], 'class_filed_name':
 ['class_datapoints_1', 'class_datapoints_2']}`.
+
+----
+
+## kfold_cross_validate
+
+
+```python
+ludwig.api.kfold_cross_validate(
+  k_fold,
+  model_definition=None,
+  model_definition_file=None,
+  data_csv=None,
+  output_directory='results',
+  random_seed=42
+)
+```
+
+
+Performs k-fold cross validation and returns result data structures.
+
+
+__Inputs__
+
+
+:param k_fold: (int) number of folds to create for the cross-validation
+:param model_definition: (dict, default: None) a dictionary containing
+information needed to build a model. Refer to the [User Guide]
+(http://ludwig.ai/user_guide/#model-definition) for details.
+:param model_definition_file: (string, optional, default: `None`) path to
+a YAML file containing the model definition. If available it will be
+used instead of the model_definition dict.
+:param data_csv: (dataframe, default: None)
+:param data_csv: (string, default: None)
+:param output_directory: (string, default: 'results')
+:param random_seed: (int) Random seed used k-fold splits.
+
+__Return__
+
+
+- __return__ (tuple of dict)::
+     kfold_cv_stats contains metrics from cv run.
+     kfold_split_indices: indices to split training data into
+        training fold and test fold.
+ 

--- a/mkdocs/docs/api/LudwigModel.md
+++ b/mkdocs/docs/api/LudwigModel.md
@@ -677,23 +677,24 @@ Performs k-fold cross validation and returns result data structures.
 __Inputs__
 
 
-:param k_fold: (int) number of folds to create for the cross-validation
-:param model_definition: (dict, default: None) a dictionary containing
-information needed to build a model. Refer to the [User Guide]
-(http://ludwig.ai/user_guide/#model-definition) for details.
-:param model_definition_file: (string, optional, default: `None`) path to
-a YAML file containing the model definition. If available it will be
-used instead of the model_definition dict.
-:param data_csv: (dataframe, default: None)
-:param data_csv: (string, default: None)
-:param output_directory: (string, default: 'results')
-:param random_seed: (int) Random seed used k-fold splits.
+- __k_fold__ (int): number of folds to create for the cross-validation
+- __model_definition__ (dict, default: None): a dictionary containing
+   information needed to build a model. Refer to the
+   [User Guide](http://ludwig.ai/user_guide/#model-definition)
+   for details.
+- __model_definition_file__ (string, optional, default: `None`): path to
+   a YAML file containing the model definition. If available it will be
+   used instead of the model_definition dict.
+- __data_csv__ (dataframe, default: None):
+- __data_csv__ (string, default: None):
+- __output_directory__ (string, default: 'results'):
+- __random_seed__ (int): Random seed used k-fold splits.
 
 __Return__
 
 
-- __return__ (tuple of dict)::
-     kfold_cv_stats contains metrics from cv run.
-     kfold_split_indices: indices to split training data into
-        training fold and test fold.
+- __return__ (tuple(kfold_cv_stats, kfold_split_indices), dict): a tuple of
+    dictionaries `kfold_cv_stats`: contains metrics from cv run.
+     `kfold_split_indices`: indices to split training data into
+     training fold and test fold.
  

--- a/mkdocs/docs/api/visualization.md
+++ b/mkdocs/docs/api/visualization.md
@@ -1,3 +1,7 @@
+# Module functions
+
+----
+
 ## learning_curves
 
 


### PR DESCRIPTION
# Code Pull Requests

* Modified `mkdocs/code_docs_autogen.py` to add a **Module functions** section title in the generated markdown file.  Reason for adding  **Modules functions** section title:  Without this section title the api documentation for `kfold_cross_validate()` appears to be a `LudwigModel` class method.


# Documentation Pull Requests

* Reformatted docstring for `ludwig.api.kfold_cross_validate()` to allow proper rendering of generated markdown by `mkdocs/code_docs_autogen.py`
* Added **Module functions** Section header to `mkdocs/docs/api/LudwigModel.md`
* Added **Module functions** section header to `mkdocs/docs/api/visualization.md`

Tested locally the generated markdown with `mkdocs serve`.  Here are sample screenshots with the changes:

`LudwigModel.md`:
<img width="1134" alt="Screen Shot 2020-02-08 at 09 09 48" src="https://user-images.githubusercontent.com/1425269/74086852-fff25000-4a54-11ea-83c0-5b3fba05d257.png">

`visualization.md`:
<img width="1173" alt="Screen Shot 2020-02-08 at 09 05 05" src="https://user-images.githubusercontent.com/1425269/74086862-0ed90280-4a55-11ea-804f-126017f23ac8.png">



