### PR TITLE
TF2 porting:  change default keyword parameters for Adam to match Keras api spec

### DIFF
--- a/ludwig/utils/defaults.py
+++ b/ludwig/utils/defaults.py
@@ -70,8 +70,8 @@ default_training_params = {
 
 default_optimizer_params_registry = {
     'adam': {
-        'beta1': 0.9,
-        'beta2': 0.999,
+        'beta_1': 0.9,
+        'beta_2': 0.999,
         'epsilon': 1e-08
     },
     'adadelta': {


### PR DESCRIPTION
# Code Pull Requests

This fixes unexpected keyword error during initialization of the Adam optimizer.  With the introduction of the `OptimizerWrapper` object (commit https://github.com/uber/ludwig/commit/3ad7af3ea2ed7f79f24c8f09dbfcf08a08b339e5), the implementation of optimizers changed from `tf.nn` to Keras optimizers `tf.keras.optimizer`.  At least for the Adam optimizer, the keyword name change from `beta1` to `beta_1` and `beta2` to beta_2`.  Under the old names several unit tests now fail, such as
```
============================= test session starts ==============================
platform linux -- Python 3.6.9, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /opt/project
plugins: pycharm-0.6.0, typeguard-2.9.1
collected 10 items

test_simple_features.py FFFFFFFFFF                                       [100%]

=================================== FAILURES ===================================
```

This PR changes the names used in the default parameter specification to match the Keras api spec.  After making the change the above test now passes
```
=========================================================== test session starts ============================================================
platform linux -- Python 3.6.9, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /opt/project
plugins: pycharm-0.6.0, typeguard-2.9.1
collected 10 items

test_simple_features.py ..........                                                                                                   [100%]

============================================================= warnings summary ============================================================
```