### PR TITLE
Cache pre-trained embeddings

### DIFF
--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -22,6 +22,7 @@ import os.path
 import pickle
 import random
 import re
+import functools
 
 import h5py
 import numpy as np
@@ -204,6 +205,7 @@ def load_pretrained_embeddings(embeddings_path, vocab):
     return embeddings_matrix
 
 
+@functools.lru_cache(1)
 def load_glove(file_path):
     logger.info('  Loading Glove format file {}'.format(file_path))
     embeddings = {}


### PR DESCRIPTION
# Code Pull Requests

Please provide the following:

- a clear explanation of what your code dose

When multiple input features are using the same pre-trained embeddings ludwig loads the embedding from scratch for each feature - thus it takes a lot of time to even begin training. This change prevents that, at the cost of keeping the most recent embedding in memory.

- if applicable, a reference to an issue
- a reproducible test for your PR (code, model definition and data sample)

# Documentation Pull Requests

Note that the documentation HTML files are in `docs/` while the Markdown sources are in `mkdocs/docs`.

If you are proposing a modification to the documentation you should change only the Markdown files.

`api.md` is automatically generated from the docstrings in the code, so if you want to change something in that file, first modify `ludwig/api.py` docstring, then run `mkdocs/code_docs_autogen.py`, which will create `mkdocs/docs/api.md` .
