### PR TITLE
Fixed wandb and comet for tf2, improved integration tests, enabled contrib with programmatic API

### DIFF
--- a/ludwig/contrib.py
+++ b/ludwig/contrib.py
@@ -23,6 +23,20 @@ import sys
 from .contribs import contrib_registry
 
 
+def use_contrib(name, *args, **kwargs):
+    # Import a contrib package and cache its instance, if appropriate
+    contrib_class = contrib_registry["classes"][name]
+    if contrib_class not in [obj.__class__ for obj in contrib_registry["instances"]]:
+        try:
+            instance = contrib_class.import_call(*args, **kwargs)
+        except Exception:
+            instance = None
+
+        # Save instance in registry
+        if instance:
+            contrib_registry["instances"].append(instance)
+
+
 def contrib_import():
     """
     Checks for contrib flags, and calls static method:
@@ -37,20 +51,11 @@ def contrib_import():
     for contrib_name in contrib_registry["classes"]:
         parameter_name = '--' + contrib_name
         if parameter_name in argv_set:
-            ## Calls ContribClass.import_call(argv_list)
-            ## and return an instance, if appropriate
-            contrib_class = contrib_registry["classes"][contrib_name]
-            if contrib_class not in [
-                obj.__class__ for obj in contrib_registry["instances"]]:
-                try:
-                    instance = contrib_class.import_call(argv_list)
-                except Exception:
-                    instance = None
-                ## Save instance in registry
-                if instance:
-                    contrib_registry["instances"].append(instance)
-            ## Clean up and remove the flag
+            use_contrib(contrib_name, *argv_list)
+
+            # Clean up and remove the flag
             sys.argv.remove(parameter_name)
+
 
 def contrib_command(command, *args, **kwargs):
     """

--- a/ludwig/contribs/comet.py
+++ b/ludwig/contribs/comet.py
@@ -28,7 +28,7 @@ class Comet():
     """
 
     @staticmethod
-    def import_call(argv, *args, **kwargs):
+    def import_call(*args, **kwargs):
         """
         Enable Third-party support from comet.ml
         Allows experiment tracking, visualization, and
@@ -50,13 +50,16 @@ class Comet():
         else:
             logger.error("Ignored --comet: Need version 1.0.51 or greater")
 
+    def __init__(self):
+        self.cometml_experiment = None
+
     def experiment(self, *args, **kwargs):
         import comet_ml
         try:
             self.cometml_experiment = comet_ml.Experiment(log_code=False)
         except Exception:
             self.cometml_experiment = None
-            logger.error(
+            logger.exception(
                 "comet_ml.Experiment() had errors. Perhaps you need to define COMET_API_KEY")
             return
 
@@ -74,7 +77,7 @@ class Comet():
             self.cometml_experiment = comet_ml.Experiment(log_code=False)
         except Exception:
             self.cometml_experiment = None
-            logger.error(
+            logger.exception(
                 "comet_ml.Experiment() had errors. Perhaps you need to define COMET_API_KEY")
             return
 
@@ -86,15 +89,37 @@ class Comet():
         config = comet_ml.get_config()
         self._save_config(config)
 
-    def train_model(self, *args, **kwargs):
+    def train_init(self, experiment_directory, experiment_name, model_name,
+                   resume, output_directory):
+        if self.cometml_experiment:
+            # Comet ML already initialized
+            return
+
+        import comet_ml
+        try:
+            self.cometml_experiment = comet_ml.Experiment(log_code=False,
+                                                          project_name=experiment_name)
+        except Exception:
+            self.cometml_experiment = None
+            logger.exception(
+                "comet_ml.Experiment() had errors. Perhaps you need to define COMET_API_KEY")
+            return
+
+        logger.info("comet.train() called......")
+        self.cometml_experiment.set_name(model_name)
+        self.cometml_experiment.set_filename("Ludwig API")
+        config = comet_ml.get_config()
+        self._save_config(config, directory=experiment_directory)
+
+    def train_model(self, model, model_definition, model_definition_path, *args, **kwargs):
         logger.info("comet.train_model() called......")
         if self.cometml_experiment:
-            model = args[0]
-            model_definition = args[1]
-            model_definition_path = args[2]
-            if model:
-                self.cometml_experiment.set_model_graph(
-                    str(model._graph.as_graph_def()))
+            # TODO tf2: currently no clear way to set model graph
+            # see: https://github.com/comet-ml/issue-tracking/issues/296
+            # if model:
+            #     self.cometml_experiment.set_model_graph(
+            #         str(model._graph.as_graph_def()))
+
             if model_definition:
                 if model_definition_path:
                     base_name = os.path.basename(model_definition_path)
@@ -107,9 +132,8 @@ class Comet():
                 self.cometml_experiment.log_asset_data(model_definition,
                                                        base_name)
 
-    def train_save(self, *args, **kwargs):
+    def train_save(self, experiment_dir_name, *args, **kwargs):
         logger.info("comet.train_save() called......")
-        experiment_dir_name = args[0]
         if self.cometml_experiment:
             self.cometml_experiment.log_asset_folder(experiment_dir_name)
 
@@ -186,10 +210,10 @@ class Comet():
         cli = self._make_command_line(args)
         self._log_html(cli)
 
-    def _save_config(self, config):
+    def _save_config(self, config, directory='.'):
         ## save the .comet.config here:
         config["comet.experiment_key"] = self.cometml_experiment.id
-        config.save()
+        config.save(directory=directory)
 
     def _log_html(self, text):
         ## log the text to the html tab:

--- a/ludwig/contribs/comet.py
+++ b/ludwig/contribs/comet.py
@@ -105,7 +105,7 @@ class Comet():
                 "comet_ml.Experiment() had errors. Perhaps you need to define COMET_API_KEY")
             return
 
-        logger.info("comet.train() called......")
+        logger.info("comet.train_init() called......")
         self.cometml_experiment.set_name(model_name)
         self.cometml_experiment.set_filename("Ludwig API")
         config = comet_ml.get_config()

--- a/ludwig/contribs/wandb.py
+++ b/ludwig/contribs/wandb.py
@@ -25,7 +25,7 @@ class Wandb():
     """Class that defines the methods necessary to hook into process."""
 
     @staticmethod
-    def import_call(argv, *args, **kwargs):
+    def import_call(*args, **kwargs):
         """
         Enable Third-party support from wandb.ai
         Allows experiment tracking, visualization, and

--- a/ludwig/utils/horovod_utils.py
+++ b/ludwig/utils/horovod_utils.py
@@ -17,8 +17,6 @@
 import io
 import os
 
-import tensorflow as tf
-
 
 def should_use_horovod(use_horovod):
     """Returns True if user did not specify explicitly and running with `horovodrun`."""
@@ -42,7 +40,10 @@ def allgather_object(obj):
     Returns:
         The list of objects that were allgathered across all ranks.
     """
+    # Horovod and its deps are optional, so do not import them at the top.
+    # TensorFlow is included here as certain modules (like comet) must import before TF.
     import cloudpickle
+    import tensorflow as tf
     from horovod.tensorflow import allgather, size
 
     def load(byte_array):

--- a/tests/integration_tests/scripts/run_train_comet.py
+++ b/tests/integration_tests/scripts/run_train_comet.py
@@ -1,0 +1,82 @@
+# Tests the following end-to-end:
+#
+# 1. Comet is imported
+# 2. Conflicting modules (i.e., TensorFlow) are not imported
+# 3. Overridden methods are called (train_init, train_model, etc.) and run without error
+#
+# This test runs in an isolated environment to ensure TensorFlow imports are not leaked
+# from previous tests.
+
+import argparse
+import os
+import shutil
+import sys
+
+from unittest.mock import patch
+
+import ludwig.contrib
+
+# Use contrib module before other imports to avoid importing TensorFlow before comet.
+# Bad key will ensure Comet is initialized, but nothing is uploaded externally.
+os.environ['COMET_API_KEY'] = 'key'
+ludwig.contrib.use_contrib('comet')
+
+from ludwig.api import LudwigModel
+from ludwig.contribs.comet import Comet
+
+PATH_HERE = os.path.abspath(os.path.dirname(__file__))
+PATH_ROOT = os.path.join(PATH_HERE, '..', '..', '..')
+sys.path.insert(0, os.path.abspath(PATH_ROOT))
+
+from tests.integration_tests.utils import category_feature
+from tests.integration_tests.utils import generate_data
+from tests.integration_tests.utils import image_feature
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--csv-filename', required=True)
+
+
+def run(csv_filename):
+    # Check that comet has been imported successfully as a contrib package
+    contrib_instances = ludwig.contrib.contrib_registry["instances"]
+    assert len(contrib_instances) == 1
+
+    comet_instance = contrib_instances[0]
+    assert isinstance(comet_instance, Comet)
+
+    # Image Inputs
+    image_dest_folder = os.path.join(os.getcwd(), 'generated_images')
+
+    # Inputs & Outputs
+    input_features = [image_feature(folder=image_dest_folder)]
+    output_features = [category_feature()]
+    data_csv = generate_data(input_features, output_features, csv_filename)
+
+    model_definition = {
+        'input_features': input_features,
+        'output_features': output_features,
+        'combiner': {'type': 'concat', 'fc_size': 14},
+        'training': {'epochs': 2}
+    }
+
+    model = LudwigModel(model_definition)
+
+    with patch('comet_ml.Experiment.log_asset_data') as mock_log_asset_data:
+        try:
+            # Training with csv
+            model.train(data_csv=data_csv)
+            model.predict(data_csv=data_csv)
+        finally:
+            if model.exp_dir_name:
+                shutil.rmtree(model.exp_dir_name, ignore_errors=True)
+
+    # Verify that the experiment was created successfully
+    assert comet_instance.cometml_experiment is not None
+
+    # Check that we ran `train_model`, which calls into `log_assert_data`, successfully
+    mock_log_asset_data.assert_called()
+
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    run(args.csv_filename)

--- a/tests/integration_tests/scripts/run_train_comet.py
+++ b/tests/integration_tests/scripts/run_train_comet.py
@@ -12,7 +12,7 @@ import os
 import shutil
 import sys
 
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
 import ludwig.contrib
 
@@ -61,6 +61,10 @@ def run(csv_filename):
 
     model = LudwigModel(model_definition)
 
+    # Wrap these methods so we can check that they were called
+    comet_instance.train_init = Mock(side_effect=comet_instance.train_init)
+    comet_instance.train_model = Mock(side_effect=comet_instance.train_model)
+
     with patch('comet_ml.Experiment.log_asset_data') as mock_log_asset_data:
         try:
             # Training with csv
@@ -72,6 +76,10 @@ def run(csv_filename):
 
     # Verify that the experiment was created successfully
     assert comet_instance.cometml_experiment is not None
+
+    # Check that these methods were called at least once
+    comet_instance.train_init.assert_called()
+    comet_instance.train_model.assert_called()
 
     # Check that we ran `train_model`, which calls into `log_assert_data`, successfully
     mock_log_asset_data.assert_called()

--- a/tests/integration_tests/scripts/run_train_wandb.py
+++ b/tests/integration_tests/scripts/run_train_wandb.py
@@ -1,0 +1,73 @@
+# Tests the following end-to-end:
+#
+# 1. W&B is imported
+# 2. Overridden methods are called (train_init, train_model, etc.) and run without error
+#
+# This test runs in an isolated environment because W&B make breaking changes to the
+# global interpreter state that will otherwise cause subsequent tests to fail.
+
+import argparse
+import os
+import shutil
+import sys
+
+from unittest.mock import Mock
+
+import ludwig.contrib
+
+from ludwig.contribs.wandb import Wandb
+
+PATH_HERE = os.path.abspath(os.path.dirname(__file__))
+PATH_ROOT = os.path.join(PATH_HERE, '..', '..', '..')
+sys.path.insert(0, os.path.abspath(PATH_ROOT))
+
+from tests.integration_tests.test_experiment import run_experiment
+from tests.integration_tests.utils import category_feature
+from tests.integration_tests.utils import generate_data
+from tests.integration_tests.utils import image_feature
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--csv-filename', required=True)
+
+
+def run(csv_filename):
+    # enable wandb contrib module
+    ludwig.contrib.use_contrib('wandb')
+
+    # Check that wandb has been imported successfully as a contrib package
+    contrib_instances = ludwig.contrib.contrib_registry["instances"]
+    assert len(contrib_instances) == 1
+
+    wandb_instance = contrib_instances[0]
+    assert isinstance(wandb_instance, Wandb)
+
+    # Wrap these methods so we can check that they were called
+    wandb_instance.train_init = Mock(side_effect=wandb_instance.train_init)
+    wandb_instance.train_model = Mock(side_effect=wandb_instance.train_model)
+
+    # disable sync to cloud
+    os.environ['WANDB_MODE'] = 'dryrun'
+
+    # Image Inputs
+    image_dest_folder = os.path.join(os.getcwd(), 'generated_images')
+
+    try:
+        # Inputs & Outputs
+        input_features = [image_feature(folder=image_dest_folder)]
+        output_features = [category_feature()]
+        rel_path = generate_data(input_features, output_features, csv_filename)
+
+        # Run experiment
+        run_experiment(input_features, output_features, data_csv=rel_path)
+    finally:
+        # Delete the temporary data created
+        shutil.rmtree(image_dest_folder, ignore_errors=True)
+
+    # Check that these methods were called at least once
+    wandb_instance.train_init.assert_called()
+    wandb_instance.train_model.assert_called()
+
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    run(args.csv_filename)

--- a/tests/integration_tests/test_contrib_comet.py
+++ b/tests/integration_tests/test_contrib_comet.py
@@ -1,0 +1,27 @@
+import logging
+import os
+import subprocess
+import sys
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+logging.getLogger("ludwig").setLevel(logging.INFO)
+
+TEST_SCRIPT = os.path.join(os.path.dirname(__file__), 'scripts', 'run_train_comet.py')
+
+
+def test_contrib_experiment(csv_filename):
+    cmdline = [
+        sys.executable, TEST_SCRIPT,
+        '--csv-filename', csv_filename
+    ]
+    exit_code = subprocess.call(' '.join(cmdline), shell=True, env=os.environ.copy())
+    assert exit_code == 0
+
+
+if __name__ == '__main__':
+    """
+    To run tests individually, run:
+    ```python -m pytest tests/integration_tests/test_contrib_comet.py::test_name```
+    """
+    pass

--- a/tests/integration_tests/test_contrib_wandb.py
+++ b/tests/integration_tests/test_contrib_wandb.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import shutil
-import sys
 
 from unittest.mock import patch
 
@@ -20,9 +19,8 @@ logging.getLogger("ludwig").setLevel(logging.INFO)
 def test_wandb_experiment(import_wandb, csv_filename):
     # Test W&B integration
 
-    # add wandb arg and detect flag
-    sys.argv.append('--wandb')
-    ludwig.contrib.contrib_import()
+    # enable wandb contrib module
+    ludwig.contrib.use_contrib('wandb')
 
     # disable sync to cloud
     os.environ['WANDB_MODE'] = 'dryrun'
@@ -38,7 +36,7 @@ def test_wandb_experiment(import_wandb, csv_filename):
     # Run experiment
     run_experiment(input_features, output_features, data_csv=rel_path)
 
-    # Check a W&B run was created
+    # Check wandb was imported
     import_wandb.assert_called()
 
     # Remove instance from contrib_registry

--- a/tests/integration_tests/test_contrib_wandb.py
+++ b/tests/integration_tests/test_contrib_wandb.py
@@ -1,49 +1,22 @@
 import logging
 import os
-import shutil
-
-from unittest.mock import patch
-
-import ludwig.contrib
-from tests.integration_tests.test_experiment import run_experiment
-from tests.integration_tests.utils import category_feature
-from tests.integration_tests.utils import generate_data
-from tests.integration_tests.utils import image_feature
+import subprocess
+import sys
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 logging.getLogger("ludwig").setLevel(logging.INFO)
 
+TEST_SCRIPT = os.path.join(os.path.dirname(__file__), 'scripts', 'run_train_wandb.py')
 
-@patch('ludwig.contribs.wandb.Wandb.import_call')
-def test_wandb_experiment(import_wandb, csv_filename):
-    # Test W&B integration
 
-    # enable wandb contrib module
-    ludwig.contrib.use_contrib('wandb')
-
-    # disable sync to cloud
-    os.environ['WANDB_MODE'] = 'dryrun'
-
-    # Image Inputs
-    image_dest_folder = os.path.join(os.getcwd(), 'generated_images')
-
-    # Inputs & Outputs
-    input_features = [image_feature(folder=image_dest_folder)]
-    output_features = [category_feature()]
-    rel_path = generate_data(input_features, output_features, csv_filename)
-
-    # Run experiment
-    run_experiment(input_features, output_features, data_csv=rel_path)
-
-    # Check wandb was imported
-    import_wandb.assert_called()
-
-    # Remove instance from contrib_registry
-    ludwig.contrib.contrib_registry['instances'].pop()
-
-    # Delete the temporary data created
-    shutil.rmtree(image_dest_folder)
+def test_contrib_experiment(csv_filename):
+    cmdline = [
+        sys.executable, TEST_SCRIPT,
+        '--csv-filename', csv_filename
+    ]
+    exit_code = subprocess.call(' '.join(cmdline), shell=True, env=os.environ.copy())
+    assert exit_code == 0
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Removed TF2 incompatible code from comet and verified both comet and wandb end-to-end.
- Added integration test for comet and made wandb and comet tests use subprocess isolation to avoid test leakage.
- Added `ludwig.contrib.use_contrib` helper to allow contribs to be used from the programmatic API.