### PR TITLE
Replaced multiple inheritance in feature class hierarchy with mixins

### DIFF
--- a/ludwig/features/bag_feature.py
+++ b/ludwig/features/bag_feature.py
@@ -21,7 +21,6 @@ import numpy as np
 import tensorflow as tf
 
 from ludwig.constants import *
-from ludwig.features.base_feature import BaseFeature
 from ludwig.features.base_feature import InputFeature
 from ludwig.features.feature_utils import set_str_to_idx
 from ludwig.models.modules.bag_encoders import BagEmbedWeightedEncoder
@@ -31,7 +30,7 @@ from ludwig.utils.strings_utils import create_vocabulary, UNKNOWN_SYMBOL
 logger = logging.getLogger(__name__)
 
 
-class BagBaseFeature(BaseFeature):
+class BagFeatureMixin(object):
     type = BAG
 
     preprocessing_defaults = {
@@ -41,9 +40,6 @@ class BagBaseFeature(BaseFeature):
         'missing_value_strategy': FILL_WITH_CONST,
         'fill_value': UNKNOWN_SYMBOL
     }
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters):
@@ -88,14 +84,14 @@ class BagBaseFeature(BaseFeature):
             metadata,
             preprocessing_parameters=None
     ):
-        data[feature['name']] = BagBaseFeature.feature_data(
+        data[feature['name']] = BagFeatureMixin.feature_data(
             dataset_df[feature['name']].astype(str),
             metadata[feature['name']],
             preprocessing_parameters
         )
 
 
-class BagInputFeature(BagBaseFeature, InputFeature):
+class BagInputFeature(BagFeatureMixin, InputFeature):
     encoder = 'embed'
 
     def __init__(self, feature, encoder_obj=None):

--- a/ludwig/features/base_feature.py
+++ b/ludwig/features/base_feature.py
@@ -31,10 +31,14 @@ logger = logging.getLogger(__name__)
 class BaseFeature(object):
     """Base class for all features.
 
-    Note that this class follows cooperative multiple-inheritance best practices.
+    Note that this class is not-cooperative (does not forward kwargs), so when constructing
+    feature class hierarchies, there should be only one parent class that derives from base
+    feature.  Other functionality should be put into mixin classes to avoid the diamond
+    pattern.
     """
     def __init__(self, feature, *args, **kwargs):
-        super().__init__(*args, feature=feature, **kwargs)
+        super().__init__()
+
         if 'name' not in feature:
             raise ValueError('Missing feature name')
 
@@ -55,14 +59,10 @@ class BaseFeature(object):
                     setattr(self, k, feature[k])
 
 
-class InputFeature(tf.keras.Model, ABC):
-    """Mixin for input features.
-
-    Note that this class is not cooperative (does not forward kwargs), and as such must be placed
-    at the end of the class list.
-    """
+class InputFeature(BaseFeature, tf.keras.Model, ABC):
+    """Parent class for all input features."""
     def __init__(self, *args, **kwargs):
-        super().__init__()
+        super().__init__(*args, **kwargs)
 
     @staticmethod
     @abstractmethod
@@ -90,14 +90,10 @@ class InputFeature(tf.keras.Model, ABC):
         )
 
 
-class OutputFeature(tf.keras.Model, ABC):
-    """Mixin for output features.
-
-    Note that this class is not cooperative (does not forward kwargs), and as such must be placed
-    at the end of the class list.
-    """
+class OutputFeature(BaseFeature, tf.keras.Model, ABC):
+    """Parent class for all output features."""
     def __init__(self, feature, *args, **kwargs):
-        super().__init__()
+        super().__init__(*args, feature=feature, **kwargs)
 
         self.loss = None
         self.train_loss_function = None

--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -22,7 +22,6 @@ import tensorflow as tf
 from tensorflow.keras.metrics import Accuracy as BinaryAccuracy
 
 from ludwig.constants import *
-from ludwig.features.base_feature import BaseFeature
 from ludwig.features.base_feature import InputFeature
 from ludwig.features.base_feature import OutputFeature
 from ludwig.globals import is_on_master
@@ -43,15 +42,12 @@ from ludwig.utils.strings_utils import str2bool
 logger = logging.getLogger(__name__)
 
 
-class BinaryBaseFeature(BaseFeature):
+class BinaryFeatureMixin(object):
     type = BINARY
     preprocessing_defaults = {
         'missing_value_strategy': FILL_WITH_CONST,
         'fill_value': 0
     }
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters):
@@ -71,7 +67,7 @@ class BinaryBaseFeature(BaseFeature):
         data[feature['name']] = column.astype(np.bool_).values
 
 
-class BinaryInputFeature(BinaryBaseFeature, InputFeature):
+class BinaryInputFeature(BinaryFeatureMixin, InputFeature):
     encoder = 'passthrough'
     norm = None
     dropout = False
@@ -120,7 +116,7 @@ class BinaryInputFeature(BinaryBaseFeature, InputFeature):
     }
 
 
-class BinaryOutputFeature(BinaryBaseFeature, OutputFeature):
+class BinaryOutputFeature(BinaryFeatureMixin, OutputFeature):
     decoder = 'regressor'
     loss = {
         'robust_lambda': 0,

--- a/ludwig/features/category_feature.py
+++ b/ludwig/features/category_feature.py
@@ -21,7 +21,6 @@ import numpy as np
 import tensorflow as tf
 
 from ludwig.constants import *
-from ludwig.features.base_feature import BaseFeature
 from ludwig.features.base_feature import InputFeature
 from ludwig.features.base_feature import OutputFeature
 from ludwig.globals import is_on_master
@@ -45,7 +44,7 @@ from ludwig.utils.strings_utils import create_vocabulary
 logger = logging.getLogger(__name__)
 
 
-class CategoryBaseFeature(BaseFeature):
+class CategoryFeatureMixin(object):
     type = CATEGORY
     preprocessing_defaults = {
         'most_common': 10000,
@@ -53,9 +52,6 @@ class CategoryBaseFeature(BaseFeature):
         'missing_value_strategy': FILL_WITH_CONST,
         'fill_value': UNKNOWN_SYMBOL
     }
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters):
@@ -93,13 +89,13 @@ class CategoryBaseFeature(BaseFeature):
             metadata,
             preprocessing_parameters=None
     ):
-        data[feature['name']] = CategoryBaseFeature.feature_data(
+        data[feature['name']] = CategoryFeatureMixin.feature_data(
             dataset_df[feature['name']].astype(str),
             metadata[feature['name']]
         )
 
 
-class CategoryInputFeature(CategoryBaseFeature, InputFeature):
+class CategoryInputFeature(CategoryFeatureMixin, InputFeature):
     encoder = 'dense'
 
     def __init__(self, feature, encoder_obj=None):
@@ -148,7 +144,7 @@ class CategoryInputFeature(CategoryBaseFeature, InputFeature):
     }
 
 
-class CategoryOutputFeature(CategoryBaseFeature, OutputFeature):
+class CategoryOutputFeature(CategoryFeatureMixin, OutputFeature):
     decoder = 'classifier'
     num_classes = 0
     loss = {TYPE: SOFTMAX_CROSS_ENTROPY}

--- a/ludwig/features/date_feature.py
+++ b/ludwig/features/date_feature.py
@@ -23,7 +23,6 @@ import tensorflow as tf
 from dateutil.parser import parse
 
 from ludwig.constants import *
-from ludwig.features.base_feature import BaseFeature
 from ludwig.features.base_feature import InputFeature
 from ludwig.models.modules.date_encoders import DateEmbed, DateWave
 from ludwig.utils.misc import set_default_value
@@ -33,16 +32,13 @@ logger = logging.getLogger(__name__)
 DATE_VECTOR_LENGTH = 9
 
 
-class DateBaseFeature(BaseFeature):
+class DateFeatureMixin(object):
     type = DATE
     preprocessing_defaults = {
         'missing_value_strategy': FILL_WITH_CONST,
         'fill_value': '',
         'datetime_format': None
     }
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters):
@@ -106,7 +102,7 @@ class DateBaseFeature(BaseFeature):
     ):
         datetime_format = preprocessing_parameters['datetime_format']
         dates_to_lists = [
-            np.array(DateBaseFeature.date_to_list(
+            np.array(DateFeatureMixin.date_to_list(
                 row, datetime_format, preprocessing_parameters
             ))
             for row in dataset_df[feature['name']]
@@ -114,7 +110,7 @@ class DateBaseFeature(BaseFeature):
         data[feature['name']] = np.array(dates_to_lists, dtype=np.int16)
 
 
-class DateInputFeature(DateBaseFeature, InputFeature):
+class DateInputFeature(DateFeatureMixin, InputFeature):
     encoder = 'embed'
 
     def __init__(self, feature, encoder_obj=None):

--- a/ludwig/features/feature_registries.py
+++ b/ludwig/features/feature_registries.py
@@ -13,65 +13,36 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from ludwig.constants import BAG
-from ludwig.constants import BINARY
-from ludwig.constants import CATEGORY
-from ludwig.constants import DATE
-from ludwig.constants import H3
-from ludwig.constants import IMAGE
-from ludwig.constants import NUMERICAL
-from ludwig.constants import SEQUENCE
-from ludwig.constants import SET
-from ludwig.constants import TEXT
-from ludwig.constants import TIMESERIES
-from ludwig.constants import VECTOR
-from ludwig.features.bag_feature import BagBaseFeature
-from ludwig.constants import AUDIO
-from ludwig.features.bag_feature import BagInputFeature
-from ludwig.features.binary_feature import BinaryBaseFeature
-from ludwig.features.binary_feature import BinaryInputFeature
-from ludwig.features.binary_feature import BinaryOutputFeature
-from ludwig.features.category_feature import CategoryBaseFeature
-from ludwig.features.category_feature import CategoryInputFeature
-from ludwig.features.category_feature import CategoryOutputFeature
-from ludwig.features.date_feature import DateBaseFeature, DateInputFeature
-from ludwig.features.h3_feature import H3BaseFeature, H3InputFeature
-from ludwig.features.image_feature import ImageBaseFeature
-from ludwig.features.image_feature import ImageInputFeature
-from ludwig.features.numerical_feature import NumericalBaseFeature
-from ludwig.features.audio_feature import AudioBaseFeature
-from ludwig.features.audio_feature import AudioInputFeature
-from ludwig.features.numerical_feature import NumericalInputFeature
-from ludwig.features.numerical_feature import NumericalOutputFeature
-from ludwig.features.sequence_feature import SequenceBaseFeature
-from ludwig.features.sequence_feature import SequenceInputFeature
-from ludwig.features.sequence_feature import SequenceOutputFeature
-from ludwig.features.set_feature import SetBaseFeature
-from ludwig.features.set_feature import SetInputFeature
-from ludwig.features.set_feature import SetOutputFeature
-from ludwig.features.text_feature import TextBaseFeature
-from ludwig.features.text_feature import TextInputFeature
-from ludwig.features.text_feature import TextOutputFeature
-from ludwig.features.timeseries_feature import TimeseriesBaseFeature
-from ludwig.features.timeseries_feature import TimeseriesInputFeature
-from ludwig.features.vector_feature import VectorBaseFeature
-from ludwig.features.vector_feature import VectorInputFeature
-from ludwig.features.vector_feature import VectorOutputFeature
+from ludwig.constants import BAG, BINARY, CATEGORY, DATE, H3, IMAGE, NUMERICAL, \
+    SEQUENCE, SET, TEXT, TIMESERIES, VECTOR, AUDIO
+from ludwig.features.bag_feature import BagFeatureMixin, BagInputFeature
+from ludwig.features.binary_feature import BinaryFeatureMixin, BinaryInputFeature, BinaryOutputFeature
+from ludwig.features.category_feature import CategoryFeatureMixin, CategoryInputFeature, CategoryOutputFeature
+from ludwig.features.date_feature import DateFeatureMixin, DateInputFeature
+from ludwig.features.h3_feature import H3FeatureMixin, H3InputFeature
+from ludwig.features.image_feature import ImageFeatureMixin, ImageInputFeature
+from ludwig.features.numerical_feature import NumericalFeatureMixin, NumericalInputFeature, NumericalOutputFeature
+from ludwig.features.audio_feature import AudioFeatureMixin, AudioInputFeature
+from ludwig.features.sequence_feature import SequenceFeatureMixin, SequenceInputFeature, SequenceOutputFeature
+from ludwig.features.set_feature import SetFeatureMixin, SetInputFeature, SetOutputFeature
+from ludwig.features.text_feature import TextFeatureMixin, TextInputFeature, TextOutputFeature
+from ludwig.features.timeseries_feature import TimeseriesFeatureMixin, TimeseriesInputFeature
+from ludwig.features.vector_feature import VectorFeatureMixin, VectorInputFeature, VectorOutputFeature
 
 base_type_registry = {
-    TEXT: TextBaseFeature,
-    CATEGORY: CategoryBaseFeature,
-    SET: SetBaseFeature,
-    BAG: BagBaseFeature,
-    BINARY: BinaryBaseFeature,
-    NUMERICAL: NumericalBaseFeature,
-    SEQUENCE: SequenceBaseFeature,
-    TIMESERIES: TimeseriesBaseFeature,
-    IMAGE: ImageBaseFeature,
-    AUDIO: AudioBaseFeature,
-    H3: H3BaseFeature,
-    DATE: DateBaseFeature,
-    VECTOR: VectorBaseFeature
+    TEXT: TextFeatureMixin,
+    CATEGORY: CategoryFeatureMixin,
+    SET: SetFeatureMixin,
+    BAG: BagFeatureMixin,
+    BINARY: BinaryFeatureMixin,
+    NUMERICAL: NumericalFeatureMixin,
+    SEQUENCE: SequenceFeatureMixin,
+    TIMESERIES: TimeseriesFeatureMixin,
+    IMAGE: ImageFeatureMixin,
+    AUDIO: AudioFeatureMixin,
+    H3: H3FeatureMixin,
+    DATE: DateFeatureMixin,
+    VECTOR: VectorFeatureMixin
 }
 input_type_registry = {
     TEXT: TextInputFeature,

--- a/ludwig/features/h3_feature.py
+++ b/ludwig/features/h3_feature.py
@@ -20,7 +20,6 @@ import numpy as np
 import tensorflow as tf
 
 from ludwig.constants import *
-from ludwig.features.base_feature import BaseFeature
 from ludwig.features.base_feature import InputFeature
 from ludwig.models.modules.h3_encoders import H3WeightedSum, H3RNN, H3Embed
 from ludwig.utils.h3_util import h3_to_components
@@ -33,16 +32,13 @@ H3_VECTOR_LENGTH = MAX_H3_RESOLUTION + 4
 H3_PADDING_VALUE = 7
 
 
-class H3BaseFeature(BaseFeature):
+class H3FeatureMixin(object):
     type = H3
     preprocessing_defaults = {
         'missing_value_strategy': FILL_WITH_CONST,
         'fill_value': 576495936675512319
         # mode 1 edge 0 resolution 0 base_cell 0
     }
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters):
@@ -73,11 +69,11 @@ class H3BaseFeature(BaseFeature):
         column = dataset_df[feature['name']]
         if column.dtype == object:
             column = column.map(int)
-        column = column.map(H3BaseFeature.h3_to_list)
+        column = column.map(H3FeatureMixin.h3_to_list)
         data[feature['name']] = np.array(column.tolist(), dtype=np.uint8)
 
 
-class H3InputFeature(H3BaseFeature, InputFeature):
+class H3InputFeature(H3FeatureMixin, InputFeature):
     encoder = 'embed'
 
     def __init__(self, feature, encoder_obj=None):

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -25,7 +25,6 @@ import numpy as np
 import tensorflow as tf
 
 from ludwig.constants import *
-from ludwig.features.base_feature import BaseFeature
 from ludwig.features.base_feature import InputFeature
 from ludwig.models.modules.image_encoders import ResNetEncoder
 from ludwig.models.modules.image_encoders import Stacked2DCNN
@@ -39,7 +38,7 @@ from ludwig.utils.misc import set_default_value
 logger = logging.getLogger(__name__)
 
 
-class ImageBaseFeature(BaseFeature):
+class ImageFeatureMixin(object):
     type = IMAGE
     preprocessing_defaults = {
         'missing_value_strategy': BACKFILL,
@@ -48,9 +47,6 @@ class ImageBaseFeature(BaseFeature):
         'scaling': 'pixel_normalization',
         'num_processes': 1
     }
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters):
@@ -269,7 +265,7 @@ class ImageBaseFeature(BaseFeature):
             num_channels,
             user_specified_num_channels,
             first_image
-        ) = ImageBaseFeature._finalize_preprocessing_parameters(
+        ) = ImageFeatureMixin._finalize_preprocessing_parameters(
             preprocessing_parameters, first_path
         )
 
@@ -279,7 +275,7 @@ class ImageBaseFeature(BaseFeature):
             'num_channels'] = num_channels
 
         read_image_and_resize = partial(
-            ImageBaseFeature._read_image_and_resize,
+            ImageFeatureMixin._read_image_and_resize,
             img_width=width,
             img_height=height,
             should_resize=should_resize,
@@ -343,7 +339,7 @@ class ImageBaseFeature(BaseFeature):
             data[feature['name']] = np.arange(num_images)
 
 
-class ImageInputFeature(ImageBaseFeature, InputFeature):
+class ImageInputFeature(ImageFeatureMixin, InputFeature):
     height = 0
     width = 0
     num_channels = 0

--- a/ludwig/features/numerical_feature.py
+++ b/ludwig/features/numerical_feature.py
@@ -26,7 +26,6 @@ from tensorflow.keras.metrics import \
 from tensorflow.keras.metrics import MeanSquaredError as MeanSquaredErrorMetric
 
 from ludwig.constants import *
-from ludwig.features.base_feature import BaseFeature
 from ludwig.features.base_feature import InputFeature
 from ludwig.features.base_feature import OutputFeature
 from ludwig.globals import is_on_master
@@ -83,16 +82,13 @@ class MAEMetric(MeanAbsoluteErrorMetric):
         )
 
 
-class NumericalBaseFeature(BaseFeature):
+class NumericalFeatureMixin(object):
     type = NUMERICAL
     preprocessing_defaults = {
         'missing_value_strategy': FILL_WITH_CONST,
         'fill_value': 0,
         'normalization': None
     }
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters):
@@ -139,7 +135,7 @@ class NumericalBaseFeature(BaseFeature):
                 data[feature['name']] = (values - min_) / (max_ - min_)
 
 
-class NumericalInputFeature(NumericalBaseFeature, InputFeature):
+class NumericalInputFeature(NumericalFeatureMixin, InputFeature):
     encoder = 'passthrough'
 
     def __init__(self, feature, encoder_obj=None):
@@ -185,7 +181,7 @@ class NumericalInputFeature(NumericalBaseFeature, InputFeature):
     }
 
 
-class NumericalOutputFeature(NumericalBaseFeature, OutputFeature):
+class NumericalOutputFeature(NumericalFeatureMixin, OutputFeature):
     decoder = 'regressor'
     loss = {TYPE: MEAN_SQUARED_ERROR}
     clip = None

--- a/ludwig/features/sequence_feature.py
+++ b/ludwig/features/sequence_feature.py
@@ -21,7 +21,6 @@ import numpy as np
 import tensorflow as tf
 
 from ludwig.constants import *
-from ludwig.features.base_feature import BaseFeature
 from ludwig.features.base_feature import InputFeature
 from ludwig.features.base_feature import OutputFeature
 from ludwig.globals import is_on_master
@@ -53,7 +52,7 @@ from ludwig.utils.strings_utils import create_vocabulary
 logger = logging.getLogger(__name__)
 
 
-class SequenceBaseFeature(BaseFeature):
+class SequenceFeatureMixin(object):
     type = SEQUENCE
 
     preprocessing_defaults = {
@@ -68,9 +67,6 @@ class SequenceBaseFeature(BaseFeature):
         'missing_value_strategy': FILL_WITH_CONST,
         'fill_value': UNKNOWN_SYMBOL
     }
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters):
@@ -125,7 +121,7 @@ class SequenceBaseFeature(BaseFeature):
         data[feature['name']] = sequence_data
 
 
-class SequenceInputFeature(SequenceBaseFeature, InputFeature):
+class SequenceInputFeature(SequenceFeatureMixin, InputFeature):
     encoder = 'embed'
 
     def __init__(self, feature, encoder_obj=None):
@@ -181,7 +177,7 @@ class SequenceInputFeature(SequenceBaseFeature, InputFeature):
     }
 
 
-class SequenceOutputFeature(SequenceBaseFeature, OutputFeature):
+class SequenceOutputFeature(SequenceFeatureMixin, OutputFeature):
     decoder = 'tagger'
     loss = {TYPE: SOFTMAX_CROSS_ENTROPY}
 

--- a/ludwig/features/set_feature.py
+++ b/ludwig/features/set_feature.py
@@ -22,7 +22,6 @@ import tensorflow as tf
 from tensorflow.keras.metrics import MeanIoU
 
 from ludwig.constants import *
-from ludwig.features.base_feature import BaseFeature
 from ludwig.features.base_feature import InputFeature
 from ludwig.features.base_feature import OutputFeature
 from ludwig.features.feature_utils import set_str_to_idx
@@ -37,7 +36,7 @@ from ludwig.utils.strings_utils import create_vocabulary, UNKNOWN_SYMBOL
 logger = logging.getLogger(__name__)
 
 
-class SetBaseFeature(BaseFeature):
+class SetFeatureMixin(object):
     type = SET
     preprocessing_defaults = {
         'tokenizer': 'space',
@@ -46,9 +45,6 @@ class SetBaseFeature(BaseFeature):
         'missing_value_strategy': FILL_WITH_CONST,
         'fill_value': UNKNOWN_SYMBOL
     }
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters):
@@ -96,20 +92,20 @@ class SetBaseFeature(BaseFeature):
             metadata,
             preprocessing_parameters,
     ):
-        data[feature['name']] = SetBaseFeature.feature_data(
+        data[feature['name']] = SetFeatureMixin.feature_data(
             dataset_df[feature['name']].astype(str),
             metadata[feature['name']],
             preprocessing_parameters
         )
 
 
-class SetInputFeature(SetBaseFeature, InputFeature):
+class SetInputFeature(SetFeatureMixin, InputFeature):
     encoder = 'embed'
 
     def __init__(self, feature, encoder_obj=None):
         super().__init__(feature)
 
-        SetBaseFeature.__init__(self, feature)
+        SetFeatureMixin.__init__(self, feature)
         InputFeature.__init__(self)
         self.overwrite_defaults(feature)
         if encoder_obj:
@@ -146,7 +142,7 @@ class SetInputFeature(SetBaseFeature, InputFeature):
     }
 
 
-class SetOutputFeature(SetBaseFeature, OutputFeature):
+class SetOutputFeature(SetFeatureMixin, OutputFeature):
     decoder = 'classifier'
     num_classes = 0
     loss = {TYPE: SIGMOID_CROSS_ENTROPY}

--- a/ludwig/features/text_feature.py
+++ b/ludwig/features/text_feature.py
@@ -21,7 +21,6 @@ import numpy as np
 import tensorflow as tf
 
 from ludwig.constants import *
-from ludwig.features.base_feature import BaseFeature
 from ludwig.features.sequence_feature import SequenceInputFeature
 from ludwig.features.sequence_feature import SequenceOutputFeature
 from ludwig.globals import is_on_master
@@ -37,7 +36,7 @@ from ludwig.utils.strings_utils import create_vocabulary
 logger = logging.getLogger(__name__)
 
 
-class TextBaseFeature(BaseFeature):
+class TextFeatureMixin(object):
     type = TEXT
 
     preprocessing_defaults = {
@@ -56,9 +55,6 @@ class TextBaseFeature(BaseFeature):
         'missing_value_strategy': FILL_WITH_CONST,
         'fill_value': UNKNOWN_SYMBOL
     }
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
 
     @staticmethod
     def feature_meta(column, preprocessing_parameters):
@@ -102,7 +98,7 @@ class TextBaseFeature(BaseFeature):
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters):
-        tf_meta = TextBaseFeature.feature_meta(
+        tf_meta = TextFeatureMixin.feature_meta(
             column, preprocessing_parameters
         )
         (
@@ -175,7 +171,7 @@ class TextBaseFeature(BaseFeature):
             metadata,
             preprocessing_parameters
     ):
-        chars_data, words_data = TextBaseFeature.feature_data(
+        chars_data, words_data = TextFeatureMixin.feature_data(
             dataset_df[feature['name']].astype(str),
             metadata[feature['name']], preprocessing_parameters
         )
@@ -183,7 +179,7 @@ class TextBaseFeature(BaseFeature):
         data['{}_word'.format(feature['name'])] = words_data
 
 
-class TextInputFeature(TextBaseFeature, SequenceInputFeature):
+class TextInputFeature(TextFeatureMixin, SequenceInputFeature):
     encoder = 'parallel_cnn'
     level = 'word'
     length = 0
@@ -236,7 +232,7 @@ class TextInputFeature(TextBaseFeature, SequenceInputFeature):
         )
 
 
-class TextOutputFeature(TextBaseFeature, SequenceOutputFeature):
+class TextOutputFeature(TextFeatureMixin, SequenceOutputFeature):
     decoder = 'generator'
     level = 'word'
     max_sequence_length = 0

--- a/ludwig/features/timeseries_feature.py
+++ b/ludwig/features/timeseries_feature.py
@@ -20,7 +20,6 @@ import numpy as np
 import tensorflow as tf
 
 from ludwig.constants import *
-from ludwig.features.base_feature import BaseFeature
 from ludwig.features.sequence_feature import SequenceInputFeature
 from ludwig.utils.misc import get_from_registry, set_default_values
 from ludwig.utils.strings_utils import tokenizer_registry
@@ -28,7 +27,7 @@ from ludwig.utils.strings_utils import tokenizer_registry
 logger = logging.getLogger(__name__)
 
 
-class TimeseriesBaseFeature(BaseFeature):
+class TimeseriesFeatureMixin(object):
     type = TIMESERIES
 
     preprocessing_defaults = {
@@ -39,9 +38,6 @@ class TimeseriesBaseFeature(BaseFeature):
         'missing_value_strategy': FILL_WITH_CONST,
         'fill_value': ''
     }
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters):
@@ -104,7 +100,7 @@ class TimeseriesBaseFeature(BaseFeature):
 
     @staticmethod
     def feature_data(column, metadata, preprocessing_parameters):
-        timeseries_data = TimeseriesBaseFeature.build_matrix(
+        timeseries_data = TimeseriesFeatureMixin.build_matrix(
             column,
             preprocessing_parameters['tokenizer'],
             metadata['max_timeseries_length'],
@@ -120,7 +116,7 @@ class TimeseriesBaseFeature(BaseFeature):
             metadata,
             preprocessing_parameters
     ):
-        timeseries_data = TimeseriesBaseFeature.feature_data(
+        timeseries_data = TimeseriesFeatureMixin.feature_data(
             dataset_df[feature['name']].astype(str),
             metadata[feature['name']],
             preprocessing_parameters
@@ -128,7 +124,7 @@ class TimeseriesBaseFeature(BaseFeature):
         data[feature['name']] = timeseries_data
 
 
-class TimeseriesInputFeature(TimeseriesBaseFeature, SequenceInputFeature):
+class TimeseriesInputFeature(TimeseriesFeatureMixin, SequenceInputFeature):
     encoder = 'parallel_cnn'
     length = 0
 

--- a/ludwig/features/vector_feature.py
+++ b/ludwig/features/vector_feature.py
@@ -26,7 +26,6 @@ from tensorflow.keras.metrics import \
 from tensorflow.keras.metrics import MeanSquaredError as MeanSquaredErrorMetric
 
 from ludwig.constants import *
-from ludwig.features.base_feature import BaseFeature
 from ludwig.features.base_feature import InputFeature
 from ludwig.features.base_feature import OutputFeature
 from ludwig.globals import is_on_master
@@ -86,15 +85,12 @@ class MAEMetric(MeanAbsoluteErrorMetric):
         )
 
 
-class VectorBaseFeature(BaseFeature):
+class VectorFeatureMixin(object):
     type = VECTOR
     preprocessing_defaults = {
         'missing_value_strategy': FILL_WITH_CONST,
         'fill_value': ""
     }
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters):
@@ -146,7 +142,7 @@ class VectorBaseFeature(BaseFeature):
         metadata[feature['name']]['vector_size'] = vector_size
 
 
-class VectorInputFeature(VectorBaseFeature, InputFeature):
+class VectorInputFeature(VectorFeatureMixin, InputFeature):
     encoder = 'dense'
 
     def __init__(self, feature, encoder_obj=None):
@@ -193,7 +189,7 @@ class VectorInputFeature(VectorBaseFeature, InputFeature):
     }
 
 
-class VectorOutputFeature(VectorBaseFeature, OutputFeature):
+class VectorOutputFeature(VectorFeatureMixin, OutputFeature):
     decoder = 'projector'
     loss = {'type': MEAN_SQUARED_ERROR}
     vector_size = 0

--- a/tests/ludwig/utils/test_normalization.py
+++ b/tests/ludwig/utils/test_normalization.py
@@ -16,10 +16,12 @@
 import pandas as pd
 import numpy as np
 
-from ludwig.features.numerical_feature import NumericalBaseFeature
+from ludwig.features.numerical_feature import NumericalFeatureMixin
+
 
 def numerical_feature():
     return {'name': 'x' , 'type': 'numerical'}
+
 
 data_df = pd.DataFrame(pd.Series([
     2,
@@ -37,14 +39,12 @@ data = pd.DataFrame(pd.Series([
     10
 ]), columns=['x'])
 
-feature_1 = NumericalBaseFeature(numerical_feature())
-feature_2 = NumericalBaseFeature(numerical_feature())
 
 def test_norm():
-    feature_1_meta = feature_1.get_feature_meta(
+    feature_1_meta = NumericalFeatureMixin.get_feature_meta(
         data_df['x'], {'normalization': 'zscore'}
     )
-    feature_2_meta = feature_1.get_feature_meta(
+    feature_2_meta = NumericalFeatureMixin.get_feature_meta(
         data_df['x'], {'normalization': 'minmax'}
     )
     
@@ -53,7 +53,7 @@ def test_norm():
     assert feature_2_meta['max'] == 10
     
     # value checks after normalization
-    feature_1.add_feature_data(
+    NumericalFeatureMixin.add_feature_data(
         feature=numerical_feature(),
         dataset_df=data_df,
         data=data,
@@ -64,7 +64,7 @@ def test_norm():
         np.array([-1.26491106, -0.63245553,  0,  0.63245553,  1.26491106])
     )
 
-    feature_2.add_feature_data(
+    NumericalFeatureMixin.add_feature_data(
         feature=numerical_feature(),
         dataset_df=data_df,
         data=data,


### PR DESCRIPTION
This change does the following:

- Replaced `*BaseFeature` classes with `*FeatureMixin` classes that do not inherit from `BaseFeature`, so they do not get constructed during calls to `super().__init__()`.
- Made `InputFeature` and `OutputFeature` the sole parent classes of concrete features, so that there is no multiple inheritance (diamond pattern) in the constructors.
- Changed `InputFeature` and `OutputFeature` to derive from `BaseFeature`.
- Replaced usage of concrete instances in `test_normalization.py` with using the class directly, since all method calls are static.