### PR TITLE
Fixed race condition with hyperopt caused by different trials sharing the same experiment directory

### DIFF
--- a/ludwig/utils/hyperopt_utils.py
+++ b/ludwig/utils/hyperopt_utils.py
@@ -521,8 +521,6 @@ class ParallelExecutor(HyperoptExecutor):
     ):
         ctx = multiprocessing.get_context('spawn')
 
-        hyperopt_parameters = []
-
         if gpus is None:
             gpus = get_available_gpus_cuda_string()
 
@@ -640,6 +638,7 @@ class ParallelExecutor(HyperoptExecutor):
         while not self.hyperopt_strategy.finished():
             sampled_parameters = self.hyperopt_strategy.sample_batch()
 
+            hyperopt_parameters = []
             for i, parameters in enumerate(sampled_parameters):
                 modified_model_definition = substitute_parameters(
                     copy.deepcopy(model_definition), parameters)

--- a/tests/integration_tests/test_hyperopt.py
+++ b/tests/integration_tests/test_hyperopt.py
@@ -62,7 +62,7 @@ STRATEGIES = [
 EXECUTORS = [
     {"type": "serial"},
     {"type": "parallel", "num_workers": 4},
-    # {"type": "fiber", "num_workers": 4},
+    {"type": "fiber", "num_workers": 4},
 ]
 
 


### PR DESCRIPTION
This PR does the following:

- Assigns each trial a unique ID to ensure trials do not attempt to use the same experiment directory.
- Fixes a bug causing trials to be performed more than once by the `ParallelExecutor` by moving the parameter list inside the loop that samples batches.
- Enables Fiber during testing.