### PR TITLE
Refactored feature classes to use cooperative multiple inheritance

### DIFF
--- a/ludwig/features/audio_feature.py
+++ b/ludwig/features/audio_feature.py
@@ -54,8 +54,8 @@ class AudioBaseFeature(BaseFeature):
         }
     }
 
-    def __init__(self, feature):
-        super().__init__(feature)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters):
@@ -351,8 +351,7 @@ class AudioInputFeature(AudioBaseFeature, SequenceInputFeature):
     encoder = 'embed'
 
     def __init__(self, feature, encoder_obj=None):
-        AudioBaseFeature.__init__(self, feature)
-        SequenceInputFeature.__init__(self, feature)
+        super().__init__(feature)
         self.length = None
         self.embedding_size = None
         self.overwrite_defaults(feature)

--- a/ludwig/features/bag_feature.py
+++ b/ludwig/features/bag_feature.py
@@ -42,8 +42,8 @@ class BagBaseFeature(BaseFeature):
         'fill_value': UNKNOWN_SYMBOL
     }
 
-    def __init__(self, feature):
-        super().__init__(feature)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters):
@@ -100,9 +100,6 @@ class BagInputFeature(BagBaseFeature, InputFeature):
 
     def __init__(self, feature, encoder_obj=None):
         super().__init__(feature)
-
-        BagBaseFeature.__init__(self, feature)
-        InputFeature.__init__(self)
         self.overwrite_defaults(feature)
         if encoder_obj:
             self.encoder_obj = encoder_obj

--- a/ludwig/features/base_feature.py
+++ b/ludwig/features/base_feature.py
@@ -27,8 +27,14 @@ from ludwig.utils.tf_utils import sequence_length_3D
 
 logger = logging.getLogger(__name__)
 
-class BaseFeature:
-    def __init__(self, feature):
+
+class BaseFeature(object):
+    """Base class for all features.
+
+    Note that this class follows cooperative multiple-inheritance best practices.
+    """
+    def __init__(self, feature, *args, **kwargs):
+        super().__init__(*args, feature=feature, **kwargs)
         if 'name' not in feature:
             raise ValueError('Missing feature name')
 
@@ -49,7 +55,14 @@ class BaseFeature:
                     setattr(self, k, feature[k])
 
 
-class InputFeature(ABC, tf.keras.Model):
+class InputFeature(tf.keras.Model, ABC):
+    """Mixin for input features.
+
+    Note that this class is not cooperative (does not forward kwargs), and as such must be placed
+    at the end of the class list.
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__()
 
     @staticmethod
     @abstractmethod
@@ -77,11 +90,14 @@ class InputFeature(ABC, tf.keras.Model):
         )
 
 
-class OutputFeature(ABC, BaseFeature, tf.keras.Model):
+class OutputFeature(tf.keras.Model, ABC):
+    """Mixin for output features.
 
-    def __init__(self, feature):
-        BaseFeature.__init__(self, feature)
-        tf.keras.Model.__init__(self)
+    Note that this class is not cooperative (does not forward kwargs), and as such must be placed
+    at the end of the class list.
+    """
+    def __init__(self, feature, *args, **kwargs):
+        super().__init__()
 
         self.loss = None
         self.train_loss_function = None

--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -50,8 +50,8 @@ class BinaryBaseFeature(BaseFeature):
         'fill_value': 0
     }
 
-    def __init__(self, feature):
-        super().__init__(feature)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters):
@@ -77,8 +77,7 @@ class BinaryInputFeature(BinaryBaseFeature, InputFeature):
     dropout = False
 
     def __init__(self, feature, encoder_obj=None):
-        BinaryBaseFeature.__init__(self, feature)
-        InputFeature.__init__(self)
+        super().__init__(feature)
         self.overwrite_defaults(feature)
         if encoder_obj:
             self.encoder_obj = encoder_obj
@@ -132,8 +131,7 @@ class BinaryOutputFeature(BinaryBaseFeature, OutputFeature):
     threshold = 0.5
 
     def __init__(self, feature):
-        BinaryBaseFeature.__init__(self, feature)
-        OutputFeature.__init__(self, feature)
+        super().__init__(feature)
         self.overwrite_defaults(feature)
         self.decoder_obj = self.initialize_decoder(feature)
         self._setup_loss()

--- a/ludwig/features/category_feature.py
+++ b/ludwig/features/category_feature.py
@@ -54,8 +54,8 @@ class CategoryBaseFeature(BaseFeature):
         'fill_value': UNKNOWN_SYMBOL
     }
 
-    def __init__(self, feature):
-        super().__init__(feature)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters):
@@ -103,8 +103,7 @@ class CategoryInputFeature(CategoryBaseFeature, InputFeature):
     encoder = 'dense'
 
     def __init__(self, feature, encoder_obj=None):
-        CategoryBaseFeature.__init__(self, feature)
-        InputFeature.__init__(self)
+        super().__init__(feature)
         self.overwrite_defaults(feature)
         if encoder_obj:
             self.encoder_obj = encoder_obj
@@ -156,8 +155,7 @@ class CategoryOutputFeature(CategoryBaseFeature, OutputFeature):
     top_k = 3
 
     def __init__(self, feature):
-        CategoryBaseFeature.__init__(self, feature)
-        OutputFeature.__init__(self, feature)
+        super().__init__(feature)
         self.overwrite_defaults(feature)
         self.decoder_obj = self.initialize_decoder(feature)
         self._setup_loss()

--- a/ludwig/features/date_feature.py
+++ b/ludwig/features/date_feature.py
@@ -41,8 +41,8 @@ class DateBaseFeature(BaseFeature):
         'datetime_format': None
     }
 
-    def __init__(self, feature):
-        super().__init__(feature)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters):
@@ -118,8 +118,7 @@ class DateInputFeature(DateBaseFeature, InputFeature):
     encoder = 'embed'
 
     def __init__(self, feature, encoder_obj=None):
-        DateBaseFeature.__init__(self, feature)
-        InputFeature.__init__(self)
+        super().__init__(feature)
 
         self.overwrite_defaults(feature)
         if encoder_obj:

--- a/ludwig/features/h3_feature.py
+++ b/ludwig/features/h3_feature.py
@@ -41,8 +41,8 @@ class H3BaseFeature(BaseFeature):
         # mode 1 edge 0 resolution 0 base_cell 0
     }
 
-    def __init__(self, feature):
-        super().__init__(feature)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters):
@@ -81,8 +81,7 @@ class H3InputFeature(H3BaseFeature, InputFeature):
     encoder = 'embed'
 
     def __init__(self, feature, encoder_obj=None):
-        H3BaseFeature.__init__(self, feature)
-        InputFeature.__init__(self)
+        super().__init__(feature)
 
         self.overwrite_defaults(feature)
         if encoder_obj:

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -49,8 +49,8 @@ class ImageBaseFeature(BaseFeature):
         'num_processes': 1
     }
 
-    def __init__(self, feature):
-        super().__init__(feature)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters):
@@ -351,8 +351,7 @@ class ImageInputFeature(ImageBaseFeature, InputFeature):
     encoder = 'stacked_cnn'
 
     def __init__(self, feature, encoder_obj=None):
-        ImageBaseFeature.__init__(self, feature)
-        InputFeature.__init__(self)
+        super().__init__(feature)
         self.overwrite_defaults(feature)
         if encoder_obj:
             self.encoder_obj = encoder_obj

--- a/ludwig/features/numerical_feature.py
+++ b/ludwig/features/numerical_feature.py
@@ -91,8 +91,8 @@ class NumericalBaseFeature(BaseFeature):
         'normalization': None
     }
 
-    def __init__(self, feature):
-        super().__init__(feature)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters):
@@ -143,8 +143,7 @@ class NumericalInputFeature(NumericalBaseFeature, InputFeature):
     encoder = 'passthrough'
 
     def __init__(self, feature, encoder_obj=None):
-        NumericalBaseFeature.__init__(self, feature)
-        InputFeature.__init__(self)
+        super().__init__(feature)
         self.overwrite_defaults(feature)
         if encoder_obj:
             self.encoder_obj = encoder_obj
@@ -192,8 +191,7 @@ class NumericalOutputFeature(NumericalBaseFeature, OutputFeature):
     clip = None
 
     def __init__(self, feature):
-        NumericalBaseFeature.__init__(self, feature)
-        OutputFeature.__init__(self, feature)
+        super().__init__(feature)
         self.overwrite_defaults(feature)
         self.decoder_obj = self.initialize_decoder(feature)
         self._setup_loss()

--- a/ludwig/features/sequence_feature.py
+++ b/ludwig/features/sequence_feature.py
@@ -69,8 +69,8 @@ class SequenceBaseFeature(BaseFeature):
         'fill_value': UNKNOWN_SYMBOL
     }
 
-    def __init__(self, feature):
-        super().__init__(feature)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters):
@@ -129,8 +129,7 @@ class SequenceInputFeature(SequenceBaseFeature, InputFeature):
     encoder = 'embed'
 
     def __init__(self, feature, encoder_obj=None):
-        SequenceBaseFeature.__init__(self, feature)
-        InputFeature.__init__(self)
+        super().__init__(feature)
         self.overwrite_defaults(feature)
         if encoder_obj:
             self.encoder_obj = encoder_obj

--- a/ludwig/features/set_feature.py
+++ b/ludwig/features/set_feature.py
@@ -47,8 +47,8 @@ class SetBaseFeature(BaseFeature):
         'fill_value': UNKNOWN_SYMBOL
     }
 
-    def __init__(self, feature):
-        super().__init__(feature)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters):
@@ -152,8 +152,7 @@ class SetOutputFeature(SetBaseFeature, OutputFeature):
     loss = {TYPE: SIGMOID_CROSS_ENTROPY}
 
     def __init__(self, feature):
-        SetBaseFeature.__init__(self, feature)
-        OutputFeature.__init__(self, feature)
+        super().__init__(feature)
 
         self.num_classes = 0
         self.threshold = 0.5

--- a/ludwig/features/text_feature.py
+++ b/ludwig/features/text_feature.py
@@ -57,8 +57,8 @@ class TextBaseFeature(BaseFeature):
         'fill_value': UNKNOWN_SYMBOL
     }
 
-    def __init__(self, feature):
-        super().__init__(feature)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     @staticmethod
     def feature_meta(column, preprocessing_parameters):
@@ -189,8 +189,7 @@ class TextInputFeature(TextBaseFeature, SequenceInputFeature):
     length = 0
 
     def __init__(self, feature, encoder_obj=None):
-        TextBaseFeature.__init__(self, feature)
-        SequenceInputFeature.__init__(self, feature)
+        super().__init__(feature)
 
         self.overwrite_defaults(feature)
         if encoder_obj:
@@ -250,8 +249,7 @@ class TextOutputFeature(TextBaseFeature, SequenceOutputFeature):
     num_classes = 0
 
     def __init__(self, feature, decoder_obj=None):
-        TextBaseFeature.__init__(self, feature)
-        SequenceOutputFeature.__init__(self, feature)
+        super().__init__(feature)
         self.overwrite_defaults(feature)
         if decoder_obj:
             self.encoder_obj = decoder_obj

--- a/ludwig/features/timeseries_feature.py
+++ b/ludwig/features/timeseries_feature.py
@@ -40,8 +40,8 @@ class TimeseriesBaseFeature(BaseFeature):
         'fill_value': ''
     }
 
-    def __init__(self, feature):
-        super().__init__(feature)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters):
@@ -133,8 +133,7 @@ class TimeseriesInputFeature(TimeseriesBaseFeature, SequenceInputFeature):
     length = 0
 
     def __init__(self, feature, encoder_obj=None):
-        TimeseriesBaseFeature.__init__(self, feature)
-        SequenceInputFeature.__init__(self, feature)
+        super().__init__(feature)
 
         self.overwrite_defaults(feature)
         if encoder_obj:

--- a/ludwig/features/vector_feature.py
+++ b/ludwig/features/vector_feature.py
@@ -93,8 +93,8 @@ class VectorBaseFeature(BaseFeature):
         'fill_value': ""
     }
 
-    def __init__(self, feature):
-        super().__init__(feature)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters):
@@ -150,8 +150,7 @@ class VectorInputFeature(VectorBaseFeature, InputFeature):
     encoder = 'dense'
 
     def __init__(self, feature, encoder_obj=None):
-        VectorBaseFeature.__init__(self, feature)
-        InputFeature.__init__(self)
+        super.__init__(feature)
         self.overwrite_defaults(feature)
         if encoder_obj:
             self.encoder_obj = encoder_obj
@@ -200,8 +199,7 @@ class VectorOutputFeature(VectorBaseFeature, OutputFeature):
     vector_size = 0
 
     def __init__(self, feature):
-        VectorBaseFeature.__init__(self, feature)
-        OutputFeature.__init__(self, feature)
+        super().__init__(feature)
         self.overwrite_defaults(feature)
         self.decoder_obj = self.initialize_decoder(feature)
         self._setup_loss()


### PR DESCRIPTION
The purpose of this PR is to simplify the class hierarchy for features so that constructors will properly forward their args and kwargs through the chain and that each constructor is called exactly once, without needing to explicitly call each constructor individually (using `super().__init__()` instead).

The changes made to accomplish this include:

1. Made `InputFeature` and `OutputFeature` mixins as opposed to proper subclasses of `BaseFeature`.  This helps ensure that `BaseFeature` (which is cooperative) will be constructed before `InputFeature` and `OutputFeature` (which inherit from `tf.keras.Model`, which is not cooperative).
2. Replaced all explicit constructor calls with `super().__init__()` to make the hierarchy extensible and prevent constructors being called multiple times.
3. Changed `BaseFeature` to cooperatively forward `feature` and all other args/kwargs cooperatively so both `InputFeature` and `OutputFeature` can handle these parameters appropriately.

Note that going forward, all we need to do for this to continue to work is ensure that `InputFeature` and `OutputFeature` are the last classes declared in the superclass list, which ensures they fall last in the method resolution order (MRO).