### PR TITLE
tensorflow-addons fixed version range

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ tabulate>=0.7
 scikit-learn
 tqdm
 tensorflow==2.1
-tensorflow-addons
+tensorflow-addons>=0.7.1,<=0.9.1
 PyYAML>=3.12
 absl-py

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ scipy>=0.18
 tabulate>=0.7
 scikit-learn
 tqdm
-tensorflow==2.1
-tensorflow-addons>=0.7.1,<=0.9.1
+tensorflow==2.2
+tensorflow-addons>=0.9.1
 PyYAML>=3.12
 absl-py


### PR DESCRIPTION
tensorflow-addons==0.10.0 is only compatible with tensorflow==2.2.0
Setting lower and higher limit as per https://github.com/tensorflow/addons

(pytest was failing hard looking for random number generator introduced in 2.2.0)