### PR TITLE
TF2 Optimizer unit test

### DIFF
--- a/tests/integration_tests/test_model_training_options.py
+++ b/tests/integration_tests/test_model_training_options.py
@@ -261,7 +261,7 @@ OPTIMIZER_REGISTRY = [
     'adam', 'adadelta', 'adagrad', 'ftrl', 'rmsprop'
 ]
 @pytest.mark.parametrize('optimizer_type', OPTIMIZER_REGISTRY)
-def test_default_optimizer(optimizer_type, generated_data, tmp_path):
+def test_optimizers(optimizer_type, generated_data, tmp_path):
 
     input_features, output_features = get_feature_definitions()
 


### PR DESCRIPTION
# Code Pull Requests

Added unit test for optimizers:  `tests/integration_tests/test_model_training_options.py::test_optimizers`
```
pytest -v test_model_training_options.py::test_optimizers
=========================================================== test session starts ============================================================
platform linux -- Python 3.6.9, pytest-5.4.3, py-1.8.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /opt/project
plugins: pycharm-0.6.0, typeguard-2.9.1
collected 9 items

test_model_training_options.py::test_optimizers[sgd] PASSED                                                                          [ 11%]
test_model_training_options.py::test_optimizers[stochastic_gradient_descent] PASSED                                                  [ 22%]
test_model_training_options.py::test_optimizers[gd] PASSED                                                                           [ 33%]
test_model_training_options.py::test_optimizers[gradient_descent] PASSED                                                             [ 44%]
test_model_training_options.py::test_optimizers[adam] PASSED                                                                         [ 55%]
test_model_training_options.py::test_optimizers[adadelta] PASSED                                                                     [ 66%]
test_model_training_options.py::test_optimizers[adagrad] PASSED                                                                      [ 77%]
test_model_training_options.py::test_optimizers[ftrl] PASSED                                                                         [ 88%]
test_model_training_options.py::test_optimizers[rmsprop] PASSED                                                                      [100%]

============================================================= warnings summary =============================================================
/usr/local/lib/python3.6/dist-packages/tensorflow/python/pywrap_tensorflow_internal.py:15
  /usr/local/lib/python3.6/dist-packages/tensorflow/python/pywrap_tensorflow_internal.py:15: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    import imp

-- Docs: https://docs.pytest.org/en/latest/warnings.html
====================================================== 9 passed, 1 warning in 31.04s ======================================================
```

Right now I have this hard-coded in `test_model_training_options.py` to support testing of the optimizers.  
```
# todo tf2: add optimizer registry in optimization_module.py
OPTIMIZER_REGISTRY = [
    'sgd', 'stochastic_gradient_descent', 'gd', 'gradient_descent',
    'adam', 'adadelta', 'adagrad', 'ftrl', 'rmsprop'
]
```

Once a decision is made on the `OptimizerWrapper` class and the `optimization_modules.py` is baselined, I think we convert this to a optimizer registry dictionary and move it to that module, modify code in `optimization_modules.py` and 'test_model_training_opstions.py` to make use of this new optimizer registry dictionary.
