### PR TITLE
TF2 porting: make categorical targets and predictions consistent dtype

### DIFF
--- a/ludwig/models/modules/loss_modules.py
+++ b/ludwig/models/modules/loss_modules.py
@@ -79,7 +79,7 @@ class SoftmaxCrossEntropyLoss(tf.keras.losses.Loss):
 
     def call(self, y, y_pred):
         vector_labels = tf.one_hot(
-            tf.cast(y, dtype=tf.int32),
+            tf.cast(y, dtype=tf.int64),
             self.num_classes
         )
 
@@ -108,7 +108,7 @@ class SampledSoftmaxCrossEntropyLoss(tf.keras.losses.Loss):
 
     def call(self, y, y_pred):
         vector_labels = tf.one_hot(
-            tf.cast(y, dtype=tf.int32),
+            tf.cast(y, dtype=tf.int64),
             self.num_classes
         )
 
@@ -156,8 +156,6 @@ class SequenceLoss(tf.keras.losses.Loss):
             sample_weight=sample_mask
         )
         return loss  # vector of shape [batch_size,]
-
-
 
 # end of custom classes
 

--- a/ludwig/models/modules/metric_modules.py
+++ b/ludwig/models/modules/metric_modules.py
@@ -250,6 +250,20 @@ class TokenAccuracyMetric(tf.keras.metrics.Mean):
 
         super().update_state(masked_corrected_predictions)
 
+
+class CategoryAccuracy(tf.keras.metrics.Accuracy):
+    def __init__(self, name=None):
+        super(CategoryAccuracy, self).__init__(name=name)
+
+    def update_state(self, y_true, y_pred, sample_weight=None):
+        # make sure y_true is tf.int64
+        super().update_state(
+            tf.cast(y_true, dtype=tf.int64),
+            y_pred,
+            sample_weight=sample_weight
+        )
+
+
 # end of custom classes
 
 


### PR DESCRIPTION
# Code Pull Requests

Implements this change: https://github.com/uber/ludwig/pull/682#issuecomment-616269006
This is casts categorical targets and predictions to tf.int64

