### PR TITLE
Prevent TensorFlow from being initialized more than once

### DIFF
--- a/ludwig/collect.py
+++ b/ludwig/collect.py
@@ -100,17 +100,17 @@ def collect_activations(
         train_set_metadata_fp
     )
 
-    model, model_definition = load_model_and_definition(model_path)
+    model, model_definition = load_model_and_definition(model_path,
+                                                        gpus=gpus,
+                                                        gpu_memory_limit=gpu_memory_limit,
+                                                        allow_parallel_threads=allow_parallel_threads)
 
     # collect activations
     print_boxed('COLLECT ACTIVATIONS')
     collected_tensors = model.collect_activations(
         dataset,
         tensors,
-        batch_size,
-        gpus=gpus,
-        gpu_memory_limit=gpu_memory_limit,
-        allow_parallel_threads=allow_parallel_threads
+        batch_size
     )
 
     model.close_session()

--- a/ludwig/experiment.py
+++ b/ludwig/experiment.py
@@ -146,9 +146,6 @@ def experiment(
             model_definition,
             batch_size,
             evaluate_performance=True,
-            gpus=gpus,
-            gpu_memory_limit=gpu_memory_limit,
-            allow_parallel_threads=allow_parallel_threads,
             debug=debug
         )
     else:

--- a/ludwig/models/model.py
+++ b/ludwig/models/model.py
@@ -58,6 +58,7 @@ from ludwig.utils.math_utils import learning_rate_warmup, \
     learning_rate_warmup_distributed
 from ludwig.utils.misc import set_random_seed
 from ludwig.utils.misc import sum_dicts
+from ludwig.utils.tf_utils import initialize_tensorflow
 
 logger = logging.getLogger(__name__)
 
@@ -77,6 +78,9 @@ class Model:
             training,
             preprocessing,
             use_horovod=None,
+            gpus=None,
+            gpu_memory_limit=None,
+            allow_parallel_threads=True,
             random_seed=default_random_seed,
             debug=False,
             **kwargs
@@ -87,8 +91,7 @@ class Model:
             self._horovod = horovod.tensorflow
             self._horovod.init()
 
-        self._initialized = False
-        # self.session = None
+        initialize_tensorflow(gpus, gpu_memory_limit, allow_parallel_threads, self._horovod)
 
         self._debug = debug
         self._weights_save_path = None
@@ -109,6 +112,7 @@ class Model:
         tf.random.set_seed(random_seed)
 
         # public
+        # NOTE: TensorFlow must be initialized prior to creating the model
         self.ecd = ECD(input_features, combiner, output_features)
 
         # ================ Optimizer ================
@@ -140,34 +144,6 @@ class Model:
     @tf.function
     def predict_step(self, model, inputs):
         return model.predictions(inputs, output_features=None)
-
-    def initialize_tensorflow(self, gpus=None, gpu_memory_limit=None,
-                              allow_parallel_threads=True):
-        # For reproducivility / determinism, set parallel threads to 1.
-        # For performance, set to 0 to allow TensorFlow to select the best value automatically.
-        tf.config.threading.set_intra_op_parallelism_threads(
-            0 if allow_parallel_threads else 1)
-        tf.config.threading.set_inter_op_parallelism_threads(
-            0 if allow_parallel_threads else 1)
-
-        if self._horovod is not None and gpus is None:
-            gpus = [self._horovod.local_rank()]
-        gpus = [gpus] if isinstance(gpus, int) else gpus
-
-        if gpus is not None:
-            gpu_devices = tf.config.list_physical_devices('GPU')
-            for gpu in gpu_devices:
-                tf.config.experimental.set_memory_growth(gpu, True)
-                if gpu_memory_limit is not None:
-                    tf.config.set_logical_device_configuration(
-                        gpu,
-                        [tf.config.LogicalDeviceConfiguration(
-                            memory_limit=gpu_memory_limit)])
-            if gpu_devices:
-                local_devices = [gpu_devices[g] for g in gpus]
-                tf.config.set_visible_devices(local_devices, 'GPU')
-
-        self._initialized = True
 
     @classmethod
     def write_epoch_summary(
@@ -239,9 +215,6 @@ class Model:
             skip_save_model=False,
             skip_save_progress=False,
             skip_save_log=False,
-            gpus=None,
-            gpu_memory_limit=None,
-            allow_parallel_threads=True,
             random_seed=default_random_seed,
             **kwargs
     ):
@@ -324,13 +297,6 @@ class Model:
                is not needed turning it off can slightly increase the
                overall speed..
         :type skip_save_log: Boolean
-        :param gpus: List of gpus to use
-        :type gpus: List
-        :param gpu_memory_limit: maximum memory in MB to allocate per GPU device.
-        :type gpu_memory_limit: Integer
-        :param allow_parallel_threads: allow TensorFlow to use multithreading parallelism
-               to improve performance at the cost of determinism.
-        :type allow_parallel_threads: Boolean
         :param random_seed: Default initialization for the random seeds
         :type: Float
         """
@@ -750,13 +716,8 @@ class Model:
             dataset,
             batch_size=128,
             regularization_lambda=0.0,
-            bucketing_field=None,
-            gpus=None,
-            gpu_memory_limit=None,
-            allow_parallel_threads=True
+            bucketing_field=None
     ):
-        self.initialize_tensorflow(gpus, gpu_memory_limit,
-                                   allow_parallel_threads)
         batcher = self.initialize_batcher(dataset, batch_size, bucketing_field)
 
         # training step loop
@@ -1068,9 +1029,6 @@ class Model:
             dataset,
             batch_size,
             evaluate_performance=True,
-            gpus=None,
-            gpu_memory_limit=None,
-            allow_parallel_threads=True,
             **kwargs
     ):
         # predict
@@ -1097,15 +1055,8 @@ class Model:
             dataset,
             tensor_names,
             batch_size,
-            gpus=None,
-            gpu_memory_limit=None,
-            allow_parallel_threads=True,
             **kwargs
     ):
-        if not self._initialized:
-            self.initialize_tensorflow(gpus, gpu_memory_limit,
-                                       allow_parallel_threads)
-
         # if self.session is None:
         #     session = self.initialize_session(gpus, gpu_fraction)
         #
@@ -1139,15 +1090,8 @@ class Model:
     def collect_weights(
             self,
             tensor_names,
-            gpus=None,
-            gpu_memory_limit=None,
-            allow_parallel_threads=True,
             **kwargs
     ):
-        if not self._initialized:
-            self.initialize_tensorflow(gpus, gpu_memory_limit,
-                                       allow_parallel_threads)
-
         # todo tf2: reintroduce functionality
         # if self.session is None:
         #     session = self.initialize_session(gpus, gpu_fraction)
@@ -1228,20 +1172,21 @@ class Model:
         self.ecd.load_weights(weights_path)
 
     @staticmethod
-    def load(load_path, gpus=None, gpu_memory_limit=None,
-             allow_parallel_threads=True, use_horovod=None):
+    def load(load_path, use_horovod=None, gpus=None, gpu_memory_limit=None, allow_parallel_threads=True):
         hyperparameter_file = os.path.join(
             load_path,
             MODEL_HYPERPARAMETERS_FILE_NAME
         )
         hyperparameters = load_json(hyperparameter_file)
-        model = Model(use_horovod=use_horovod, **hyperparameters)
+        model = Model(use_horovod=use_horovod,
+                      gpus=gpus,
+                      gpu_memory_limit=gpu_memory_limit,
+                      allow_parallel_threads=allow_parallel_threads,
+                      **hyperparameters)
         weights_save_path = os.path.join(
             load_path,
             MODEL_WEIGHTS_FILE_NAME
         )
-        model.initialize_tensorflow(gpus, gpu_memory_limit,
-                                    allow_parallel_threads)
         model.restore(weights_save_path)
         return model
 
@@ -1501,7 +1446,11 @@ class ProgressTracker:
         return ProgressTracker(**loaded)
 
 
-def load_model_and_definition(model_dir, use_horovod=None):
+def load_model_and_definition(model_dir,
+                              use_horovod=None,
+                              gpus=None,
+                              gpu_memory_limit=None,
+                              allow_parallel_threads=True):
     # Load model definition and weights
     model_definition = load_json(
         os.path.join(
@@ -1509,5 +1458,9 @@ def load_model_and_definition(model_dir, use_horovod=None):
             MODEL_HYPERPARAMETERS_FILE_NAME
         )
     )
-    model = Model.load(model_dir, use_horovod=use_horovod)
+    model = Model.load(model_dir,
+                       use_horovod=use_horovod,
+                       gpus=gpus,
+                       gpu_memory_limit=gpu_memory_limit,
+                       allow_parallel_threads=allow_parallel_threads)
     return model, model_definition

--- a/ludwig/predict.py
+++ b/ludwig/predict.py
@@ -89,7 +89,10 @@ def full_predict(
     if is_on_master():
         print_boxed('LOADING MODEL')
     model, model_definition = load_model_and_definition(model_path,
-                                                        use_horovod=use_horovod)
+                                                        use_horovod=use_horovod,
+                                                        gpus=gpus,
+                                                        gpu_memory_limit=gpu_memory_limit,
+                                                        allow_parallel_threads=allow_parallel_threads)
 
     prediction_results = predict(
         dataset,
@@ -98,9 +101,6 @@ def full_predict(
         model_definition,
         batch_size,
         evaluate_performance,
-        gpus,
-        gpu_memory_limit,
-        allow_parallel_threads,
         debug
     )
     # model.close_session()  # todo tf2 code clean -up
@@ -146,9 +146,6 @@ def predict(
         model_definition,
         batch_size=128,
         evaluate_performance=True,
-        gpus=None,
-        gpu_memory_limit=None,
-        allow_parallel_threads=True,
         debug=False
 ):
     """Computes predictions based on the computed model.
@@ -168,9 +165,6 @@ def predict(
                to contain also ground truth for the output features, otherwise
                the metrics cannot be computed.
         :type evaluate_performance: Bool
-        :type gpus: List
-        :type gpu_memory_limit Int
-        :type allow_parallel_threads: Bool
         :param debug: If true turns on tfdbg with inf_or_nan checks.
         :type debug: Boolean
 
@@ -184,10 +178,7 @@ def predict(
     test_stats, test_predictions = model.predict(
         dataset,
         batch_size,
-        evaluate_performance=evaluate_performance,
-        gpus=gpus,
-        gpu_memory_limit=gpu_memory_limit,
-        allow_parallel_threads=allow_parallel_threads
+        evaluate_performance=evaluate_performance
     )
 
     # combine predictions with the overall metrics

--- a/ludwig/utils/tf_utils.py
+++ b/ludwig/utils/tf_utils.py
@@ -51,7 +51,8 @@ def initialize_tensorflow(gpus=None,
                           horovod=None):
     global _TF_INIT_PARAMS
 
-    param_tuple = (gpus, gpu_memory_limit, allow_parallel_threads)
+    use_horovod = horovod is not None
+    param_tuple = (gpus, gpu_memory_limit, allow_parallel_threads, use_horovod)
     if _TF_INIT_PARAMS is not None:
         if _TF_INIT_PARAMS != param_tuple:
             warnings.warn('TensorFlow has already been initialized. Changes to `gpus`, '


### PR DESCRIPTION
As part of this PR, move GPU and other TF config settings to Model constructor to ensure it occurs before the TensorFlow model is constructed.