### PR TITLE
TF2 porting: h3 feature (re-submission)

### DIFF
--- a/ludwig/features/h3_feature.py
+++ b/ludwig/features/h3_feature.py
@@ -95,9 +95,8 @@ class H3InputFeature(H3BaseFeature, InputFeature):
         # assert inputs.dtype == tf.float32 or inputs.dtype == tf.float64
         # assert len(inputs.shape) == 1
 
-        inputs_exp = inputs[:, tf.newaxis]
         inputs_encoded = self.encoder_obj(
-            inputs_exp, training=training, mask=mask
+            inputs, training=training, mask=mask
         )
 
         return inputs_encoded

--- a/ludwig/features/h3_feature.py
+++ b/ludwig/features/h3_feature.py
@@ -88,6 +88,19 @@ class H3InputFeature(H3BaseFeature, InputFeature):
             self.encoder_obj = self.initialize_encoder(feature)
 
 
+    def call(self, inputs, training=None, mask=None):
+        assert isinstance(inputs, tf.Tensor)
+        # assert inputs.dtype == tf.float32 or inputs.dtype == tf.float64
+        # assert len(inputs.shape) == 1
+
+        inputs_exp = inputs[:, tf.newaxis]
+        inputs_encoded = self.encoder_obj(
+            inputs_exp, training=training, mask=mask
+        )
+
+        return inputs_encoded
+
+
     @staticmethod
     def update_model_definition_with_metadata(
             input_feature,
@@ -102,8 +115,8 @@ class H3InputFeature(H3BaseFeature, InputFeature):
         set_default_value(input_feature, TIED, None)
 
 
-    encoder_registry = {
-        'embed': H3Embed,
-        'weighted_sum': H3WeightedSum,
-        'rnn': H3RNN
-    }
+encoder_registry = {
+    'embed': H3Embed,
+    'weighted_sum': H3WeightedSum,
+    'rnn': H3RNN
+}

--- a/ludwig/features/h3_feature.py
+++ b/ludwig/features/h3_feature.py
@@ -34,15 +34,15 @@ H3_PADDING_VALUE = 7
 
 
 class H3BaseFeature(BaseFeature):
-    def __init__(self, feature):
-        super().__init__(feature)
-        self.type = H3
-
+    type = H3
     preprocessing_defaults = {
         'missing_value_strategy': FILL_WITH_CONST,
         'fill_value': 576495936675512319
         # mode 1 edge 0 resolution 0 base_cell 0
     }
+
+    def __init__(self, feature):
+        super().__init__(feature)
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters):
@@ -66,9 +66,7 @@ class H3BaseFeature(BaseFeature):
     def add_feature_data(
             feature,
             dataset_df,
-            data,
-            metadata,
-            preprocessing_parameters=None
+            data
     ):
         data[feature['name']] = np.array(
             [H3BaseFeature.h3_to_list(row)
@@ -77,56 +75,18 @@ class H3BaseFeature(BaseFeature):
 
 
 class H3InputFeature(H3BaseFeature, InputFeature):
-    def __init__(self, feature):
-        super().__init__(feature)
+    encoder = 'embed'
 
-        self.encoder = 'embed'
+    def __init__(self, feature, encoder_obj=None):
+        H3BaseFeature.__init__(self, feature)
+        InputFeature.__init__(self)
 
-        encoder_parameters = self.overwrite_defaults(feature)
+        self.overwrite_defaults(feature)
+        if encoder_obj:
+            self.encoder_obj = encoder_obj
+        else:
+            self.encoder_obj = self.initialize_encoder(feature)
 
-        self.encoder_obj = self.get_h3_encoder(encoder_parameters)
-
-    def get_h3_encoder(self, encoder_parameters):
-        return get_from_registry(
-            self.encoder, h3_encoder_registry)(
-            **encoder_parameters
-        )
-
-    def _get_input_placeholder(self):
-        # None dimension is for dealing with variable batch size
-        return tf.placeholder(
-            tf.int32,
-            shape=[None, H3_VECTOR_LENGTH],
-            name=self.feature_name
-        )
-
-    def build_input(
-            self,
-            regularizer,
-            dropout_rate,
-            is_training=False,
-            **kwargs
-    ):
-        placeholder = self._get_input_placeholder()
-        logger.debug('placeholder: {0}'.format(placeholder))
-
-        feature_representation, feature_representation_size = self.encoder_obj(
-            placeholder,
-            regularizer=regularizer,
-            dropout_rate=dropout_rate,
-            is_training=is_training
-        )
-        logging.debug('  feature_representation: {0}'.format(
-            feature_representation))
-
-        feature_representation = {
-            'name': self.feature_name,
-            'type': self.type,
-            'representation': feature_representation,
-            'size': feature_representation_size,
-            'placeholder': placeholder
-        }
-        return feature_representation
 
     @staticmethod
     def update_model_definition_with_metadata(
@@ -142,8 +102,8 @@ class H3InputFeature(H3BaseFeature, InputFeature):
         set_default_value(input_feature, TIED, None)
 
 
-h3_encoder_registry = {
-    'embed': H3Embed,
-    'weighted_sum': H3WeightedSum,
-    'rnn': H3RNN
-}
+    encoder_registry = {
+        'embed': H3Embed,
+        'weighted_sum': H3WeightedSum,
+        'rnn': H3RNN
+    }

--- a/ludwig/features/h3_feature.py
+++ b/ludwig/features/h3_feature.py
@@ -92,8 +92,8 @@ class H3InputFeature(H3BaseFeature, InputFeature):
 
     def call(self, inputs, training=None, mask=None):
         assert isinstance(inputs, tf.Tensor)
-        # assert inputs.dtype == tf.float32 or inputs.dtype == tf.float64
-        # assert len(inputs.shape) == 1
+        assert inputs.dtype == tf.uint8
+        assert len(inputs.shape) == 2
 
         inputs_encoded = self.encoder_obj(
             inputs, training=training, mask=mask

--- a/ludwig/features/h3_feature.py
+++ b/ludwig/features/h3_feature.py
@@ -66,7 +66,9 @@ class H3BaseFeature(BaseFeature):
     def add_feature_data(
             feature,
             dataset_df,
-            data
+            data,
+            metadata,
+            preprocessing_parameters
     ):
         data[feature['name']] = np.array(
             [H3BaseFeature.h3_to_list(row)
@@ -114,9 +116,8 @@ class H3InputFeature(H3BaseFeature, InputFeature):
     def populate_defaults(input_feature):
         set_default_value(input_feature, TIED, None)
 
-
-encoder_registry = {
-    'embed': H3Embed,
-    'weighted_sum': H3WeightedSum,
-    'rnn': H3RNN
-}
+    encoder_registry = {
+        'embed': H3Embed,
+        'weighted_sum': H3WeightedSum,
+        'rnn': H3RNN
+    }

--- a/ludwig/models/modules/h3_encoders.py
+++ b/ludwig/models/modules/h3_encoders.py
@@ -397,7 +397,19 @@ class H3RNN(Layer):
             state_size=10,
             cell_type='rnn',
             bidirectional=False,
-            dropout=False,
+            activation='tanh',
+            recurrent_activation='sigmoid',
+            use_bias=True,
+            unit_forget_bias=True,
+            weights_initializer='glorot_uniform',
+            recurrent_initializer='orthogonal',
+            bias_initializer='zeros',
+            weights_regularizer=None,
+            recurrent_regularizer=None,
+            bias_regularizer=None,
+            activity_regularizer=None,
+            dropout_rate=0.0,
+            recurrent_dropout=0.0,
             initializer=None,
             regularize=True,
             reduce_output='last',
@@ -434,9 +446,42 @@ class H3RNN(Layer):
                    encoding in the forward and backward direction and
                    their outputs will be concatenated.
             :type bidirectional: Boolean
-            :param dropout: determines if there should be a dropout layer before
+            :param activation: Activation function to use.
+            :type activation: string
+            :param recurrent_activation: Activation function to use for the
+                    recurrent step.
+            :type recurrent_activation: string
+            :param use_bias: bool determines where to use a bias vector
+            :type use_bias: bool
+            :param unit_forget_bias: if True add 1 to the bias forget gate at
+                   initialization.
+            :type unit_forget_bias: bool
+            :param weights_initializer: Initializer for the weights (aka kernel)
+                   matrix
+            :type weights_initializer: string
+            :param recurrent_initializer: Initializer for the recurrent weights
+                   matrix
+            :type recurrent_initializer: string
+            :param bias_initializer: Initializer for the bias vector
+            :type bias_initializer: string
+            :param weights_regularizer: regularizer applied to the weights
+                   (kernal) matrix
+            :type weights_regularizer: string
+            :param recurrent_regularizer: Regularizer for the recurrent weights
+                   matrix
+            :type recurrent_regularizer: string
+            :param bias_regularizer: reguralizer function applied to biase vector.
+            :type bias_regularizer: string
+            :param activity_regularizer: Regularizer applied to the output of the
+                   layer (activation)
+            :type activity_regularizer: string
+            :param dropout_rate: determines if there should be a dropout layer before
                    returning the encoder output.
-            :type dropout: Boolean
+            :type dropout_rate: float
+            :param recurrent_dropout: Float between 0.0 and 1.0.  Fraction of
+                   the units to drop for the linear transformation of the
+                   recurrent state.
+            :type recurrent_dropout: float
             :param initializer: the initializer to use. If `None` it uses
                    `glorot_uniform`. Options are: `constant`, `identity`,
                    `zeros`, `ones`, `orthogonal`, `normal`, `uniform`,
@@ -472,7 +517,7 @@ class H3RNN(Layer):
         self.h3_embed = H3Embed(
             embedding_size,
             embeddings_on_cpu=embeddings_on_cpu,
-            dropout=dropout,
+            dropout=dropout_rate,
             initializer=initializer,
             regularize=regularize,
             reduce_output=None
@@ -483,7 +528,19 @@ class H3RNN(Layer):
             cell_type=cell_type,
             num_layers=num_layers,
             bidirectional=bidirectional,
-            dropout=dropout,
+            activation=activation,
+            recurrent_activation=recurrent_activation,
+            use_bias=use_bias,
+            unit_forget_bias=unit_forget_bias,
+            weights_initializer=weights_initializer,
+            recurrent_initializer=recurrent_initializer,
+            bias_initializer=bias_initializer,
+            weights_regularizer=weights_regularizer,
+            recurrent_regularizer=recurrent_regularizer,
+            bias_regularizer=bias_regularizer,
+            activity_regularizer=activity_regularizer,
+            dropout=dropout_rate,
+            recurrent_dropout=recurrent_dropout,
             regularize=regularize,
             reduce_output=reduce_output
         )

--- a/ludwig/models/modules/h3_encoders.py
+++ b/ludwig/models/modules/h3_encoders.py
@@ -319,12 +319,10 @@ class H3WeightedSum(Layer):
             dropout=dropout_rate,
             initializer=weights_initializer,
             regularize=weights_regularizer,
-            reduce_output='None',
+            reduce_output=None,
         )
 
-        # renamed from self.weights to self.h3_weights
-        # apparent conflict with `weight` attribute in super class
-        self.h3_weights = tf.Variable(
+        self.aggregation_weights = tf.Variable(
             get_initializer(weights_initializer)([19, 1])
         )
 
@@ -371,9 +369,9 @@ class H3WeightedSum(Layer):
 
         # ================ Weighted Sum ================
         if self.should_softmax:
-            weights = tf.nn.softmax(self.h3_weights)
+            weights = tf.nn.softmax(self.aggregation_weights)
         else:
-            weights = self.h3_weights
+            weights = self.aggregation_weights
 
         hidden = reduce_sum(embedded_h3['encoder_output'] * weights)
 
@@ -477,7 +475,7 @@ class H3RNN(Layer):
             dropout=dropout,
             initializer=initializer,
             regularize=regularize,
-            reduce_output='None'
+            reduce_output=None
         )
 
         self.recurrent_stack = RecurrentStack(
@@ -505,11 +503,10 @@ class H3RNN(Layer):
             :param mask: bool tensor encoding masked timesteps in the input
             :type mask: bool
          """
-        input_vector = inputs
 
         # ================ Embeddings ================
         embedded_h3 = self.h3_embed(
-            input_vector,
+            inputs,
             training=training,
             mask=mask
         )

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -23,6 +23,7 @@ import yaml
 from ludwig.data.concatenate_datasets import concatenate_df
 from ludwig.experiment import full_experiment
 from ludwig.predict import full_predict
+from ludwig.features.h3_feature import H3InputFeature
 from ludwig.utils.data_utils import read_csv
 from tests.integration_tests.utils import ENCODERS
 from tests.integration_tests.utils import audio_feature
@@ -612,7 +613,7 @@ def test_experiment_date(csv_filename):
         input_features[0]['encoder'] = encoder
         run_experiment(input_features, output_features, data_csv=rel_path)
 
-@pytest.mark.parametrize('encoder', ['embed', 'weighted_sum', 'rnn'])
+@pytest.mark.parametrize('encoder', H3InputFeature.encoder_registry.keys())
 def test_experiment_h3(encoder, csv_filename):
     input_features = [h3_feature()]
     output_features = [binary_feature()]

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -22,7 +22,7 @@ import yaml
 
 from ludwig.data.concatenate_datasets import concatenate_df
 from ludwig.experiment import full_experiment
-from ludwig.features.h3_feature import h3_encoder_registry
+from ludwig.features.h3_feature import encoder_registry as h3_encoder_registry
 from ludwig.predict import full_predict
 from ludwig.utils.data_utils import read_csv
 from tests.integration_tests.utils import ENCODERS

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -22,7 +22,6 @@ import yaml
 
 from ludwig.data.concatenate_datasets import concatenate_df
 from ludwig.experiment import full_experiment
-from ludwig.features.h3_feature import encoder_registry as h3_encoder_registry
 from ludwig.predict import full_predict
 from ludwig.utils.data_utils import read_csv
 from tests.integration_tests.utils import ENCODERS
@@ -613,16 +612,16 @@ def test_experiment_date(csv_filename):
         input_features[0]['encoder'] = encoder
         run_experiment(input_features, output_features, data_csv=rel_path)
 
-
-def test_experiment_h3(csv_filename):
+@pytest.mark.parametrize('encoder', ['embed', 'weighted_sum', 'rnn'])
+def test_experiment_h3(encoder, csv_filename):
     input_features = [h3_feature()]
     output_features = [binary_feature()]
 
     # Generate test data
     rel_path = generate_data(input_features, output_features, csv_filename)
-    for encoder in h3_encoder_registry:
-        input_features[0]['encoder'] = encoder
-        run_experiment(input_features, output_features, data_csv=rel_path)
+
+    input_features[0]['encoder'] = encoder
+    run_experiment(input_features, output_features, data_csv=rel_path)
 
 
 def test_experiment_vector_feature_1(csv_filename):

--- a/tests/integration_tests/test_simple_features.py
+++ b/tests/integration_tests/test_simple_features.py
@@ -14,32 +14,15 @@
 # limitations under the License.
 # ==============================================================================
 import logging
-import os
 import shutil
 
 import pytest
-import yaml
 
-from ludwig.data.concatenate_datasets import concatenate_df
 from ludwig.experiment import full_experiment
-from ludwig.features.h3_feature import h3_encoder_registry
-from ludwig.predict import full_predict
-from ludwig.utils.data_utils import read_csv
-from tests.integration_tests.utils import ENCODERS
-from tests.integration_tests.utils import audio_feature
-from tests.integration_tests.utils import bag_feature
 from tests.integration_tests.utils import binary_feature
 from tests.integration_tests.utils import category_feature
-from tests.integration_tests.utils import date_feature
 from tests.integration_tests.utils import generate_data
-from tests.integration_tests.utils import h3_feature
-from tests.integration_tests.utils import image_feature
 from tests.integration_tests.utils import numerical_feature
-from tests.integration_tests.utils import sequence_feature
-from tests.integration_tests.utils import set_feature
-from tests.integration_tests.utils import text_feature
-from tests.integration_tests.utils import timeseries_feature
-from tests.integration_tests.utils import vector_feature
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)


### PR DESCRIPTION
# Code Pull Requests

This is still work-in-progress.  I wanted to give you an early look into the progress.  Right now I have the `embed` and `weighted_sum` passing the unit test.  I have not started on `rnn` encoder yet.

```
pytest -v test_experiment.py::test_experiment_h3
=========================================================== test session starts ============================================================
platform linux -- Python 3.6.9, pytest-5.4.3, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /opt/project
plugins: pycharm-0.6.0, typeguard-2.8.0
collected 3 items

test_experiment.py::test_experiment_h3[embed] PASSED                                                                                 [ 33%]
test_experiment.py::test_experiment_h3[weighted_sum] PASSED                                                                          [ 66%]
test_experiment.py::test_experiment_h3[rnn] FAILED                                                                                   [100%]
```

re: the `weighted_sum` encoder, I had to rename the `self.weights` instance variable.  This came about when I made `H3WeightedSum` a subclass of `tf.keras.layers.Layer`.  It appears that `tf.keras.layers.Layer` has a read-only attribute called `weights`.    This caused an error when the `H3WeightedSum` constructor executed.  

I renamed `self.weights` to `self.h3_weights` and modified the subsequent code as needed.  AFAICT, I made all adjustments for the new name of `self.h3_weights`.  I'd appreciate if you double check this change.

Second to better understand the H3 encoder, I reviewed the ludwig user doc.  I noticed a issue.  The description of the H3 encoder is word for word the same as for the Date encoder:
```
H3 Input Features and Encoders¶

Input date features are transformed into a int valued tensors of size N x 8 (where N is the size
of the dataset and the 8 dimensions contain year, month, day, weekday, yearday, hour, 
minute and second) and added to HDF5 with a key that reflects the name of column in the CSV.

Currently there are two encoders supported for dates: Embed Encoder and Wave encoder 
which can be set by setting encoder parameter to embed or wave in the input feature dictionary 
in the model definition (embed is the default one).
```
I was going to open an issue re: this observation but I noticed all the documentation content was moved out of the repo a few days ago.  So I'm not sure where to open the issue.

