### PR TITLE
Set encoding to UTF-8 for CSV dataset file

### DIFF
--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -60,7 +60,7 @@ def read_csv(data_fp, header=0, nrows=None, skiprows=None):
     """
 
     separator = ','
-    with open(data_fp, 'r') as csvfile:
+    with open(data_fp, 'r', encoding="utf8") as csvfile:
         try:
             dialect = csv.Sniffer().sniff(csvfile.read(1024 * 100),
                                           delimiters=[',', '\t', '|'])


### PR DESCRIPTION
In some cases where the default system's encoding is not UTF-8, some Python installations will use unexpected encoding when calling `open()` on a CSV dataset file. This results in Ludwig failing with a `UnicodeDecodeError` for some CSV files on Windows.

Since Ludwig docs [explicitly states the input CSV files are expected to be UTF-8](https://uber.github.io/ludwig/user_guide/#csv-format), `open()` calls for CSV files should set the encoding accordingly. This PR ensures that CSV files are always opened as UTF-8, thus eliminating the issue.