### PR TITLE
TF2 porting: Fix kfold_cv unit test (WIP)

### DIFF
--- a/ludwig/experiment.py
+++ b/ludwig/experiment.py
@@ -493,11 +493,11 @@ def kfold_cross_validate(
     # consolidate raw fold metrics across all folds
     raw_kfold_stats = {}
     for fold_name in kfold_cv_stats:
-        for category in kfold_cv_stats[fold_name]['fold_metric']:
-            if category not in raw_kfold_stats:
-                raw_kfold_stats[category] = {}
+        for output_name in kfold_cv_stats[fold_name]['fold_metric']:
+            if output_name not in raw_kfold_stats:
+                raw_kfold_stats[output_name] = {}
             fold_outputs = \
-                kfold_cv_stats[fold_name]['fold_metric'][category]
+                kfold_cv_stats[fold_name]['fold_metric'][output_name]
 
             # todo revisit to see if can use output feature.postprocess_results()
             # convert tensors created during predictions to numpy arrays to
@@ -517,20 +517,20 @@ def kfold_cross_validate(
                     'roc_curve',
                     'precision_recall_curve'
                 }:
-                    if metric not in raw_kfold_stats[category]:
-                        raw_kfold_stats[category][metric] = []
-                    raw_kfold_stats[category][metric] \
+                    if metric not in raw_kfold_stats[output_name]:
+                        raw_kfold_stats[output_name][metric] = []
+                    raw_kfold_stats[output_name][metric] \
                         .append(fold_outputs[metric])
 
     # calculate overall kfold statistics
     overall_kfold_stats = {}
-    for category in raw_kfold_stats:
-        overall_kfold_stats[category] = {}
-        for metric in raw_kfold_stats[category]:
-            mean = np.mean(raw_kfold_stats[category][metric])
-            std = np.std(raw_kfold_stats[category][metric])
-            overall_kfold_stats[category][metric + '_mean'] = mean
-            overall_kfold_stats[category][metric + '_std'] = std
+    for output_name in raw_kfold_stats:
+        overall_kfold_stats[output_name] = {}
+        for metric in raw_kfold_stats[output_name]:
+            mean = np.mean(raw_kfold_stats[output_name][metric])
+            std = np.std(raw_kfold_stats[output_name][metric])
+            overall_kfold_stats[output_name][metric + '_mean'] = mean
+            overall_kfold_stats[output_name][metric + '_std'] = std
 
     kfold_cv_stats['overall'] = overall_kfold_stats
 

--- a/ludwig/experiment.py
+++ b/ludwig/experiment.py
@@ -496,18 +496,18 @@ def kfold_cross_validate(
         for category in kfold_cv_stats[fold_name]['fold_metric']:
             if category not in raw_kfold_stats:
                 raw_kfold_stats[category] = {}
-            category_stats = \
+            fold_outputs = \
                 kfold_cv_stats[fold_name]['fold_metric'][category]
 
-            # clear out predictions Tensors
-            # todo revisit to see if we can save predictions output
-            #    not enough structures to use output feature.postprocess_results()
-            keys = [key for key in category_stats
-                    if isinstance(category_stats[key], tf.Tensor)]
-            for key in keys:
-                del category_stats[key]
+            # todo revisit to see if can use output feature.postprocess_results()
+            # convert tensors created during predictions to numpy arrays to
+            # allow saving as json object
+            for key in fold_outputs:
+                if isinstance(fold_outputs[key], tf.Tensor):
+                    fold_outputs[key] = \
+                        fold_outputs[key].numpy()
 
-            for metric in category_stats:
+            for metric in fold_outputs:
                 if metric not in {
                     'predictions',
                     'probabilities',
@@ -520,7 +520,7 @@ def kfold_cross_validate(
                     if metric not in raw_kfold_stats[category]:
                         raw_kfold_stats[category][metric] = []
                     raw_kfold_stats[category][metric] \
-                        .append(category_stats[metric])
+                        .append(fold_outputs[metric])
 
     # calculate overall kfold statistics
     overall_kfold_stats = {}

--- a/ludwig/experiment.py
+++ b/ludwig/experiment.py
@@ -28,6 +28,8 @@ import numpy as np
 import pandas as pd
 import yaml
 
+import tensorflow as tf
+
 from ludwig.constants import TRAINING
 from ludwig.contrib import contrib_command
 from ludwig.data.postprocessing import postprocess
@@ -496,6 +498,15 @@ def kfold_cross_validate(
                 raw_kfold_stats[category] = {}
             category_stats = \
                 kfold_cv_stats[fold_name]['fold_metric'][category]
+
+            # clear out predictions Tensors
+            # todo revisit to see if we can save predictions output
+            #    not enough structures to use output feature.postprocess_results()
+            keys = [key for key in category_stats
+                    if isinstance(category_stats[key], tf.Tensor)]
+            for key in keys:
+                del category_stats[key]
+
             for metric in category_stats:
                 if metric not in {
                     'predictions',

--- a/tests/integration_tests/test_kfold_cv.py
+++ b/tests/integration_tests/test_kfold_cv.py
@@ -2,8 +2,10 @@ import logging
 import os
 import os.path
 import tempfile
+from collections import namedtuple
 
 import yaml
+import pytest
 
 from ludwig.api import kfold_cross_validate
 from ludwig.experiment import full_kfold_cross_validate
@@ -11,13 +13,98 @@ from ludwig.utils.data_utils import load_json
 from tests.integration_tests.utils import category_feature
 from tests.integration_tests.utils import generate_data
 from tests.integration_tests.utils import numerical_feature
+from tests.integration_tests.utils import binary_feature
+from tests.integration_tests.utils import sequence_feature
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 logging.getLogger("ludwig").setLevel(logging.INFO)
 
 
-def test_kfold_cv_cli():
+FeaturesToUse = namedtuple('FeaturesToUse', 'input_features output_features')
+
+FEATURES_TO_TEST = [
+    FeaturesToUse(
+        #input feature
+        [
+            numerical_feature(normalization='zscore'),
+            numerical_feature(normalization='zscore')
+        ],
+        # output feature
+        [
+            numerical_feature()
+        ]
+    ),
+    FeaturesToUse(
+        # input feature
+        [
+            numerical_feature(normalization='zscore'),
+            numerical_feature(normalization='zscore')
+        ],
+        # output feature
+        [
+            binary_feature()
+        ]
+    ),
+    FeaturesToUse(
+        # input feature
+        [
+            numerical_feature(normalization='zscore'),
+            numerical_feature(normalization='zscore')
+        ],
+        # output feature
+        [
+            category_feature(vocab_size=2, reduce_input='sum')
+        ]
+    ),
+    FeaturesToUse(
+        # input feature
+        [
+            sequence_feature(
+                min_len=5,
+                max_len=10,
+                encoder='rnn',
+                cell_type='lstm',
+                reduce_output=None
+            )
+         ],
+        # output feature
+        [
+            sequence_feature(
+                min_len=5,
+                max_len=10,
+                decoder='generator',
+                cell_type='lstm',
+                attention='bahdanau',
+                reduce_input=None
+            )
+        ]
+    ),
+    FeaturesToUse(
+        # input feature
+        [
+            sequence_feature(
+                min_len=5,
+                max_len=10,
+                encoder='rnn',
+                cell_type='lstm',
+                reduce_output=None
+            )
+
+        ],
+        # output feature
+        [
+            sequence_feature(
+                max_len=10,
+                decoder='tagger',
+                reduce_input=None
+            )
+        ]
+    )
+]
+
+@pytest.mark.parametrize('features_to_use', FEATURES_TO_TEST)
+def test_kfold_cv_cli(features_to_use):
     # k-fold cross validation cli
     num_folds = 3
 
@@ -32,14 +119,10 @@ def test_kfold_cv_cli():
         indices_fp = os.path.join(results_dir, 'kfold_split_indices.json')
 
         # generate synthetic data for the test
-        input_features = [
-            numerical_feature(normalization='zscore'),
-            numerical_feature(normalization='zscore')
-        ]
+        input_features = features_to_use.input_features
 
-        output_features = [
-            category_feature(vocab_size=2, reduce_input='sum')
-        ]
+
+        output_features = features_to_use.output_features
 
         generate_data(input_features, output_features, training_data_fp)
 


### PR DESCRIPTION
# Code Pull Requests

Unit test `tests/integration_tests/test_kfold_cv.py::test_kfold_cv_cli` fails on this call
https://github.com/uber/ludwig/blob/ff7159992eb59d5e8cb2bc3b4850d8a10a91f702/ludwig/experiment.py#L571-L572
because `kfold_cv_stats` structure contained `tf.Tensors` created by the output features `predict()` method.

Initially tried to resolve the issue by using output feature's `postprocess_results()` method, which converts the `tf.Tensor` object into numpy arrays.  Given current data structures at that point in processing, the structure for the `metadata` parameter required in `postprocess_results()` does not appear to be addressable.

As a work-around, the `tf.Tensor` objects, which represent predictions from the test data set are removed from `kfold_cv_stats`.  All other performance metrics are still available in `kfold_cv_stats` structure.

I'm still working on this to see what it will take to be able to use `post process_results()` method.  In the meantime, I wanted to provide some visibility in the work.

**Current view of unit tests with the above work-around**
```
=========================================================== test session starts ============================================================
platform linux -- Python 3.6.9, pytest-5.4.3, py-1.8.2, pluggy-0.13.1
rootdir: /opt/project
plugins: pycharm-0.6.0, typeguard-2.9.1
collected 460 items

../../../tests/integration_tests/test_api.py ..                                                                                      [  0%]
../../../tests/integration_tests/test_contrib_comet.py F                                                                             [  0%]
../../../tests/integration_tests/test_contrib_wandb.py .                                                                             [  0%]
../../../tests/integration_tests/test_encoders.py ......                                                                             [  2%]
../../../tests/integration_tests/test_experiment.py ....F........................................................................... [ 19%]
.................................................................................................................................... [ 48%]
..................................................................................................................................F. [ 76%]
.......                                                                                                                              [ 78%]
../../../tests/integration_tests/test_generic_features.py ..                                                                         [ 78%]
../../../tests/integration_tests/test_horovod.py Fs                                                                                  [ 79%]
../../../tests/integration_tests/test_hyperopt.py F                                                                                  [ 79%]
../../../tests/integration_tests/test_kfold_cv.py ...                                                                                [ 80%]
../../../tests/integration_tests/test_model_save_and_load.py .                                                                       [ 80%]
../../../tests/integration_tests/test_model_training_options.py ..FF.............                                                    [ 84%]
../../../tests/integration_tests/test_savedmodel.py F                                                                                [ 84%]
../../../tests/integration_tests/test_server.py F                                                                                    [ 84%]
../../../tests/integration_tests/test_simple_features.py ..........                                                                  [ 86%]
../../../tests/integration_tests/test_visualization.py ..........................                                                    [ 92%]
../../../tests/integration_tests/test_visualization_api.py ......................                                                    [ 97%]
../../../tests/ludwig/models/modules/test_encoder.py FFF.                                                                            [ 98%]
../../../tests/ludwig/utils/test_data_utils.py .                                                                                     [ 98%]
../../../tests/ludwig/utils/test_horovod_utils.py s                                                                                  [ 98%]
../../../tests/ludwig/utils/test_hyperopt_utils.py ....                                                                              [ 99%]
../../../tests/ludwig/utils/test_image_utils.py ..                                                                                   [ 99%]
../../../tests/ludwig/utils/test_normalization.py .                                                                                  [100%]

================================================================= FAILURES =================================================================

========================================================= short test summary info ==========================================================
FAILED ../../../tests/integration_tests/test_contrib_comet.py::test_contrib_experiment - assert 1 == 0
FAILED ../../../tests/integration_tests/test_experiment.py::test_experiment_multiple_seq_seq - tensorflow.python.framework.errors_impl.In...
FAILED ../../../tests/integration_tests/test_experiment.py::test_visual_question_answering - tensorflow.python.framework.errors_impl.Inva...
FAILED ../../../tests/integration_tests/test_horovod.py::test_horovod_implicit - assert 127 == 0
FAILED ../../../tests/integration_tests/test_hyperopt.py::test_hyperopt_executor - AttributeError: 'Model' object has no attribute 'close...
FAILED ../../../tests/integration_tests/test_model_training_options.py::test_model_progress_save[False-False] - AssertionError: assert 2 ...
FAILED ../../../tests/integration_tests/test_model_training_options.py::test_model_progress_save[False-True] - AssertionError: assert 2 == 3
FAILED ../../../tests/integration_tests/test_savedmodel.py::test_savedmodel - AttributeError: 'Model' object has no attribute '_session'
FAILED ../../../tests/integration_tests/test_server.py::test_server_integration - AssertionError: assert ['error'] == ['category_F0..._pr...
FAILED ../../../tests/ludwig/models/modules/test_encoder.py::test_image_encoders_resnet - AttributeError: 'ResNetEncoder' object has no a...
FAILED ../../../tests/ludwig/models/modules/test_encoder.py::test_image_encoders_stacked_2dcnn - assert (2, 2) == 2
FAILED ../../../tests/ludwig/models/modules/test_encoder.py::test_sequence_encoder_embed - AttributeError: 'EmbedSequence' object has no ...
=================================== 12 failed, 446 passed, 2 skipped, 4367 warnings in 901.37s (0:15:01) ===================================

```
