### PR TITLE
TF2 porting: Fix test_server.py unit test

### DIFF
--- a/ludwig/models/modules/generic_decoders.py
+++ b/ludwig/models/modules/generic_decoders.py
@@ -52,7 +52,7 @@ class Regressor(Layer):
         logger.debug('  {}'.format(self.dense.name))
 
     def call(self, inputs, **kwargs):
-        return tf.squeeze(self.dense(inputs))
+        return tf.squeeze(self.dense(inputs), axis=1)
 
 
 class Projector(Layer):

--- a/ludwig/models/modules/generic_decoders.py
+++ b/ludwig/models/modules/generic_decoders.py
@@ -52,7 +52,7 @@ class Regressor(Layer):
         logger.debug('  {}'.format(self.dense.name))
 
     def call(self, inputs, **kwargs):
-        return tf.squeeze(self.dense(inputs), axis=1)
+        return tf.squeeze(self.dense(inputs), axis=-1)
 
 
 class Projector(Layer):


### PR DESCRIPTION

# Code Pull Requests

This fixes an issue with `Regressor` decoder where it returns either a tensor of rank 0 or tensor of rank 1.  With fix it now returns tensor of rank 1 under all conditions.

This change fixes the issue with the `test_server.py` unit test.

Here is log from the entire unit tests
```
pytest /opt/project/tests
=========================================================== test session starts ============================================================
platform linux -- Python 3.6.9, pytest-5.4.3, py-1.9.0, pluggy-0.13.1
rootdir: /opt/project
plugins: forked-1.2.0, xdist-1.33.0, pycharm-0.6.0, typeguard-2.9.1
collected 464 items

../../../tests/integration_tests/test_api.py ..                                                                                      [  0%]
../../../tests/integration_tests/test_contrib_comet.py F                                                                             [  0%]
../../../tests/integration_tests/test_contrib_wandb.py .                                                                             [  0%]
../../../tests/integration_tests/test_encoders.py ......                                                                             [  2%]
../../../tests/integration_tests/test_experiment.py ................................................................................ [ 19%]
.................................................................................................................................... [ 47%]
.................................................................................................................................... [ 76%]
.......                                                                                                                              [ 77%]
../../../tests/integration_tests/test_generic_features.py ..                                                                         [ 78%]
../../../tests/integration_tests/test_horovod.py Fs                                                                                  [ 78%]
../../../tests/integration_tests/test_hyperopt.py .                                                                                  [ 78%]
../../../tests/integration_tests/test_kfold_cv.py .......                                                                            [ 80%]
../../../tests/integration_tests/test_model_save_and_load.py .                                                                       [ 80%]
../../../tests/integration_tests/test_model_training_options.py .................                                                    [ 84%]
../../../tests/integration_tests/test_savedmodel.py F                                                                                [ 84%]
../../../tests/integration_tests/test_server.py .                                                                                    [ 84%]
../../../tests/integration_tests/test_simple_features.py ..........                                                                  [ 86%]
../../../tests/integration_tests/test_visualization.py ..........................                                                    [ 92%]
../../../tests/integration_tests/test_visualization_api.py ......................                                                    [ 97%]
../../../tests/ludwig/models/modules/test_encoder.py ....                                                                            [ 98%]
../../../tests/ludwig/utils/test_data_utils.py .                                                                                     [ 98%]
../../../tests/ludwig/utils/test_horovod_utils.py s                                                                                  [ 98%]
../../../tests/ludwig/utils/test_hyperopt_utils.py FFFF                                                                              [ 99%]
../../../tests/ludwig/utils/test_image_utils.py ..                                                                                   [ 99%]
../../../tests/ludwig/utils/test_normalization.py .                                                                                  [100%]

================================================================= FAILURES =================================================================
========================================================= short test summary info ==========================================================
FAILED ../../../tests/integration_tests/test_contrib_comet.py::test_contrib_experiment - assert 1 == 0
FAILED ../../../tests/integration_tests/test_horovod.py::test_horovod_implicit - assert 127 == 0
FAILED ../../../tests/integration_tests/test_savedmodel.py::test_savedmodel - AttributeError: 'Model' object has no attribute '_session'
FAILED ../../../tests/ludwig/utils/test_hyperopt_utils.py::test_grid_strategy[test_1] - ValueError: Key float not supported, available op...
FAILED ../../../tests/ludwig/utils/test_hyperopt_utils.py::test_grid_strategy[test_2] - ValueError: Key float not supported, available op...
FAILED ../../../tests/ludwig/utils/test_hyperopt_utils.py::test_random_strategy[test_1] - AssertionError: invalid input type float
FAILED ../../../tests/ludwig/utils/test_hyperopt_utils.py::test_random_strategy[test_2] - AssertionError: invalid input type float
=================================== 7 failed, 455 passed, 2 skipped, 4446 warnings in 887.47s (0:14:47) ====================================

```
