### PR TITLE
Fixed neuropod test to not use native bindings

### DIFF
--- a/ludwig/utils/neuropod_utils.py
+++ b/ludwig/utils/neuropod_utils.py
@@ -23,7 +23,6 @@ class LudwigNeuropodModelWrapper:
         self.ludwig_model = LudwigModel.load(data_root)
 
     def __call__(self, **kwargs):
-        print('__call__', file=sys.stderr)
         data_dict = kwargs
         for key in data_dict:
             data_dict[key] = np.squeeze(data_dict[key], axis=1)
@@ -37,7 +36,6 @@ class LudwigNeuropodModelWrapper:
 
 
 def get_model(data_root):
-    print('get_model()', data_root, file=sys.stderr)
     return LudwigNeuropodModelWrapper(data_root)
 
 
@@ -117,15 +115,13 @@ def export_neuropod(
         ludwig_model_path,
         neuropod_path,
         neuropod_model_name="ludwig_model",
-        package_as_dir=False
 ):
     try:
         from neuropod.backends.python.packager import create_python_neuropod
     except ImportError:
-        logger.error(
+        raise RuntimeError(
             'The "neuropod" package is not installed in your environment.'
         )
-        sys.exit(-1)
 
     data_paths = [
         {
@@ -291,7 +287,6 @@ def export_neuropod(
         }],
         entrypoint_package="ludwig.utils.neuropod_utils",
         entrypoint="get_model",
-        # test_deps=['torch', 'numpy'],
         skip_virtualenv=True,
         input_spec=input_spec,
         output_spec=output_spec
@@ -352,10 +347,8 @@ def cli():
         args.ludwig_model_path,
         args.neuropod_path,
         args.neuropod_model_name,
-        args.package_as_dir
     )
 
 
 if __name__ == '__main__':
-    # contrib_command("neuropod", *sys.argv)
     cli()

--- a/requirements_serve.txt
+++ b/requirements_serve.txt
@@ -2,3 +2,4 @@ uvicorn
 fastapi
 pydantic==0.32.2
 python-multipart
+neuropod

--- a/tests/integration_tests/test_neuropod.py
+++ b/tests/integration_tests/test_neuropod.py
@@ -32,7 +32,7 @@ from tests.integration_tests.utils import generate_data
 from tests.integration_tests.utils import sequence_feature
 
 
-def _test_neuropod(csv_filename):
+def test_neuropod(csv_filename):
     #######
     # Setup
     #######
@@ -101,6 +101,7 @@ def _test_neuropod(csv_filename):
     # build neuropod
     ################
     neuropod_path = os.path.join(dir_path, 'neuropod')
+    shutil.rmtree(neuropod_path, ignore_errors=True)
     export_neuropod(ludwigmodel_path, neuropod_path=neuropod_path)
 
     ########################
@@ -116,7 +117,7 @@ def _test_neuropod(csv_filename):
     }
 
     from neuropod.loader import load_neuropod
-    neuropod_model = load_neuropod(neuropod_path)
+    neuropod_model = load_neuropod(neuropod_path, _always_use_native=False)
     preds = neuropod_model.infer(if_dict)
 
     for key in preds:


### PR DESCRIPTION
Using native bindings (the default) results in runtime failures, so we fall back to using Python bindings instead.

Issues to track:

https://github.com/uber/neuropod/issues/403
https://github.com/uber/neuropod/issues/404