### PR TITLE
TF2 porting: Date Feature and Encoders

### DIFF
--- a/ludwig/features/date_feature.py
+++ b/ludwig/features/date_feature.py
@@ -116,11 +116,11 @@ class DateBaseFeature(BaseFeature):
 
 
 class DateInputFeature(DateBaseFeature, InputFeature):
+    encoder = 'embed'
+
     def __init__(self, feature, encoder_obj=None):
         DateBaseFeature.__init__(self, feature)
         InputFeature.__init__(self)
-
-        self.encoder = 'embed'
 
         self.overwrite_defaults(feature)
         if encoder_obj:

--- a/ludwig/features/date_feature.py
+++ b/ludwig/features/date_feature.py
@@ -26,7 +26,7 @@ from ludwig.constants import *
 from ludwig.features.base_feature import BaseFeature
 from ludwig.features.base_feature import InputFeature
 from ludwig.models.modules.date_encoders import DateEmbed, DateWave
-from ludwig.utils.misc import set_default_value, get_from_registry
+from ludwig.utils.misc import set_default_value
 
 logger = logging.getLogger(__name__)
 
@@ -117,7 +117,8 @@ class DateBaseFeature(BaseFeature):
 
 class DateInputFeature(DateBaseFeature, InputFeature):
     def __init__(self, feature, encoder_obj=None):
-        super().__init__(feature)
+        DateBaseFeature.__init__(self, feature)
+        InputFeature.__init__(self)
 
         self.encoder = 'embed'
 
@@ -129,57 +130,13 @@ class DateInputFeature(DateBaseFeature, InputFeature):
 
     def call(self, inputs, training=None, mask=None):
         assert isinstance(inputs, tf.Tensor)
-        assert inputs.dtype == tf.uint8
-        # assert len(inputs.shape) == 1
+        assert inputs.dtype == tf.int16
 
         inputs_encoded = self.encoder_obj(
             inputs, training=training, mask=mask
         )
 
         return inputs_encoded
-
-
-    # def get_date_encoder(self, encoder_parameters):
-    #     return get_from_registry(
-    #         self.encoder, date_encoder_registry)(
-    #         **encoder_parameters
-    #     )
-    #
-    # def _get_input_placeholder(self):
-    #     # None dimension is for dealing with variable batch size
-    #     return tf.placeholder(
-    #         tf.int32,
-    #         shape=[None, DATE_VECTOR_LENGTH],
-    #         name=self.feature_name
-    #     )
-    #
-    # def build_input(
-    #         self,
-    #         regularizer,
-    #         dropout_rate,
-    #         is_training=False,
-    #         **kwargs
-    # ):
-    #     placeholder = self._get_input_placeholder()
-    #     logger.debug('placeholder: {0}'.format(placeholder))
-    #
-    #     feature_representation, feature_representation_size = self.encoder_obj(
-    #         placeholder,
-    #         regularizer=regularizer,
-    #         dropout_rate=dropout_rate,
-    #         is_training=is_training
-    #     )
-    #     logging.debug('  feature_representation: {0}'.format(
-    #         feature_representation))
-    #
-    #     feature_representation = {
-    #         'name': self.feature_name,
-    #         'type': self.type,
-    #         'representation': feature_representation,
-    #         'size': feature_representation_size,
-    #         'placeholder': placeholder
-    #     }
-    #     return feature_representation
 
     @staticmethod
     def update_model_definition_with_metadata(

--- a/ludwig/features/date_feature.py
+++ b/ludwig/features/date_feature.py
@@ -34,15 +34,16 @@ DATE_VECTOR_LENGTH = 9
 
 
 class DateBaseFeature(BaseFeature):
-    def __init__(self, feature):
-        super().__init__(feature)
-        self.type = DATE
-
+    type = DATE
     preprocessing_defaults = {
         'missing_value_strategy': FILL_WITH_CONST,
         'fill_value': '',
         'datetime_format': None
     }
+
+    def __init__(self, feature):
+        super().__init__(feature)
+
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters):
@@ -115,56 +116,70 @@ class DateBaseFeature(BaseFeature):
 
 
 class DateInputFeature(DateBaseFeature, InputFeature):
-    def __init__(self, feature):
+    def __init__(self, feature, encoder_obj=None):
         super().__init__(feature)
 
         self.encoder = 'embed'
 
-        encoder_parameters = self.overwrite_defaults(feature)
+        self.overwrite_defaults(feature)
+        if encoder_obj:
+            self.encoder_obj = encoder_obj
+        else:
+            self.encoder_obj = self.initialize_encoder(feature)
 
-        self.encoder_obj = self.get_date_encoder(encoder_parameters)
+    def call(self, inputs, training=None, mask=None):
+        assert isinstance(inputs, tf.Tensor)
+        assert inputs.dtype == tf.uint8
+        # assert len(inputs.shape) == 1
 
-    def get_date_encoder(self, encoder_parameters):
-        return get_from_registry(
-            self.encoder, date_encoder_registry)(
-            **encoder_parameters
+        inputs_encoded = self.encoder_obj(
+            inputs, training=training, mask=mask
         )
 
-    def _get_input_placeholder(self):
-        # None dimension is for dealing with variable batch size
-        return tf.placeholder(
-            tf.int32,
-            shape=[None, DATE_VECTOR_LENGTH],
-            name=self.feature_name
-        )
+        return inputs_encoded
 
-    def build_input(
-            self,
-            regularizer,
-            dropout_rate,
-            is_training=False,
-            **kwargs
-    ):
-        placeholder = self._get_input_placeholder()
-        logger.debug('placeholder: {0}'.format(placeholder))
 
-        feature_representation, feature_representation_size = self.encoder_obj(
-            placeholder,
-            regularizer=regularizer,
-            dropout_rate=dropout_rate,
-            is_training=is_training
-        )
-        logging.debug('  feature_representation: {0}'.format(
-            feature_representation))
-
-        feature_representation = {
-            'name': self.feature_name,
-            'type': self.type,
-            'representation': feature_representation,
-            'size': feature_representation_size,
-            'placeholder': placeholder
-        }
-        return feature_representation
+    # def get_date_encoder(self, encoder_parameters):
+    #     return get_from_registry(
+    #         self.encoder, date_encoder_registry)(
+    #         **encoder_parameters
+    #     )
+    #
+    # def _get_input_placeholder(self):
+    #     # None dimension is for dealing with variable batch size
+    #     return tf.placeholder(
+    #         tf.int32,
+    #         shape=[None, DATE_VECTOR_LENGTH],
+    #         name=self.feature_name
+    #     )
+    #
+    # def build_input(
+    #         self,
+    #         regularizer,
+    #         dropout_rate,
+    #         is_training=False,
+    #         **kwargs
+    # ):
+    #     placeholder = self._get_input_placeholder()
+    #     logger.debug('placeholder: {0}'.format(placeholder))
+    #
+    #     feature_representation, feature_representation_size = self.encoder_obj(
+    #         placeholder,
+    #         regularizer=regularizer,
+    #         dropout_rate=dropout_rate,
+    #         is_training=is_training
+    #     )
+    #     logging.debug('  feature_representation: {0}'.format(
+    #         feature_representation))
+    #
+    #     feature_representation = {
+    #         'name': self.feature_name,
+    #         'type': self.type,
+    #         'representation': feature_representation,
+    #         'size': feature_representation_size,
+    #         'placeholder': placeholder
+    #     }
+    #     return feature_representation
 
     @staticmethod
     def update_model_definition_with_metadata(
@@ -180,7 +195,7 @@ class DateInputFeature(DateBaseFeature, InputFeature):
         set_default_value(input_feature, TIED, None)
 
 
-date_encoder_registry = {
-    'embed': DateEmbed,
-    'wave': DateWave
-}
+    encoder_registry = {
+        'embed': DateEmbed,
+        'wave': DateWave
+    }


### PR DESCRIPTION
# Code Pull Requests
Port of the Date encoders and feature.  One item to mention. 
* I had to modify some of the tf dtype to get it to work.  

This change passes the `test_experiment.py::test_experiment_date` unit test.
``` 
ytest -v test_experiment.py::test_experiment_date
======================================== test session starts ========================================
platform linux -- Python 3.6.9, pytest-5.4.3, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /opt/project
plugins: pycharm-0.6.0, typeguard-2.8.0
collected 1 item

test_experiment.py::test_experiment_date PASSED                                               [100%]

========================================= warnings summary ==========================================
/usr/local/lib/python3.6/dist-packages/tensorflow/python/pywrap_tensorflow_internal.py:15
  /usr/local/lib/python3.6/dist-packages/tensorflow/python/pywrap_tensorflow_internal.py:15: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    import imp

tests/integration_tests/test_experiment.py::test_experiment_date
tests/integration_tests/test_experiment.py::test_experiment_date
  /usr/local/lib/python3.6/dist-packages/sklearn/metrics/_classification.py:1221: UndefinedMetricWarning: Precision is ill-defined and being set to 0.0 in labels with no predicted samples. Use `zero_division` parameter to control this behavior.
    _warn_prf(average, modifier, msg_start, len(result))

tests/integration_tests/test_experiment.py::test_experiment_date
  /usr/local/lib/python3.6/dist-packages/sklearn/metrics/_classification.py:1221: UndefinedMetricWarning: Recall is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.
    _warn_prf(average, modifier, msg_start, len(result))

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=================================== 1 passed, 4 warnings in 3.38s ==================================
```

