### PR TITLE
TF2 porting: Fix encoder unit tests

### DIFF
--- a/tests/ludwig/models/modules/test_encoder.py
+++ b/tests/ludwig/models/modules/test_encoder.py
@@ -136,13 +136,16 @@ def test_image_encoders_resnet():
     )
 
     assert encoder is not None
-    assert encoder.resnet is not None
-    assert encoder.resnet.kernel_size == 3
-    assert encoder.fc_stack.layers[0]['fc_size'] == 28
-    assert len(encoder.fc_stack.layers) == 1
-    assert encoder.fc_stack.layers[0]['activation'] == 'relu'
-    assert encoder.resnet.num_filters == 8
-    assert encoder.resnet.resnet_size == 8
+    assert encoder.layers is not None
+    assert encoder.layers[0].__class__.__name__ == 'ResNet2'
+    assert encoder.layers[1].__class__.__name__ == 'Flatten'
+    assert encoder.layers[2].__class__.__name__ == 'FCStack'
+    assert encoder.layers[0].filter_size == 3
+    assert encoder.layers[2].layers[0]['fc_size'] == 28
+    assert len(encoder.layers[2].layers) == 1
+    assert encoder.layers[2].layers[0]['activation'] == 'relu'
+    assert encoder.layers[0].num_filters == 8
+    assert encoder.layers[0].resnet_size == 8
 
 
 def test_image_encoders_stacked_2dcnn():
@@ -158,12 +161,12 @@ def test_image_encoders_stacked_2dcnn():
     assert encoder.fc_stack.layers[0]['fc_size'] == 28
     assert len(encoder.fc_stack.layers) == 1
     assert encoder.conv_stack_2d.layers[0]['num_filters'] == 16
-    assert encoder.conv_stack_2d.layers[0]['pool_size'] == 2
-    assert encoder.conv_stack_2d.layers[0]['stride'] == 1
-    assert encoder.conv_stack_2d.layers[0]['pool_stride'] == 2
+    assert encoder.conv_stack_2d.layers[0]['pool_size'] == (2, 2)
+    assert encoder.conv_stack_2d.layers[0]['strides'] == (1, 1)
+    assert encoder.conv_stack_2d.layers[0]['pool_strides'] is None
     assert encoder.conv_stack_2d.layers[0]['norm'] is None
     assert encoder.fc_stack.layers[0]['activation'] == 'relu'
-    assert encoder.conv_stack_2d.layers[-1]['dropout'] is True
+    assert encoder.conv_stack_2d.layers[-1]['dropout_rate'] == 0
 
     output_shape = [1, 28]
     input_image = generate_images(image_size, 1)
@@ -231,7 +234,7 @@ def test_sequence_encoder_embed():
             )
 
             embed = encoder.embed_sequence.embed
-            assert embed.representation == 'dense'
+            #assert embed.representation == 'dense'
             assert embed.embeddings_trainable == trainable
             assert embed.regularize is True
             assert embed.dropout is False

--- a/tests/ludwig/models/modules/test_encoder.py
+++ b/tests/ludwig/models/modules/test_encoder.py
@@ -233,11 +233,11 @@ def test_sequence_encoder_embed():
                 output_data=None
             )
 
-            embed = encoder.embed_sequence.embed
+            embed = encoder.embed_sequence.embeddings
             #assert embed.representation == 'dense'
-            assert embed.embeddings_trainable == trainable
-            assert embed.regularize is True
-            assert embed.dropout is False
+            assert embed.trainable == trainable
+            # assert embed.regularize is True
+            assert encoder.embed_sequence.dropout is None
 
 
 def test_sequence_encoders():

--- a/tests/ludwig/models/modules/test_encoder.py
+++ b/tests/ludwig/models/modules/test_encoder.py
@@ -291,3 +291,5 @@ def test_sequence_encoders():
                     output_shape=output_shape,
                     output_data=None
                 )
+
+                assert isinstance(encoder, encoder_type)


### PR DESCRIPTION
# Code Pull Requests

Updated unit tests to reflect encoder implementation changes in encoders for TF2 port.

@w4nderlust   For the most part, I was able to rewrite the `assert` tests to reflect the TF2 encoder changes.  For the `test_sequence_encoder_embed` unit test I was able to only convert about half the `assert` tests.  For the `assert`  I could not convert, they are commented out. For example one test was looking for the `representation` attribute.  In TF1, an `self.reprsentation` attribute existed.  From what I can tell, this attribute is no longer saved but is only used to derive the type of embedding matrix to create.  This particular test may no longer apply. 

Anyway, I'm interested in your perspective on this point.

With the changes in the PR, all the tests now pass
```
pytest -v /opt/project/tests/ludwig/models/modules/test_encoder.py
=========================================================== test session starts ============================================================
platform linux -- Python 3.6.9, pytest-5.4.3, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /opt/project
plugins: forked-1.2.0, xdist-1.33.0, pycharm-0.6.0, typeguard-2.9.1
collected 4 items

../../../tests/ludwig/models/modules/test_encoder.py::test_image_encoders_resnet PASSED                                              [ 25%]
../../../tests/ludwig/models/modules/test_encoder.py::test_image_encoders_stacked_2dcnn PASSED                                       [ 50%]
../../../tests/ludwig/models/modules/test_encoder.py::test_sequence_encoder_embed PASSED                                             [ 75%]
../../../tests/ludwig/models/modules/test_encoder.py::test_sequence_encoders PASSED                                                  [100%]

============================================================= warnings summary =============================================================
/usr/local/lib/python3.6/dist-packages/tensorflow/python/pywrap_tensorflow_internal.py:15
  /usr/local/lib/python3.6/dist-packages/tensorflow/python/pywrap_tensorflow_internal.py:15: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    import imp

-- Docs: https://docs.pytest.org/en/latest/warnings.html
======================================================= 4 passed, 1 warning in 3.05s =====================================================
```
