### PR TITLE
Convert neuropod output float32 np array to float64

### DIFF
--- a/ludwig/neuropod_export.py
+++ b/ludwig/neuropod_export.py
@@ -52,18 +52,18 @@ def postprocess_for_neuropod(predicted, model_definition):
                 np.expand_dims(
                     predicted[feature_name]['predictions'].astype('str'), 1)
             postprocessed[feature_name + "_probabilities"] = \
-                np.expand_dims(predicted[feature_name]['probabilities'], 1)
+                np.expand_dims(predicted[feature_name]['probabilities'].astype('float64'), 1)
         elif feature_type == NUMERICAL:
             postprocessed[feature_name + "_predictions"] = \
-                np.expand_dims(predicted[feature_name]['predictions'], 1)
+                np.expand_dims(predicted[feature_name]['predictions'].astype('float64'), 1)
         elif feature_type == CATEGORY:
             postprocessed[feature_name + "_predictions"] = np.expand_dims(
                 np.array(predicted[feature_name]['predictions'], dtype='str'), 1
             )
             postprocessed[feature_name + "_probability"] = \
-                np.expand_dims(predicted[feature_name]['probability'], 1)
+                np.expand_dims(predicted[feature_name]['probability'].astype('float64'), 1)
             postprocessed[feature_name + "_probabilities"] = \
-                predicted[feature_name]['probabilities']
+                predicted[feature_name]['probabilities'].astype('float64')
         elif feature_type == SEQUENCE:
             predictions = list(map(
                 lambda x: ' '.join(x),
@@ -96,10 +96,10 @@ def postprocess_for_neuropod(predicted, model_definition):
                 np.array(probability, dtype='str'), 1
             )
             postprocessed[feature_name + "_probabilities"] = \
-                predicted[feature_name]['probabilities']
+                predicted[feature_name]['probabilities'].astype('float64')
         elif feature_type == VECTOR:
             postprocessed[feature_name + "_predictions"] = \
-                predicted[feature_name]['predictions']
+                predicted[feature_name]['predictions'].astype('float64')
         else:
             postprocessed[feature_name + "_predictions"] = np.expand_dims(
                 np.array(predicted[feature_name]['predictions'], dtype='str'), 1
@@ -189,13 +189,13 @@ def export_neuropod(
             })
             output_spec.append({
                 "name": feature['name'] + '_probabilities',
-                "dtype": "float32",
+                "dtype": "float64",
                 "shape": (None, 1)
             })
         elif feature_type == NUMERICAL:
             output_spec.append({
                 "name": feature['name'] + '_predictions',
-                "dtype": "float32",
+                "dtype": "float64",
                 "shape": (None, 1)
             })
         elif feature_type == CATEGORY:
@@ -206,12 +206,12 @@ def export_neuropod(
             })
             output_spec.append({
                 "name": feature['name'] + '_probability',
-                "dtype": "float32",
+                "dtype": "float64",
                 "shape": (None, 1)
             })
             output_spec.append({
                 "name": feature['name'] + '_probabilities',
-                "dtype": "float32",
+                "dtype": "float64",
                 "shape": (
                     None, training_set_metadata[feature_name]['vocab_size']
                 )
@@ -241,7 +241,7 @@ def export_neuropod(
             })
             output_spec.append({
                 "name": feature['name'] + '_probabilities',
-                "dtype": "float32",
+                "dtype": "float64",
                 "shape": (
                     None, training_set_metadata[feature_name]['vocab_size']
                 )
@@ -249,7 +249,7 @@ def export_neuropod(
         elif feature_type == VECTOR:
             output_spec.append({
                 "name": feature['name'] + '_predictions',
-                "dtype": "float32",
+                "dtype": "float64",
                 "shape": (
                     None, training_set_metadata[feature_name]['vector_size']
                 )


### PR DESCRIPTION
convert the float32 np ndarray to float64 to make it compatible with neuropod and spark.