### PR TITLE
TF2 porting: implement 'encoder_output' key

### DIFF
--- a/ludwig/models/modules/binary_encoders.py
+++ b/ludwig/models/modules/binary_encoders.py
@@ -35,4 +35,4 @@ class BinaryPassthroughEncoder(Layer):
             :param inputs: The inputs fed into the encoder.
                    Shape: [batch x 1], type tf.float32
         """
-        return tf.cast(inputs, dtype=tf.float32)
+        return {'encoder_output': tf.cast(inputs, dtype=tf.float32)}

--- a/ludwig/models/modules/category_encoders.py
+++ b/ludwig/models/modules/category_encoders.py
@@ -36,7 +36,7 @@ class CategoricalPassthroughEncoder(Layer):
             :param inputs: The inputs fed into the encoder.
                    Shape: [batch x 1], type tf.int32
         """
-        return inputs
+        return {'encoder_output': inputs}
 
 
 class CategoricalEmbedEncoder(Layer):
@@ -97,7 +97,7 @@ class CategoricalEmbedEncoder(Layer):
         #           dimension
         embedded = tf.squeeze(embedded)
 
-        return embedded
+        return {'encoder_output': embedded}
 
 class CategoricalSparseEncoder(Layer):
 
@@ -157,4 +157,4 @@ class CategoricalSparseEncoder(Layer):
         #           dimension
         embedded = tf.squeeze(embedded)
 
-        return embedded
+        return {'encoder_output': embedded}

--- a/ludwig/models/modules/combiners.py
+++ b/ludwig/models/modules/combiners.py
@@ -91,12 +91,12 @@ class ConcatCombiner(tf.keras.Model):
             mask=None,
             **kwargs
     ):
-        encoder_outputs = inputs
+        encoder_outputs = [inputs[k]['encoder_output'] for k in inputs]
         # ================ Concat ================
         if len(encoder_outputs) > 1:
-            hidden = concatenate(encoder_outputs.values(), 1)
+            hidden = concatenate(encoder_outputs, 1)
         else:
-            hidden = list(encoder_outputs.values())[0]
+            hidden = list(encoder_outputs)[0]
 
         # ================ Fully Connected ================
         if self.fc_stack is not None:

--- a/ludwig/models/modules/image_encoders.py
+++ b/ludwig/models/modules/image_encoders.py
@@ -123,7 +123,7 @@ class Stacked2DCNN(Layer):
         # ================ Fully Connected ================
         outputs = self.fc_stack(hidden)
 
-        return outputs
+        return {'encoder_output': outputs}
 
 
 class ResNetEncoder:

--- a/ludwig/models/modules/numerical_encoders.py
+++ b/ludwig/models/modules/numerical_encoders.py
@@ -34,4 +34,4 @@ class NumericalPassthroughEncoder(Layer):
             :param inputs: The inputs fed into the encoder.
                    Shape: [batch x 1], type tf.float32
         """
-        return inputs
+        return {'encoder_output': inputs}


### PR DESCRIPTION
# Code Pull Requests

Numerical, Binary, Categorical and Image(Stacked2DCNN) encoders and ConcatCombiner class updated to reflect the change.
```
encoder_output = {
    'encoder_output': Tensor
}
```
