### PR TITLE
Add Grid Strategy to Hyperopt

### DIFF
--- a/ludwig/hyperopt.py
+++ b/ludwig/hyperopt.py
@@ -125,7 +125,7 @@ def hyperopt(
             raise ValueError(
                 'The data for the specified split for hyperopt "{}" '
                 'was not provided, '
-                'or the plit amount specified in the preprocessing section '
+                'or the split amount specified in the preprocessing section '
                 'of the model definition is not greater than 0'.format(split)
             )
     elif split == VALIDATION:
@@ -146,7 +146,7 @@ def hyperopt(
             raise ValueError(
                 'The data for the specified split for hyperopt "{}" '
                 'was not provided, '
-                'or the plit amount specified in the preprocessing section '
+                'or the split amount specified in the preprocessing section '
                 'of the model definition is not greater than 0'.format(split)
             )
     else:


### PR DESCRIPTION
#### Grid Strategy to sample the hyper-parameters for the Executor:

### Strategy

Example of grid strategy:
```yaml
strategy:
  type: grid
```

### Float parameters

For a `float` value, the parameters to specify are:
- `low`: minimum value
- `high`: maximum value
- `scale`: `log` or `linear`
- `steps`: OPTIONAL number of steps. NEEDED by the gird strategy. For instance min:0.0, max:1.0, steps 3 would yeald [0.0, 0.5, 1.0] for the grid search

In the future the distribution to use (`uniform`, `gaussian`, `gamma`, etc.) with the distribution parameters could be specified, but to begin with just those parameters are sufficient.

Example:
```yaml
training.learning_rate:
  type: float
  low: 0.0001
  high: 0.1
  scale: linear
```


### Int parameters

For an `int` value, the parameters to specify are:
- `low`: minimum value
- `high`: maximum value
- `steps`: OPTIONAL number of steps. NEEDED by the gird strategy. For instance min:0, max:10, steps 3 would yield [0, 5, 10] for the grid search

Example:
```yaml
combiner.num_fc_layers:
  type: int
  low: 0
  high: 5
```


### Category parameters

For a `category` value, the parameters to specify are:
- `values`: a list of possible values. The type of each value of the list is not important (they could be strings, integers, floats and anything else).
- `probabilties`: an OPTIONAL list of float values, that have to sum up to 1, of the same length of the `values` value. It associates a probability to each element of `values` for sampling purposes.

Example:
```yaml
utterance.cell_type:
  type: category
  values: [rnn, gru, lstm]
  probabilities: [0.3, 0.3, 0.5]  # OPTIONAL
```