### PR TITLE
fix: train_set_metadata_json arg

### DIFF
--- a/ludwig/experiment.py
+++ b/ludwig/experiment.py
@@ -648,7 +648,7 @@ def cli(sys_argv):
     )
 
     parser.add_argument(
-        '--metadata_json',
+        '--train_set_metadata_json',
         help='input metadata JSON file. It is an intermediate preprocess file'
              ' containing the mappings of the input CSV created the first time '
              'a CSV file is used in the same directory with the same name and a'


### PR DESCRIPTION
There is a bug of experiment `cli` arg `train_set_metadata_json` which fixed in this PR