### PR TITLE
Fix broken links in docs and comments #740

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,4 +266,4 @@ Refer to the [Developer Guide](https://ludwig-ai.github.io/ludwig-docs/developer
 Full documentation
 ------------------
 
-You can find the full documentation [here](http://uber.github.io/ludwig/).
+You can find the full documentation [here](https://ludwig-ai.github.io/ludwig-docs).

--- a/examples/kfold_cv/regression_example.ipynb
+++ b/examples/kfold_cv/regression_example.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "# K-fold cross validation - Regression Model\n",
-    "Based on the [Ludwig regression example](https://uber.github.io/ludwig/examples/#simple-regression-fuel-efficiency-prediction)  \n",
+    "Based on the [Ludwig regression example](https://ludwig-ai.github.io/ludwig-docs/examples/#simple-regression-fuel-efficiency-prediction)  \n",
     "\n",
     "[Data set](https://archive.ics.uci.edu/ml/datasets/auto+mpg)\n",
     "\n",

--- a/examples/mnist/README.md
+++ b/examples/mnist/README.md
@@ -1,6 +1,6 @@
 # MNIST Hand-written Digit Classification
 
-This API example is based on [Ludwig's MNIST Hand-written Digit image classification example](https://uber.github.io/ludwig/examples/#image-classification-mnist). 
+This API example is based on [Ludwig's MNIST Hand-written Digit image classification example](https://ludwig-ai.github.io/ludwig-docs/examples/#image-classification-mnist). 
 
 ### Preparatory Steps
 To create data for training and testing run this command:

--- a/examples/mnist/simple_model_training.py
+++ b/examples/mnist/simple_model_training.py
@@ -2,9 +2,9 @@
 # coding: utf-8
 
 # # Simple Model Training Example
-# 
+#
 # This example is the API example for this Ludwig command line example
-# (https://uber.github.io/ludwig/examples/#image-classification-mnist).
+# (https://ludwig-ai.github.io/ludwig-docs/examples/#image-classification-mnist).
 
 # Import required libraries
 
@@ -29,7 +29,7 @@ with open('./model_definition.yaml','r') as f:
 model = LudwigModel(model_definition,
                     logging_level=logging.INFO)
 
-# initiate model training 
+# initiate model training
 train_stats = model.train(data_train_csv='./data/mnist_dataset_training.csv',
                           data_test_csv='./data/mnist_dataset_testing.csv',
                          experiment_name='simple_image_experiment',

--- a/examples/titanic/README.md
+++ b/examples/titanic/README.md
@@ -1,6 +1,6 @@
 # Kaggle Titanic Survivor Prediction
 
-This API example is based on [Ludwig's Kaggle Titanic example](https://uber.github.io/ludwig/examples/#kaggles-titanic-predicting-survivors) for predicting probability of surviving. 
+This API example is based on [Ludwig's Kaggle Titanic example](https://ludwig-ai.github.io/ludwig-docs/examples/#kaggles-titanic-predicting-survivors) for predicting probability of surviving. 
 
 ### Preparatory Steps
 * Create `data` directory

--- a/examples/titanic/simple_model_training.py
+++ b/examples/titanic/simple_model_training.py
@@ -2,9 +2,9 @@
 # coding: utf-8
 
 # # Simple Model Training Example
-# 
+#
 # This example is the API example for this Ludwig command line example
-# (https://uber.github.io/ludwig/examples/#kaggles-titanic-predicting-survivors).
+# (https://ludwig-ai.github.io/ludwig-docs/examples/#kaggles-titanic-predicting-survivors).
 
 # Import required libraries
 
@@ -24,7 +24,7 @@ except FileNotFoundError:
 model = LudwigModel(model_definition_file='./model1_definition.yaml',
                     logging_level=logging.INFO)
 
-# initiate model training 
+# initiate model training
 train_stats = model.train(data_csv='./data/train.csv',
                          experiment_name='simple_experiment',
                          model_name='simple_model')

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -146,7 +146,7 @@ class ImageBaseFeature(BaseFeature):
                 "or explicit image width and height are expected"
                 "to be provided. "
                 "Additional information: "
-                "https://uber.github.io/ludwig/user_guide/#image-features-preprocessing"
+                "https://ludwig-ai.github.io/ludwig-docs/user_guide/#image-features-preprocessing"
                     .format([img_height, img_width, num_channels], img.shape)
             )
 

--- a/tests/integration_tests/test_visualization_api.py
+++ b/tests/integration_tests/test_visualization_api.py
@@ -81,7 +81,7 @@ class Experiment:
         self.output_feature_name = self.output_features[0]['name']
         # probabilities need to be list of lists containing each row data
         # from the probability columns
-        # ref: https://uber.github.io/ludwig/api/#test - Return
+        # ref: https://ludwig-ai.github.io/ludwig-docs/api/#test - Return
         num_probs = self.output_features[0]['vocab_size']
         self.probability = self.test_stats_full[0].iloc[:, 1:(num_probs+2)].values
         self.ground_truth_metadata = self.model.train_set_metadata
@@ -506,7 +506,7 @@ def test_confidence_thresholding_2thresholds_2d_vis_api(csv_filename):
     output_feature_name1 = output_features[0]['name']
     output_feature_name2 = output_features[1]['name']
     # probabilities need to be list of lists containing each row data from the
-    # probability columns ref: https://uber.github.io/ludwig/api/#test - Return
+    # probability columns ref: https://ludwig-ai.github.io/ludwig-docs/api/#test - Return
     probability1 = test_stats[0].iloc[:, [2, 3, 4]].values
     probability2 = test_stats[0].iloc[:, [7, 8, 9]].values
 
@@ -572,7 +572,7 @@ def test_confidence_thresholding_2thresholds_3d_vis_api(csv_filename):
     output_feature_name1 = output_features[0]['name']
     output_feature_name2 = output_features[1]['name']
     # probabilities need to be list of lists containing each row data from the
-    # probability columns ref: https://uber.github.io/ludwig/api/#test - Return
+    # probability columns ref: https://ludwig-ai.github.io/ludwig-docs/api/#test - Return
     probability1 = test_stats[0].iloc[:, [2, 3, 4]].values
     probability2 = test_stats[0].iloc[:, [7, 8, 9]].values
 


### PR DESCRIPTION
Links to uber.github.io/ludwig are broken and should be replaced with ludwig-ai.github.io/ludwig-docs