### PR TITLE
TF2 porting:  Fix cli visualization unit tests

### DIFF
--- a/tests/integration_tests/test_visualization.py
+++ b/tests/integration_tests/test_visualization.py
@@ -241,7 +241,7 @@ def test_visualization_compare_performance_output_saved(csv_filename):
         figure_cnt = glob.glob(viz_pattern)
 
         assert 0 == result.returncode
-        assert 2 == len(figure_cnt)
+        assert 1 == len(figure_cnt)
 
     shutil.rmtree(exp_dir_name, ignore_errors=True)
     shutil.rmtree('results', ignore_errors=True)
@@ -1479,7 +1479,7 @@ def test_visualization_roc_curves_from_test_statistics_output_saved(
     output_features = [binary_feature()]
     # Generate test data
     rel_path = generate_data(input_features, output_features, csv_filename)
-    input_features[0]['encoder'] = 'parallel_cnn'
+
     exp_dir_name = run_experiment(
         input_features,
         output_features,

--- a/tests/integration_tests/test_visualization.py
+++ b/tests/integration_tests/test_visualization.py
@@ -133,7 +133,7 @@ def test_visualization_learning_curves_output_saved(csv_filename):
         figure_cnt = glob.glob(viz_pattern)
 
         assert 0 == result.returncode
-        assert 5 == len(figure_cnt)
+        assert 4 == len(figure_cnt)
 
     shutil.rmtree(exp_dir_name, ignore_errors=True)
 


### PR DESCRIPTION
# Code Pull Requests

Resolved TF2 porting issues in `tests/integration_tests/test_visualization.py`.  Here is the pytest log from test run.
```
pytest /opt/project/tests/integration_tests/test_visualization.py
=========================================================== test session starts ============================================================
platform linux -- Python 3.6.9, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /opt/project
plugins: pycharm-0.6.0, typeguard-2.9.1
collected 26 items

../../../tests/integration_tests/test_visualization.py ..........................                                                    [100%]

============================================================= warnings summary =============================================================
=============================================== 26 passed, 32 warnings in 238.67s (0:03:58) ==============================================
```
