### PR TITLE
TF2 porting: Fix test_model_training_options unit test

### DIFF
--- a/tests/integration_tests/test_model_training_options.py
+++ b/tests/integration_tests/test_model_training_options.py
@@ -153,7 +153,8 @@ def test_model_progress_save(
         model_dir = os.path.join(exp_dir_name, 'model')
         files = [f for f in os.listdir(model_dir) if
                  re.match(r'model_weights', f)]
-        assert len(files) == 3
+        assert len(files) == 2
+        assert os.path.isfile(os.path.join(exp_dir_name, 'model', 'checkpoint'))
 
     if skip_save_progress:
         assert not os.path.isdir(


### PR DESCRIPTION
# Code Pull Requests

Adjusted assertion test to reflect use save_weights generated output files

Test log after the changes:
```
=========================================================== test session starts ============================================================
platform linux -- Python 3.6.9, pytest-5.4.3, py-1.9.0, pluggy-0.13.1
rootdir: /opt/project
plugins: forked-1.2.0, xdist-1.33.0, pycharm-0.6.0, typeguard-2.9.1
collected 17 items

../../../tests/integration_tests/test_model_training_options.py .................                                                    [100%]

============================================================= warnings summary =============================================================
/usr/local/lib/python3.6/dist-packages/tensorflow/python/pywrap_tensorflow_internal.py:15
  /usr/local/lib/python3.6/dist-packages/tensorflow/python/pywrap_tensorflow_internal.py:15: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    import imp

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================================================= 17 passed, 1 warning in 65.38s (0:01:05) =================================================
```