### PR TITLE
Remove should_close_session param & Fix Hyperopt Integration tests

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -551,7 +551,6 @@ class LudwigModel:
             skip_save_log=skip_save_log,
             skip_save_processed_input=skip_save_processed_input,
             output_directory=output_directory,
-            should_close_session=False,
             gpus=gpus,
             gpu_memory_limit=gpu_memory_limit,
             allow_parallel_threads=allow_parallel_threads,

--- a/ludwig/experiment.py
+++ b/ludwig/experiment.py
@@ -75,7 +75,6 @@ def experiment(
         skip_save_test_predictions=False,  # skipcq: PYL-W0613
         skip_save_test_statistics=False,  # skipcq: PYL-W0613
         output_directory='results',
-        should_close_session=False,
         gpus=None,
         gpu_memory_limit=None,
         allow_parallel_threads=True,
@@ -117,7 +116,6 @@ def experiment(
         skip_save_log=skip_save_log,
         skip_save_processed_input=skip_save_processed_input,
         output_directory=output_directory,
-        should_close_session=should_close_session,
         gpus=gpus,
         gpu_memory_limit=gpu_memory_limit,
         allow_parallel_threads=allow_parallel_threads,
@@ -345,7 +343,6 @@ def full_experiment(
         skip_save_log=skip_save_log,
         skip_save_processed_input=skip_save_processed_input,
         output_directory=output_directory,
-        should_close_session=False,
         gpus=gpus,
         gpu_memory_limit=gpu_memory_limit,
         allow_parallel_threads=allow_parallel_threads,

--- a/ludwig/train.py
+++ b/ludwig/train.py
@@ -78,7 +78,6 @@ def full_train(
         skip_save_log=False,
         skip_save_processed_input=False,
         output_directory='results',
-        should_close_session=True,
         gpus=None,
         gpu_memory_limit=None,
         allow_parallel_threads=True,
@@ -367,9 +366,6 @@ def full_train(
         VALIDATION: train_valisest_stats,
         TEST: train_testset_stats
     }
-
-    if should_close_session:
-        model.close_session()
 
     # save training statistics
     if is_on_master():

--- a/ludwig/utils/hyperopt_utils.py
+++ b/ludwig/utils/hyperopt_utils.py
@@ -1006,8 +1006,6 @@ def train_and_eval_on_split(
         model_definition,
         batch_size,
         evaluate_performance=True,
-        gpus=gpus,
-        gpu_fraction=gpu_fraction,
         debug=debug
     )
     if not (


### PR DESCRIPTION
Will need to update `gpu_fraction` logic for `gpu_memory_limit` next. The logic for ParallelExecutor is dependent on `process_per_gpu = int(1 / gpu_fraction)`. We could figure out the available GPU memory by the `nvidia-smi` command and then execute the tasks parallelly with the hardbound limit on each process with `gpy_memory_limit`.