### PR TITLE
Use the standard library for CPUs count instead of psutil

### DIFF
--- a/ludwig/utils/hyperopt_utils.py
+++ b/ludwig/utils/hyperopt_utils.py
@@ -27,7 +27,6 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Tuple, Iterable
 
 import numpy as np
-import psutil
 
 from ludwig.constants import EXECUTOR, STRATEGY, MINIMIZE, COMBINED, LOSS, VALIDATION, MAXIMIZE, TRAINING, TEST
 from ludwig.data.postprocessing import postprocess
@@ -517,14 +516,7 @@ class ParallelExecutor(HyperoptExecutor):
 
         if gpus is not None:
 
-            num_available_cpus = psutil.cpu_count(logical=False)
-
-            if num_available_cpus is None:
-                num_available_cpus = psutil.cpu_count()
-                logger.warning(
-                    'WARNING: Couldn\'t get the number of physical cores '
-                    'from the OS, using the logical cores instead.'
-                )
+            num_available_cpus = multiprocessing.cpu_count()
 
             if self.num_workers > num_available_cpus:
                 logger.warning(

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ scipy>=0.18
 tabulate>=0.7
 scikit-learn
 tqdm
-psutil
 tensorflow==1.15.2
 PyYAML>=3.12
 absl-py


### PR DESCRIPTION
After running a test of training ten instances of models with Pool using 4 cores (`mp.cpu_count`) and 2 cores (`psutil.cpu_count(logical=False)`). There wasn't much difference in the task completion time for both the approaches. The CPU utilization among the cores was the difference, as the logical cores spend time swapping as well. There was no apparent degradation in performance by using logical cores. Hence, we decided to go with the standard library than using `psutil`.