### PR TITLE
TF2 porting: Enable early stopping + model save and load

### DIFF
--- a/ludwig/features/audio_feature.py
+++ b/ludwig/features/audio_feature.py
@@ -243,10 +243,13 @@ class AudioBaseFeature(BaseFeature):
                 'for audio.')
 
         csv_path = None
+        # this is not super nice, but works both and DFs and lists
+        first_path = '.'
+        for first_path in dataset_df[feature['name']]:
+            break
         if hasattr(dataset_df, 'csv'):
             csv_path = os.path.dirname(os.path.abspath(dataset_df.csv))
-        if (csv_path is None and
-                not os.path.isabs(dataset_df[feature['name']][0])):
+        if csv_path is None and not os.path.isabs(first_path):
             raise ValueError(
                 'Audio file paths must be absolute'
             )
@@ -281,10 +284,10 @@ class AudioBaseFeature(BaseFeature):
                 (num_audio_utterances, max_length, feature_dim),
                 dtype=np.float32
             )
-            for i in range(len(dataset_df)):
+            for i, path in enumerate(dataset_df[feature['name']]):
                 filepath = get_abs_path(
                     csv_path,
-                    dataset_df[feature['name']][i]
+                    path
                 )
                 audio_feature = AudioBaseFeature._read_audio_and_transform_to_feature(
                     filepath, audio_feature_dict, feature_dim, max_length,

--- a/ludwig/features/bag_feature.py
+++ b/ludwig/features/bag_feature.py
@@ -25,7 +25,6 @@ from ludwig.features.base_feature import BaseFeature
 from ludwig.features.base_feature import InputFeature
 from ludwig.features.feature_utils import set_str_to_idx
 from ludwig.models.modules.bag_encoders import BagEmbedWeightedEncoder
-from ludwig.models.modules.embedding_modules import EmbedWeighted
 from ludwig.utils.misc import set_default_value
 from ludwig.utils.strings_utils import create_vocabulary
 
@@ -70,13 +69,14 @@ class BagBaseFeature(BaseFeature):
             dtype=float
         )
 
-        for i in range(len(column)):
+        for i, set_str in enumerate(column):
             col_counter = Counter(set_str_to_idx(
-                column[i],
+                set_str,
                 metadata['str2idx'],
                 preprocessing_parameters['tokenizer'])
             )
-            bag_matrix[i, list(col_counter.keys())] = list(col_counter.values())
+            bag_matrix[i, list(col_counter.keys())] = list(
+                col_counter.values())
 
         return bag_matrix
 

--- a/ludwig/features/base_feature.py
+++ b/ludwig/features/base_feature.py
@@ -168,11 +168,12 @@ class OutputFeature(ABC, BaseFeature, tf.keras.Model):
     ):
         # account for output feature target
         if isinstance(inputs, tuple):
-            inputs, target = inputs
+            local_inputs, target = inputs
         else:
+            local_inputs = inputs
             target = None
 
-        combiner_outputs, other_output_hidden = inputs
+        combiner_outputs, other_output_hidden = local_inputs
 
         # extract the combined hidden layer
         combiner_output = combiner_outputs['combiner_output']
@@ -389,6 +390,5 @@ class OutputFeature(ABC, BaseFeature, tf.keras.Model):
             training=training,
             mask=mask
         )
-        other_output_features[self.feature_name] = feature_hidden
 
         return feature_hidden

--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -35,7 +35,7 @@ from ludwig.utils.metrics_utils import average_precision_score
 from ludwig.utils.metrics_utils import precision_recall_curve
 from ludwig.utils.metrics_utils import roc_auc_score
 from ludwig.utils.metrics_utils import roc_curve
-from ludwig.utils.misc import set_default_value, get_from_registry
+from ludwig.utils.misc import set_default_value
 from ludwig.utils.misc import set_default_values
 
 logger = logging.getLogger(__name__)
@@ -79,12 +79,7 @@ class BinaryInputFeature(BinaryBaseFeature, InputFeature):
         if encoder_obj:
             self.encoder_obj = encoder_obj
         else:
-            self.encoder_obj = self.get_binary_encoder(feature)
-
-    def get_binary_encoder(self, encoder_parameters):
-        return get_from_registry(self.encoder, self.encoder_registry)(
-            **encoder_parameters
-        )
+            self.encoder_obj = self.initialize_encoder(feature)
 
     def call(self, inputs, training=None, mask=None):
         assert isinstance(inputs, tf.Tensor)

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -252,7 +252,10 @@ class ImageBaseFeature(BaseFeature):
         if num_images == 0:
             raise ValueError('There are no images in the dataset provided.')
 
-        first_image_path = dataset_df[feature['name']][0]
+        # this is not super nice, but works both and DFs and lists
+        for first_image_path in dataset_df[feature['name']]:
+            break
+
         if csv_path is None and not os.path.isabs(first_image_path):
             raise ValueError('Image file paths must be absolute')
 

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -253,13 +253,14 @@ class ImageBaseFeature(BaseFeature):
             raise ValueError('There are no images in the dataset provided.')
 
         # this is not super nice, but works both and DFs and lists
-        for first_image_path in dataset_df[feature['name']]:
+        first_path = '.'
+        for first_path in dataset_df[feature['name']]:
             break
 
-        if csv_path is None and not os.path.isabs(first_image_path):
+        if csv_path is None and not os.path.isabs(first_path):
             raise ValueError('Image file paths must be absolute')
 
-        first_image_path = get_abs_path(csv_path, first_image_path)
+        first_path = get_abs_path(csv_path, first_path)
 
         (
             should_resize,
@@ -269,7 +270,7 @@ class ImageBaseFeature(BaseFeature):
             user_specified_num_channels,
             first_image
         ) = ImageBaseFeature._finalize_preprocessing_parameters(
-            preprocessing_parameters, first_image_path
+            preprocessing_parameters, first_path
         )
 
         metadata[feature['name']]['preprocessing']['height'] = height

--- a/ludwig/features/set_feature.py
+++ b/ludwig/features/set_feature.py
@@ -20,7 +20,6 @@ from collections import OrderedDict
 
 import numpy as np
 import tensorflow as tf
-
 from tensorflow.keras.metrics import MeanIoU
 
 from ludwig.constants import *
@@ -28,11 +27,10 @@ from ludwig.features.base_feature import BaseFeature
 from ludwig.features.base_feature import InputFeature
 from ludwig.features.base_feature import OutputFeature
 from ludwig.features.feature_utils import set_str_to_idx
-from ludwig.models.modules.initializer_modules import get_initializer
 from ludwig.models.modules.loss_modules import SigmoidCrossEntropyLoss
 from ludwig.models.modules.metric_modules import SigmoidCrossEntropyMetric
-from ludwig.models.modules.set_encoders import SetSparseEncoder
 from ludwig.models.modules.set_decoders import Classifier
+from ludwig.models.modules.set_encoders import SetSparseEncoder
 from ludwig.utils.misc import set_default_value
 from ludwig.utils.strings_utils import create_vocabulary
 
@@ -168,12 +166,15 @@ class SetOutputFeature(SetBaseFeature, OutputFeature):
     def logits(
             self,
             inputs,  # hidden
+            **kwargs
     ):
-        return self.decoder_obj(inputs)
+        hidden = inputs[HIDDEN]
+        return self.decoder_obj(hidden)
 
     def predictions(
             self,
             inputs,  # logits
+            **kwargs
     ):
         logits = inputs[LOGITS]
 
@@ -284,9 +285,10 @@ class SetOutputFeature(SetBaseFeature, OutputFeature):
             del result[PREDICTIONS]
 
         if PROBABILITIES in result and len(result[PROBABILITIES]) > 0:
-            probs = result[PROBABILITIES]
+            probs = result[PROBABILITIES].numpy()
             prob = [[prob for prob in prob_set if
-                     prob >= output_feature['threshold']] for prob_set in probs]
+                     prob >= output_feature['threshold']] for prob_set in
+                    probs]
             postprocessed[PROBABILITIES] = probs
             postprocessed[PROBABILITY] = prob
 

--- a/ludwig/features/vector_feature.py
+++ b/ludwig/features/vector_feature.py
@@ -209,12 +209,15 @@ class VectorOutputFeature(VectorBaseFeature, OutputFeature):
     def logits(
             self,
             inputs,  # hidden
+            **kwargs
     ):
-        return self.decoder_obj(inputs)
+        hidden = inputs[HIDDEN]
+        return self.decoder_obj(hidden)
 
     def predictions(
             self,
             inputs,  # logits
+            **kwargs
     ):
         return {PREDICTIONS: inputs[LOGITS], LOGITS: inputs[LOGITS]}
 
@@ -285,7 +288,7 @@ class VectorOutputFeature(VectorBaseFeature, OutputFeature):
         name = output_feature['name']
 
         if PREDICTIONS in result and len(result[PREDICTIONS]) > 0:
-            postprocessed[PREDICTIONS] = result[PREDICTIONS]
+            postprocessed[PREDICTIONS] = result[PREDICTIONS].numpy()
             if not skip_save_unprocessed_output:
                 np.save(
                     npy_filename.format(name, PREDICTIONS),

--- a/ludwig/features/vector_feature.py
+++ b/ludwig/features/vector_feature.py
@@ -18,7 +18,6 @@ import logging
 import os
 
 import numpy as np
-
 import tensorflow as tf
 from tensorflow.keras.losses import MeanAbsoluteError
 from tensorflow.keras.losses import MeanSquaredError
@@ -167,7 +166,7 @@ class VectorInputFeature(VectorBaseFeature, InputFeature):
             inputs, training=training, mask=mask
         )
 
-        return {'encoder_outputs': inputs_encoded}
+        return inputs_encoded
 
     @staticmethod
     def update_model_definition_with_metadata(

--- a/ludwig/models/model.py
+++ b/ludwig/models/model.py
@@ -1200,6 +1200,7 @@ class Model:
             load_path,
             MODEL_WEIGHTS_FILE_NAME
         )
+        model.restore(model.weights_save_path)
         return model
 
     def set_epochs_to_1_or_quit(self, signum, frame):

--- a/ludwig/models/model.py
+++ b/ludwig/models/model.py
@@ -1162,9 +1162,6 @@ class Model:
 
     def restore(self, weights_path):
         self.ecd.load_weights(weights_path)
-        weights = self.ecd.get_weights()
-        pass
-
 
     @staticmethod
     def load(load_path, use_horovod=False):

--- a/ludwig/models/model.py
+++ b/ludwig/models/model.py
@@ -379,8 +379,8 @@ class Model:
 
         # ====== Setup session =======
         # todo tf2: reintroduce restoring weights
-        # if self.weights_save_path:
-        #    self.restore(session, self.weights_save_path)
+        if self.weights_save_path:
+           self.restore(self.weights_save_path)
 
         # todo tf2: reintroduce tensorboard logging
         # train_writer = None
@@ -1298,7 +1298,6 @@ class Model:
 
     def resume_session(
             self,
-            session,
             save_path,
             model_weights_path,
             model_weights_progress_path

--- a/ludwig/models/model.py
+++ b/ludwig/models/model.py
@@ -56,6 +56,9 @@ from ludwig.utils.defaults import default_random_seed
 from ludwig.utils.misc import set_random_seed
 from ludwig.utils.misc import sum_dicts
 
+from ludwig.features.numerical_feature import MSEMetric  #todo tf2 testing code
+from ludwig.models.modules.metric_modules import ErrorScore, R2Score
+
 logger = logging.getLogger(__name__)
 
 tf.config.experimental_run_functions_eagerly(True)
@@ -1158,9 +1161,15 @@ class Model:
         pass
 
     def restore(self, weights_path):
-        # todo tf2: reintroduce this functionality
-        # self.saver.restore(session, weights_path)
-        tf.keras.models.load_model(weights_path)
+        # todo tf2: clean up debugging code
+        tf.keras.models.load_model(
+            weights_path,
+            custom_objects={
+                'MSEMetric': MSEMetric,
+                'ErrorScore': ErrorScore,
+                'R2Score': R2Score
+            }
+        )
 
 
     @staticmethod

--- a/ludwig/models/model.py
+++ b/ludwig/models/model.py
@@ -406,13 +406,12 @@ class Model:
                 model_weights_path
             )
             # todo tf3: reintroduce session resume
-            # if is_on_master():
-            #    self.resume_session(
-            #        session,
-            #        save_path,
-            #        model_weights_path,
-            #        model_weights_progress_path
-            #    )
+            if is_on_master():
+               self.resume_session(
+                   save_path,
+                   model_weights_path,
+                   model_weights_progress_path
+               )
         else:
             (
                 train_metrics,
@@ -1158,7 +1157,7 @@ class Model:
         # builder.save()
         pass
 
-    def restore(self,weights_path):
+    def restore(self, weights_path):
         # todo tf2: reintroduce this functionality
         # self.saver.restore(session, weights_path)
         self.ecd.load_weights(weights_path)
@@ -1308,9 +1307,9 @@ class Model:
             if pattern.match(file_path):
                 num_matching_files += 1
         if num_matching_files == 3:
-            self.restore(session, model_weights_progress_path)
+            self.restore(model_weights_progress_path)
         else:
-            self.restore(session, model_weights_path)
+            self.restore(model_weights_path)
 
     def reduce_learning_rate(
             self,

--- a/ludwig/models/model.py
+++ b/ludwig/models/model.py
@@ -759,7 +759,12 @@ class Model:
         for output_feature in self.ecd.output_features:
             scores = [dataset_name]
 
-            for metric in metrics_log[output_feature]:
+            # collect metric names based on output features metrics to
+            # ensure consistent order of reporting metrics
+            metric_names = self.ecd.output_features[output_feature]\
+                .metric_functions.keys()
+
+            for metric in metric_names:
                 score = results[output_feature][metric]
                 metrics_log[output_feature][metric].append(score)
                 scores.append(score)

--- a/ludwig/models/model.py
+++ b/ludwig/models/model.py
@@ -670,32 +670,32 @@ class Model:
                 )
                 if should_break:
                     break
-            # else:
-            #     # there's no validation, so we save the model at each iteration
-            #     if is_on_master():
-            #         if not skip_save_model:
-            #             self.save_weights(session, model_weights_path)
-            #             self.save_hyperparameters(
-            #                 self.hyperparameters,
-            #                 model_hyperparameters_path
-            #             )
-            #
-        #     # ========== Save training progress ==========
-        #     if is_on_master():
-        #         if not skip_save_progress:
-        #             self.save_weights(session, model_weights_progress_path)
-        #             progress_tracker.save(
-        #                 os.path.join(
-        #                     save_path,
-        #                     TRAINING_PROGRESS_FILE_NAME
-        #                 )
-        #             )
-        #             if skip_save_model:
-        #                 self.save_hyperparameters(
-        #                     self.hyperparameters,
-        #                     model_hyperparameters_path
-        #                 )
-        #
+            else:
+                # there's no validation, so we save the model at each iteration
+                if is_on_master():
+                    if not skip_save_model:
+                        self.save_weights(model_weights_path)
+                        self.save_hyperparameters(
+                            self.hyperparameters,
+                            model_hyperparameters_path
+                        )
+
+            # ========== Save training progress ==========
+            if is_on_master():
+                if not skip_save_progress:
+                    self.save_weights(model_weights_progress_path)
+                    progress_tracker.save(
+                        os.path.join(
+                            save_path,
+                            TRAINING_PROGRESS_FILE_NAME
+                        )
+                    )
+                    if skip_save_model:
+                        self.save_hyperparameters(
+                            self.hyperparameters,
+                            model_hyperparameters_path
+                        )
+
         #     if is_on_master():
         #         contrib_command("train_epoch_end", progress_tracker)
         #         logger.info('')
@@ -956,7 +956,7 @@ class Model:
                 validation_field][validation_metric][-1]
             if is_on_master():
                 if not skip_save_model:
-                    self.save_weights(session, model_weights_path)
+                    self.save_weights(model_weights_path)
                     self.save_hyperparameters(
                         self.hyperparameters,
                         model_hyperparameters_path
@@ -1110,10 +1110,10 @@ class Model:
         # return collected_tensors
         pass
 
-    def save_weights(self, session, save_path):
+    def save_weights(self, save_path):
         # todo tf2: reintroduce functionality
-        # self.weights_save_path = self.saver.save(session, save_path)
-        pass
+        #self.weights_save_path = self.saver.save(save_path)
+        self.ecd.save_weights(save_path)
 
     def save_hyperparameters(self, hyperparameters, save_path):
         # removing pretrained embeddings paths from hyperparameters
@@ -1158,10 +1158,11 @@ class Model:
         # builder.save()
         pass
 
-    def restore(self, session, weights_path):
+    def restore(self,weights_path):
         # todo tf2: reintroduce this functionality
         # self.saver.restore(session, weights_path)
-        pass
+        self.ecd.load_weights(weights_path)
+
 
     @staticmethod
     def load(load_path, use_horovod=False):

--- a/ludwig/models/model.py
+++ b/ludwig/models/model.py
@@ -651,36 +651,35 @@ class Model:
                             )
                         )
 
-        #     if should_validate:
-        #         should_break = self.check_progress_on_validation(
-        #             progress_tracker,
-        #             validation_field,
-        #             validation_metric,
-        #             session,
-        #             model_weights_path,
-        #             model_hyperparameters_path,
-        #             reduce_learning_rate_on_plateau,
-        #             reduce_learning_rate_on_plateau_patience,
-        #             reduce_learning_rate_on_plateau_rate,
-        #             increase_batch_size_on_plateau_patience,
-        #             increase_batch_size_on_plateau,
-        #             increase_batch_size_on_plateau_max,
-        #             increase_batch_size_on_plateau_rate,
-        #             early_stop,
-        #             skip_save_model
-        #         )
-        #         if should_break:
-        #             break
-        #     else:
-        #         # there's no validation, so we save the model at each iteration
-        #         if is_on_master():
-        #             if not skip_save_model:
-        #                 self.save_weights(session, model_weights_path)
-        #                 self.save_hyperparameters(
-        #                     self.hyperparameters,
-        #                     model_hyperparameters_path
-        #                 )
-        #
+            if should_validate:
+                should_break = self.check_progress_on_validation(
+                    progress_tracker,
+                    validation_field,
+                    validation_metric,
+                    model_weights_path,
+                    model_hyperparameters_path,
+                    reduce_learning_rate_on_plateau,
+                    reduce_learning_rate_on_plateau_patience,
+                    reduce_learning_rate_on_plateau_rate,
+                    increase_batch_size_on_plateau_patience,
+                    increase_batch_size_on_plateau,
+                    increase_batch_size_on_plateau_max,
+                    increase_batch_size_on_plateau_rate,
+                    early_stop,
+                    skip_save_model
+                )
+                if should_break:
+                    break
+            # else:
+            #     # there's no validation, so we save the model at each iteration
+            #     if is_on_master():
+            #         if not skip_save_model:
+            #             self.save_weights(session, model_weights_path)
+            #             self.save_hyperparameters(
+            #                 self.hyperparameters,
+            #                 model_hyperparameters_path
+            #             )
+            #
         #     # ========== Save training progress ==========
         #     if is_on_master():
         #         if not skip_save_progress:
@@ -932,7 +931,7 @@ class Model:
             progress_tracker,
             validation_field,
             validation_metric,
-            session, model_weights_path,
+            model_weights_path,
             model_hyperparameters_path,
             reduce_learning_rate_on_plateau,
             reduce_learning_rate_on_plateau_patience,

--- a/ludwig/models/model.py
+++ b/ludwig/models/model.py
@@ -1112,7 +1112,7 @@ class Model:
     def save_weights(self, save_path):
         # todo tf2: reintroduce functionality
         #self.weights_save_path = self.saver.save(save_path)
-        self.ecd.save_weights(save_path)
+        self.ecd.save(save_path)
 
     def save_hyperparameters(self, hyperparameters, save_path):
         # removing pretrained embeddings paths from hyperparameters
@@ -1160,7 +1160,7 @@ class Model:
     def restore(self, weights_path):
         # todo tf2: reintroduce this functionality
         # self.saver.restore(session, weights_path)
-        self.ecd.load_weights(weights_path)
+        tf.keras.models.load_model(weights_path)
 
 
     @staticmethod

--- a/ludwig/models/modules/generic_decoders.py
+++ b/ludwig/models/modules/generic_decoders.py
@@ -56,7 +56,7 @@ class Projector(Layer):
 
     def __init__(
             self,
-            num_classes,
+            vector_size,
             use_bias=True,
             kernel_initializer='glorot_uniform',
             bias_initializer='zeros',
@@ -69,7 +69,7 @@ class Projector(Layer):
     ):
         super().__init__()
         self.dense = Dense(
-            num_classes,
+            vector_size,
             use_bias=use_bias,
             kernel_initializer=kernel_initializer,
             bias_initializer=bias_initializer,

--- a/ludwig/models/modules/metric_modules.py
+++ b/ludwig/models/modules/metric_modules.py
@@ -18,7 +18,8 @@ import numpy as np
 import tensorflow as tf
 
 from ludwig.constants import *
-from ludwig.models.modules.loss_modules import BWCEWLoss
+from ludwig.models.modules.loss_modules import BWCEWLoss, \
+    SigmoidCrossEntropyLoss
 from ludwig.models.modules.loss_modules import SequenceLoss
 from ludwig.models.modules.loss_modules import SoftmaxCrossEntropyLoss
 from ludwig.utils.tf_utils import sequence_length_2D

--- a/ludwig/models/modules/metric_modules.py
+++ b/ludwig/models/modules/metric_modules.py
@@ -43,7 +43,7 @@ class R2Score(tf.keras.metrics.Metric):
 
     # todo tf2 - convert to tensors?
 
-    def __init__(self, name='r2_score'):
+    def __init__(self, name='r2_score', **kwargs):
         super(R2Score, self).__init__(name=name)
         self._reset_states()
 
@@ -81,7 +81,7 @@ class ErrorScore(tf.keras.metrics.Metric):
 
     # todo tf2 - convert to tensors?
 
-    def __init__(self, name='error_score'):
+    def __init__(self, name='error_score', **kwargs):
         super(ErrorScore, self).__init__(name=name)
         self._reset_states()
 

--- a/ludwig/models/modules/sequence_decoders.py
+++ b/ludwig/models/modules/sequence_decoders.py
@@ -455,9 +455,10 @@ class SequenceGeneratorDecoder(Layer):
         # ================ predictions =================
         greedy_sampler = tfa.seq2seq.GreedyEmbeddingSampler()
 
-        # decoder_input = tf.expand_dims([self.GO_SYMBOL] * batch_size, 1)
+        decoder_input = tf.expand_dims([self.GO_SYMBOL] * batch_size, 1)
         start_tokens = tf.fill([batch_size], self.GO_SYMBOL)
         end_token = self.END_SYMBOL
+        decoder_inp_emb = self.decoder_embedding(decoder_input)
 
         if self.attention_mechanism is not None:
             self.attention_mechanism.setup_memory(

--- a/ludwig/predict.py
+++ b/ludwig/predict.py
@@ -99,7 +99,7 @@ def full_predict(
         gpu_fraction,
         debug
     )
-    model.close_session()
+    # model.close_session()  # todo tf2 code clean -up
 
     if is_on_master():
         # setup directories and file names

--- a/tests/integration_tests/test_model_training_options.py
+++ b/tests/integration_tests/test_model_training_options.py
@@ -141,7 +141,7 @@ def test_model_progress_save(
         skip_save_unprocessed_output=True,
         skip_save_model=skip_save_model,
         skip_save_log=True
-    )˚
+    )
 
     #========== Check for required result data sets =============
     if skip_save_model:

--- a/tests/integration_tests/test_model_training_options.py
+++ b/tests/integration_tests/test_model_training_options.py
@@ -1,0 +1,91 @@
+import os.path
+import json
+
+import pandas as pd
+import numpy as np
+
+import pytest
+
+from ludwig.experiment import full_experiment
+
+@pytest.fixture
+def train_df():
+    # function generates simple training data tha guarantee convergence
+    # within 30 epochs for suitable model definition
+    NUMBER_OBSERVATIONS = 200
+
+    # generate training data
+    np.random.seed(42)
+    x = np.array(range(NUMBER_OBSERVATIONS)).reshape(-1, 1)
+    y = 2*x + 1 + np.random.normal(size=x.shape[0]).reshape(-1, 1)
+
+    train_df = pd.DataFrame(np.concatenate((x, y), axis=1), columns=['x', 'y'])
+
+    return train_df
+
+@pytest.mark.parametrize('early_stop', [3, 5])
+def test_early_stopping(early_stop, train_df, tmp_path):
+    # model definition guarantee convergence in under 30 epochs
+    input_features = [
+            {'name': 'x', 'type': 'numerical'},
+        ]
+    output_features = [
+        {'name': 'y', 'type': 'numerical', 'loss': {'type': 'mean_squared_error'},
+         'num_fc_layers': 5, 'fc_size': 64}
+    ]
+    model_definition = {
+        'input_features': input_features,
+        'output_features': output_features,
+        'combiner': {
+            'type': 'concat'
+        },
+        'training': {
+            'epochs': 100,
+            'early_stop': early_stop,
+            'batch_size': 16
+        }
+    }
+
+    # create sub-directory to store results
+    results_dir = tmp_path / 'results'
+    results_dir.mkdir()
+
+    # specify model training options
+    kwargs = {
+        'output_directory':results_dir,
+        'model_definition': model_definition,
+        'skip_save_processed_input': True,
+        'skip_save_progress': True,
+        'skip_save_unprocessed_output': True,
+        'skip_save_model': True,
+        'skip_save_log': True
+
+    }
+
+    # run experiment
+    exp_dir_name = full_experiment(data_df=train_df, **kwargs)
+
+    # test existence of required files
+    train_stats_fp = os.path.join(exp_dir_name, 'training_statistics.json')
+    metadata_fp = os.path.join(exp_dir_name, 'description.json')
+    assert os.path.isfile(train_stats_fp)
+    assert os.path.isfile(metadata_fp)
+
+    # retrieve results so we can validate early stopping
+    with open(train_stats_fp,'r') as f:
+        train_stats = json.load(f)
+    with open(metadata_fp, 'r') as f:
+        metadata = json.load(f)
+
+    # get early stopping value
+    early_stop_value = metadata['model_definition']['training']['early_stop']
+
+    # retrieve validation losses
+    vald_losses = np.array(train_stats['validation']['combined']['loss'])
+    last_epoch = vald_losses.shape[0]
+    best_epoch = np.argmin(vald_losses)
+
+    # confirm early stopping
+    assert (last_epoch - best_epoch - 1) == early_stop_value
+
+

--- a/tests/integration_tests/test_model_training_options.py
+++ b/tests/integration_tests/test_model_training_options.py
@@ -141,7 +141,7 @@ def test_model_save_resume(generated_data, tmp_path):
         model_resume_path=exp_dir_name
     )
 
-    test_fp = os.path.join(tmp_path, 'data_to_predict.csv')
+    test_fp = os.path.join(str(tmp_path), 'data_to_predict.csv')
     generated_data.test_df.to_csv(
         test_fp,
         index=False

--- a/tests/integration_tests/test_model_training_options.py
+++ b/tests/integration_tests/test_model_training_options.py
@@ -173,7 +173,12 @@ def test_model_save_resume(generated_data, tmp_path):
         'input_features': input_features,
         'output_features': output_features,
         'combiner': {'type': 'concat'},
-        'training': {'epochs': 5, 'early_stop': 0, 'batch_size': 16}
+        'training': {
+            'epochs': 5,
+            'early_stop': 0,
+            'batch_size': 16,
+            'optimizer': {'type': 'adam'}
+        }
     }
 
     # create sub-directory to store results

--- a/tests/integration_tests/test_model_training_options.py
+++ b/tests/integration_tests/test_model_training_options.py
@@ -173,7 +173,7 @@ def test_model_save_resume(generated_data, tmp_path):
         'input_features': input_features,
         'output_features': output_features,
         'combiner': {'type': 'concat'},
-        'training': {'epochs': 10, 'early_stop': 0, 'batch_size': 16}
+        'training': {'epochs': 5, 'early_stop': 0, 'batch_size': 16}
     }
 
     # create sub-directory to store results
@@ -190,7 +190,7 @@ def test_model_save_resume(generated_data, tmp_path):
 
     y_pred1 = np.load(os.path.join(exp_dir_name, 'y_predictions.npy'))
 
-    model_definition['training']['epochs'] = 20
+    model_definition['training']['epochs'] = 15
 
     full_experiment(
         model_definition,

--- a/tests/integration_tests/test_model_training_options.py
+++ b/tests/integration_tests/test_model_training_options.py
@@ -1,31 +1,21 @@
 import os.path
 import json
+from collections import namedtuple
 
 import pandas as pd
 import numpy as np
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import mean_squared_error
 
 import pytest
 
 from ludwig.experiment import full_experiment
+from ludwig.predict import full_predict
 
-@pytest.fixture
-def train_df():
-    # function generates simple training data tha guarantee convergence
-    # within 30 epochs for suitable model definition
-    NUMBER_OBSERVATIONS = 200
+GeneratedData = namedtuple('GeneratedData',
+                           'train_df validation_df test_df')
 
-    # generate training data
-    np.random.seed(42)
-    x = np.array(range(NUMBER_OBSERVATIONS)).reshape(-1, 1)
-    y = 2*x + 1 + np.random.normal(size=x.shape[0]).reshape(-1, 1)
-
-    train_df = pd.DataFrame(np.concatenate((x, y), axis=1), columns=['x', 'y'])
-
-    return train_df
-
-@pytest.mark.parametrize('early_stop', [3, 5])
-def test_early_stopping(early_stop, train_df, tmp_path):
-    # model definition guarantee convergence in under 30 epochs
+def get_feature_definitions():
     input_features = [
             {'name': 'x', 'type': 'numerical'},
         ]
@@ -33,6 +23,35 @@ def test_early_stopping(early_stop, train_df, tmp_path):
         {'name': 'y', 'type': 'numerical', 'loss': {'type': 'mean_squared_error'},
          'num_fc_layers': 5, 'fc_size': 64}
     ]
+
+    return input_features, output_features
+
+
+@pytest.fixture
+def generated_data():
+    # function generates simple training data that guarantee convergence
+    # within 30 epochs for suitable model definition
+    NUMBER_OBSERVATIONS = 500
+
+    # generate data
+    np.random.seed(43)
+    x = np.array(range(NUMBER_OBSERVATIONS)).reshape(-1, 1)
+    y = 2*x + 1 + np.random.normal(size=x.shape[0]).reshape(-1, 1)
+    raw_df = pd.DataFrame(np.concatenate((x, y), axis=1), columns=['x', 'y'])
+
+    # create training data
+    train, valid_test  = train_test_split(raw_df, train_size=0.7)
+
+    # create validation and test data
+    validation, test = train_test_split(valid_test, train_size=0.5)
+
+    return GeneratedData(train, validation, test)
+
+@pytest.mark.parametrize('early_stop', [3, 5])
+def test_early_stopping(early_stop, generated_data, tmp_path):
+
+    input_features, output_features = get_feature_definitions()
+
     model_definition = {
         'input_features': input_features,
         'output_features': output_features,
@@ -40,7 +59,7 @@ def test_early_stopping(early_stop, train_df, tmp_path):
             'type': 'concat'
         },
         'training': {
-            'epochs': 100,
+            'epochs': 30,
             'early_stop': early_stop,
             'batch_size': 16
         }
@@ -63,7 +82,12 @@ def test_early_stopping(early_stop, train_df, tmp_path):
     }
 
     # run experiment
-    exp_dir_name = full_experiment(data_df=train_df, **kwargs)
+    exp_dir_name = full_experiment(
+        data_train_df=generated_data.train_df,
+        data_validation_df=generated_data.validation_df,
+        data_test_df=generated_data.test_df,
+        **kwargs
+    )
 
     # test existence of required files
     train_stats_fp = os.path.join(exp_dir_name, 'training_statistics.json')
@@ -89,3 +113,43 @@ def test_early_stopping(early_stop, train_df, tmp_path):
     assert (last_epoch - best_epoch - 1) == early_stop_value
 
 
+def test_model_save_resume(generated_data, tmp_path):
+
+    input_features, output_features = get_feature_definitions()
+    model_definition = {
+        'input_features': input_features,
+        'output_features': output_features,
+        'combiner': {'type': 'concat', 'fc_size': 14},
+        'training': {'epochs': 30, 'early_stop': 5}
+    }
+
+    # create sub-directory to store results
+    results_dir = tmp_path / 'results'
+    results_dir.mkdir()
+
+    exp_dir_name = full_experiment(
+        model_definition,
+        data_train_df=generated_data.train_df,
+        data_validation_df=generated_data.validation_df,
+        data_test_df=generated_data.test_df,
+        output_directory=results_dir
+    )
+
+    full_experiment(
+        model_definition,
+        data_train_df=generated_data.train_df,
+        model_resume_path=exp_dir_name
+    )
+
+    test_fp = os.path.join(tmp_path, 'data_to_predict.csv')
+    generated_data.test_df.to_csv(
+        test_fp,
+        index=False
+    )
+
+    full_predict(os.path.join(exp_dir_name, 'model'), data_csv=test_fp)
+
+    y_pred = np.load(os.path.join(exp_dir_name, 'y_predictions.npy'))
+
+    mse = mean_squared_error(y_pred, generated_data.test_df['y'])
+    pass

--- a/tests/integration_tests/test_model_training_options.py
+++ b/tests/integration_tests/test_model_training_options.py
@@ -14,7 +14,7 @@ from ludwig.utils.data_utils import split_dataset_tvt, read_csv
 from tests.integration_tests.utils import binary_feature, numerical_feature, \
     category_feature, sequence_feature, date_feature, h3_feature, \
     set_feature, generate_data, text_feature, vector_feature, bag_feature, \
-    image_feature, audio_feature
+    image_feature, audio_feature, timeseries_feature
 
 GeneratedData = namedtuple('GeneratedData',
                            'train_df validation_df test_df')
@@ -265,7 +265,7 @@ def test_model_save_reload_API(csv_filename, tmp_path):
         vector_feature(),
         image_feature(image_dest_folder),
         audio_feature(audio_dest_folder),
-        # timeseries_feature(),
+        timeseries_feature(),
         date_feature(),
         h3_feature(),
         set_feature(vocab_size=3),

--- a/tests/integration_tests/test_model_training_options.py
+++ b/tests/integration_tests/test_model_training_options.py
@@ -13,7 +13,8 @@ from ludwig.experiment import full_experiment
 from ludwig.utils.data_utils import split_dataset_tvt, read_csv
 from tests.integration_tests.utils import binary_feature, numerical_feature, \
     category_feature, sequence_feature, date_feature, h3_feature, \
-    set_feature, generate_data, text_feature, vector_feature
+    set_feature, generate_data, text_feature, vector_feature, bag_feature, \
+    image_feature, audio_feature
 
 GeneratedData = namedtuple('GeneratedData',
                            'train_df validation_df test_df')
@@ -262,13 +263,13 @@ def test_model_save_reload_API(csv_filename, tmp_path):
         sequence_feature(vocab_size=3),
         text_feature(vocab_size=3),
         vector_feature(),
-        # image_feature(image_dest_folder),
-        # audio_feature(audio_dest_folder),
+        image_feature(image_dest_folder),
+        audio_feature(audio_dest_folder),
         # timeseries_feature(),
         date_feature(),
         h3_feature(),
         set_feature(vocab_size=3),
-        # bag_feature(vocab_size=3),
+        bag_feature(vocab_size=3),
     ]
 
     output_features = [

--- a/tests/integration_tests/test_model_training_options.py
+++ b/tests/integration_tests/test_model_training_options.py
@@ -171,7 +171,7 @@ def test_model_save_resume(generated_data, tmp_path):
         'input_features': input_features,
         'output_features': output_features,
         'combiner': {'type': 'concat', 'fc_size': 14},
-        'training': {'epochs': 30, 'early_stop': 5}
+        'training': {'epochs': 30, 'early_stop': 3}
     }
 
     # create sub-directory to store results

--- a/tests/integration_tests/test_model_training_options.py
+++ b/tests/integration_tests/test_model_training_options.py
@@ -28,7 +28,7 @@ def get_feature_definitions():
     return input_features, output_features
 
 
-@pytest.fixture
+@pytest.fixture(scope='module')
 def generated_data():
     # function generates simple training data that guarantee convergence
     # within 30 epochs for suitable model definition
@@ -121,7 +121,7 @@ def test_model_progress_save(
     model_definition = {
         'input_features': input_features,
         'output_features': output_features,
-        'combiner': {'type': 'concat', 'fc_size': 14},
+        'combiner': {'type': 'concat'},
         'training': {'epochs': 10}
     }
 
@@ -141,25 +141,25 @@ def test_model_progress_save(
         skip_save_unprocessed_output=True,
         skip_save_model=skip_save_model,
         skip_save_log=True
-    )
+    )˚
 
     #========== Check for required result data sets =============
     if skip_save_model:
-        assert not os.path.isfile(
-            os.path.join(exp_dir_name, 'model', 'model_weights.index')
+        assert not os.path.isdir(
+            os.path.join(exp_dir_name, 'model', 'model_weights')
         )
     else:
-        assert os.path.isfile(
-            os.path.join(exp_dir_name, 'model', 'model_weights.index')
+        assert os.path.isdir(
+            os.path.join(exp_dir_name, 'model', 'model_weights')
         )
 
     if skip_save_progress:
-        assert not os.path.isfile(
-            os.path.join(exp_dir_name, 'model', 'model_weights_progress.index')
+        assert not os.path.isdir(
+            os.path.join(exp_dir_name, 'model', 'model_weights_progress')
         )
     else:
-        assert os.path.isfile(
-            os.path.join(exp_dir_name, 'model', 'model_weights_progress.index')
+        assert os.path.isdir(
+            os.path.join(exp_dir_name, 'model', 'model_weights_progress')
         )
 
 
@@ -170,8 +170,8 @@ def test_model_save_resume(generated_data, tmp_path):
     model_definition = {
         'input_features': input_features,
         'output_features': output_features,
-        'combiner': {'type': 'concat', 'fc_size': 14},
-        'training': {'epochs': 30, 'early_stop': 3}
+        'combiner': {'type': 'concat'},
+        'training': {'epochs': 30, 'early_stop': 3, 'batch_size': 16}
     }
 
     # create sub-directory to store results

--- a/tests/integration_tests/test_model_training_options.py
+++ b/tests/integration_tests/test_model_training_options.py
@@ -275,11 +275,11 @@ def test_model_save_reload_API(csv_filename, tmp_path):
     output_features = [
         binary_feature(),
         numerical_feature(),
-        # category_feature(vocab_size=3),
+        category_feature(vocab_size=3),
         # sequence_feature(vocab_size=3),
         # text_feature(vocab_size=3),
-        # set_feature(vocab_size=3),
-        # vector_feature()
+        set_feature(vocab_size=3),
+        vector_feature(),
     ]
 
     # Generate test data
@@ -327,7 +327,14 @@ def test_model_save_reload_API(csv_filename, tmp_path):
     preds_2 = ludwig_model2.predict(data_df=validation_set)
 
     for key in preds_1:
-        assert np.allclose(preds_1[key], preds_2[key])
+        assert preds_1[key].dtype == preds_2[key].dtype
+        assert preds_1[key].equals(preds_2[key])
+
+        # col_dtype = preds_1[key].dtype
+        # if col_dtype in {'int32', 'int64', 'float32', 'float64'}:
+        #    assert np.allclose(preds_1[key], preds_2[key])
+        # else:
+        #    assert preds_1[key].equals(preds_2[key])
 
     for if_name in ludwig_model1.model.ecd.input_features:
         if1 = ludwig_model1.model.ecd.input_features[if_name]

--- a/tests/integration_tests/test_model_training_options.py
+++ b/tests/integration_tests/test_model_training_options.py
@@ -13,7 +13,7 @@ from ludwig.experiment import full_experiment
 from ludwig.utils.data_utils import split_dataset_tvt, read_csv
 from tests.integration_tests.utils import binary_feature, numerical_feature, \
     category_feature, sequence_feature, date_feature, h3_feature, \
-    set_feature, generate_data
+    set_feature, generate_data, text_feature, vector_feature
 
 GeneratedData = namedtuple('GeneratedData',
                            'train_df validation_df test_df')
@@ -260,8 +260,8 @@ def test_model_save_reload_API(csv_filename, tmp_path):
         numerical_feature(),
         category_feature(vocab_size=3),
         sequence_feature(vocab_size=3),
-        # text_feature(vocab_size=3),
-        # vector_feature(),
+        text_feature(vocab_size=3),
+        vector_feature(),
         # image_feature(image_dest_folder),
         # audio_feature(audio_dest_folder),
         # timeseries_feature(),


### PR DESCRIPTION
# Code Pull Requests

Re-introduced early stopping option.  From what I can tell there is no existing unit test for early stopping;  I  added early such a test.  This test used two values (3 and 5) for `early_stop` option and confirmed training stopped per the early stop specification.
``` 
pytest -v test_model_training_options.py
======================================================= test session starts ========================================================
platform linux -- Python 3.6.9, pytest-5.4.3, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /opt/project
plugins: pycharm-0.6.0, typeguard-2.8.0
collected 2 items

test_model_training_options.py::test_early_stopping[3] PASSED                                                                [ 50%]
test_model_training_options.py::test_early_stopping[5] PASSED                                                                [100%]

========================================================= warnings summary =========================================================
/usr/local/lib/python3.6/dist-packages/tensorflow/python/pywrap_tensorflow_internal.py:15
  /usr/local/lib/python3.6/dist-packages/tensorflow/python/pywrap_tensorflow_internal.py:15: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    import imp

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================================================== 2 passed, 1 warning in 12.85s ===================================================
```

The `test_model_training_options.py` can be used as a foundation to other unit tests around model training options, e.g. save or not save various logs, etc.

This PR enabled only the early stopping test.  Nothing else was reenabled. 

If this looks OK, I can start re-enabling other model training options.
