### PR TITLE
Refactoring ImageFeature for TF 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,7 +113,7 @@ celerybeat-schedule
 
 # virtualenv
 .venv
-venv/
+venv*
 ENV/
 
 # Spyder project settings

--- a/ludwig/models/modules/image_encoders.py
+++ b/ludwig/models/modules/image_encoders.py
@@ -14,9 +14,42 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+import tensorflow as tf
+from tensorflow.keras.layers import Layer
+
 from ludwig.models.modules.convolutional_modules import flatten, ConvStack2D, \
     ResNet, get_resnet_block_sizes
 from ludwig.models.modules.fully_connected_modules import FCStack
+
+# ImageTestEncoder is just for end-to-end testing, will remove this
+class ImageTestEncoder(Layer):
+
+    def __init__(
+            self,
+            **kwargs
+    ):
+        super(ImageTestEncoder, self).__init__()
+
+    def call(self, inputs, training=None, mask=None):
+        """
+            :param inputs: The inputs fed into the encoder.
+                   Shape: [batch x height x width x channels], type tf.uint8
+        """
+
+        # use FCStack only for now as it is already implemented and 
+        # ConvStack2D is not
+        fc_stack = FCStack(
+            layers=[
+                {'fc_size': 10}
+            ]
+        )
+
+        inputs = tf.cast(inputs, tf.float32)
+        # flatten the image
+        inputs = tf.reshape(inputs, [inputs.shape[0], -1])
+        outputs = fc_stack(inputs)
+
+        return outputs
 
 
 class Stacked2DCNN:

--- a/ludwig/models/modules/image_encoders.py
+++ b/ludwig/models/modules/image_encoders.py
@@ -30,24 +30,24 @@ class ImageTestEncoder(Layer):
     ):
         super(ImageTestEncoder, self).__init__()
 
+        # use FCStack only for now as it is already implemented and 
+        # ConvStack2D is not
+        self.fc_stack = FCStack(
+            layers=[
+                {'fc_size': 10}
+            ]
+        )
+
     def call(self, inputs, training=None, mask=None):
         """
             :param inputs: The inputs fed into the encoder.
                    Shape: [batch x height x width x channels], type tf.uint8
         """
 
-        # use FCStack only for now as it is already implemented and 
-        # ConvStack2D is not
-        fc_stack = FCStack(
-            layers=[
-                {'fc_size': 10}
-            ]
-        )
-
         inputs = tf.cast(inputs, tf.float32)
         # flatten the image
         inputs = tf.reshape(inputs, [inputs.shape[0], -1])
-        outputs = fc_stack(inputs)
+        outputs = self.fc_stack(inputs)
 
         return outputs
 


### PR DESCRIPTION
Tested on MNIST dataset with the following model 

input_features:
    -
        name: image_path
        type: image
        preprocessing:
            in_memory: true

output_features:
    -
        name: label
        type: numerical

training:
    dropout_rate: 0.4

Using numerical outputs for now since categories are not implemented yet.

Added ImageTestEncoder which uses FCStack only (Conv stacks are not implemented yet) just to test end-to-end training.