### PR TITLE
TF2 porting: Unit test for dependency concatenation

### DIFF
--- a/ludwig/features/base_feature.py
+++ b/ludwig/features/base_feature.py
@@ -281,7 +281,7 @@ class OutputFeature(BaseFeature, tf.keras.Model, ABC):
                         # matrix vector -> tile concat
                         sequence_max_length = hidden.shape[1]
                         multipliers = tf.concat(
-                            [[1], sequence_max_length[:, tf.newaxis], [1]],
+                            [[1], [sequence_max_length], [1]],
                             0
                         )
                         tiled_representation = tf.tile(

--- a/ludwig/features/base_feature.py
+++ b/ludwig/features/base_feature.py
@@ -270,7 +270,6 @@ class OutputFeature(BaseFeature, tf.keras.Model, ABC):
                 # because we did the topological sort of the features before
                 dependency_final_hidden = other_features_hidden[dependency]
 
-                # todo tf2: test all 4 branches, for now only vector x vector is tested
                 if len(hidden.shape) > 2:
                     if len(dependency_final_hidden.shape) > 2:
                         # matrix matrix -> concat
@@ -297,7 +296,7 @@ class OutputFeature(BaseFeature, tf.keras.Model, ABC):
                         )
                         tiled_representation = tf.multiply(
                             tiled_representation,
-                            tf.cast(mask[:, tf.newaxis], dtype=tf.float32)
+                            tf.cast(mask[:, :, tf.newaxis], dtype=tf.float32)
                         )
 
                         dependencies_hidden.append(tiled_representation)

--- a/tests/integration_tests/test_dependencies.py
+++ b/tests/integration_tests/test_dependencies.py
@@ -1,9 +1,6 @@
 import logging
-import os
-import shutil
 
 import pytest
-import yaml
 
 import tensorflow as tf
 

--- a/tests/integration_tests/test_dependencies.py
+++ b/tests/integration_tests/test_dependencies.py
@@ -21,7 +21,7 @@ HIDDEN_SIZE = 128
 OTHER_HIDDEN_SIZE = 32
 OTHER_HIDDEN_SIZE2 = 18
 
-
+# unit test for single dependency
 @pytest.mark.parametrize(
     'dependent_hidden_shape', [
         [BATCH_SIZE, OTHER_HIDDEN_SIZE],
@@ -68,6 +68,7 @@ def test_single_dependencies(hidden_shape, dependent_hidden_shape):
                [BATCH_SIZE, HIDDEN_SIZE + OTHER_HIDDEN_SIZE]
 
 
+# unit test for multiple dependencies
 @pytest.mark.parametrize(
     'dependent_hidden_shape2', [
         [BATCH_SIZE, OTHER_HIDDEN_SIZE2],

--- a/tests/integration_tests/test_dependencies.py
+++ b/tests/integration_tests/test_dependencies.py
@@ -16,26 +16,26 @@ logger.setLevel(logging.INFO)
 logging.getLogger("ludwig").setLevel(logging.INFO)
 
 BATCH_SIZE = 16
+SEQ_SIZE = 12
 HIDDEN_SIZE = 128
-HIDDEN_SEQ_SIZE = 12
 OTHER_HIDDEN_SIZE = 32
-OTHER_HIDDEN_SEQ_SIZE = 12
+OTHER_HIDDEN_SIZE2 = 18
 
 
 @pytest.mark.parametrize(
     'dependent_hidden_shape', [
         [BATCH_SIZE, OTHER_HIDDEN_SIZE],
-        [BATCH_SIZE, OTHER_HIDDEN_SEQ_SIZE, OTHER_HIDDEN_SIZE]
+        [BATCH_SIZE, SEQ_SIZE, OTHER_HIDDEN_SIZE]
 
     ]
 )
 @pytest.mark.parametrize(
     'hidden_shape', [
         [BATCH_SIZE, HIDDEN_SIZE],
-        [BATCH_SIZE, HIDDEN_SEQ_SIZE, HIDDEN_SIZE]
+        [BATCH_SIZE, SEQ_SIZE, HIDDEN_SIZE]
     ]
 )
-def test_concat_dependencies(hidden_shape, dependent_hidden_shape):
+def test_single_dependencies(hidden_shape, dependent_hidden_shape):
     hidden_layer = tf.random.normal(
         hidden_shape,
         dtype=tf.float32
@@ -61,6 +61,74 @@ def test_concat_dependencies(hidden_shape, dependent_hidden_shape):
     )
 
     if len(hidden_shape) > 2:
-        assert results.shape.as_list() == [BATCH_SIZE, HIDDEN_SEQ_SIZE, HIDDEN_SIZE + OTHER_HIDDEN_SIZE]
+        assert results.shape.as_list() == \
+               [BATCH_SIZE, SEQ_SIZE, HIDDEN_SIZE + OTHER_HIDDEN_SIZE]
     else:
-        assert results.shape.as_list() == [BATCH_SIZE, HIDDEN_SIZE + OTHER_HIDDEN_SIZE]
+        assert results.shape.as_list() == \
+               [BATCH_SIZE, HIDDEN_SIZE + OTHER_HIDDEN_SIZE]
+
+
+@pytest.mark.parametrize(
+    'dependent_hidden_shape2', [
+        [BATCH_SIZE, OTHER_HIDDEN_SIZE2],
+        [BATCH_SIZE, SEQ_SIZE, OTHER_HIDDEN_SIZE2]
+
+    ]
+)
+@pytest.mark.parametrize(
+    'dependent_hidden_shape', [
+        [BATCH_SIZE, OTHER_HIDDEN_SIZE],
+        [BATCH_SIZE, SEQ_SIZE, OTHER_HIDDEN_SIZE]
+
+    ]
+)
+@pytest.mark.parametrize(
+    'hidden_shape', [
+        [BATCH_SIZE, HIDDEN_SIZE],
+        [BATCH_SIZE, SEQ_SIZE, HIDDEN_SIZE]
+    ]
+)
+def test_multiple_dependencies(hidden_shape, dependent_hidden_shape,
+                               dependent_hidden_shape2):
+    hidden_layer = tf.random.normal(
+        hidden_shape,
+        dtype=tf.float32
+    )
+    other_hidden_layer = tf.random.normal(
+        dependent_hidden_shape,
+        dtype=tf.float32
+    )
+    other_hidden_layer2 = tf.random.normal(
+        dependent_hidden_shape2,
+        dtype=tf.float32
+    )
+
+    other_dependencies = {
+        'feature_name': other_hidden_layer,
+        'feature_name2': other_hidden_layer2
+    }
+
+    num_feature_defn = numerical_feature()
+    num_feature_defn['loss'] = {'type': 'mean_squared_error'}
+    num_feature_defn['dependencies'] = ['feature_name', 'feature_name2']
+    if len(dependent_hidden_shape) > 2 or len(dependent_hidden_shape2) > 2:
+        num_feature_defn['reduce_dependencies'] = 'sum'
+
+    out_feature = NumericalOutputFeature(num_feature_defn)
+
+    results = out_feature.concat_dependencies(
+        hidden_layer,
+        other_dependencies
+    )
+
+    if len(hidden_shape) > 2:
+        assert results.shape.as_list() == \
+               [BATCH_SIZE, SEQ_SIZE,
+                HIDDEN_SIZE + OTHER_HIDDEN_SIZE + OTHER_HIDDEN_SIZE2]
+    else:
+        assert results.shape.as_list() == \
+               [BATCH_SIZE,
+                HIDDEN_SIZE + OTHER_HIDDEN_SIZE + OTHER_HIDDEN_SIZE2]
+
+
+

--- a/tests/integration_tests/test_dependencies.py
+++ b/tests/integration_tests/test_dependencies.py
@@ -1,0 +1,66 @@
+import logging
+import os
+import shutil
+
+import pytest
+import yaml
+
+import tensorflow as tf
+
+from ludwig.features.numerical_feature import NumericalOutputFeature
+from tests.integration_tests.utils import numerical_feature
+
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+logging.getLogger("ludwig").setLevel(logging.INFO)
+
+BATCH_SIZE = 16
+HIDDEN_SIZE = 128
+HIDDEN_SEQ_SIZE = 12
+OTHER_HIDDEN_SIZE = 32
+OTHER_HIDDEN_SEQ_SIZE = 12
+
+
+@pytest.mark.parametrize(
+    'dependent_hidden_shape', [
+        [BATCH_SIZE, OTHER_HIDDEN_SIZE],
+        [BATCH_SIZE, OTHER_HIDDEN_SEQ_SIZE, OTHER_HIDDEN_SIZE]
+
+    ]
+)
+@pytest.mark.parametrize(
+    'hidden_shape', [
+        [BATCH_SIZE, HIDDEN_SIZE],
+        [BATCH_SIZE, HIDDEN_SEQ_SIZE, HIDDEN_SIZE]
+    ]
+)
+def test_concat_dependencies(hidden_shape, dependent_hidden_shape):
+    hidden_layer = tf.random.normal(
+        hidden_shape,
+        dtype=tf.float32
+    )
+    other_hidden_layer = tf.random.normal(
+        dependent_hidden_shape,
+        dtype=tf.float32
+    )
+
+    other_dependencies = {'feature_name': other_hidden_layer}
+
+    num_feature_defn = numerical_feature()
+    num_feature_defn['loss'] = {'type': 'mean_squared_error'}
+    num_feature_defn['dependencies'] = ['feature_name']
+    if len(dependent_hidden_shape) > 2:
+        num_feature_defn['reduce_dependencies'] = 'sum'
+
+    out_feature = NumericalOutputFeature(num_feature_defn)
+
+    results = out_feature.concat_dependencies(
+        hidden_layer,
+        other_dependencies
+    )
+
+    if len(hidden_shape) > 2:
+        assert results.shape.as_list() == [BATCH_SIZE, HIDDEN_SEQ_SIZE, HIDDEN_SIZE + OTHER_HIDDEN_SIZE]
+    else:
+        assert results.shape.as_list() == [BATCH_SIZE, HIDDEN_SIZE + OTHER_HIDDEN_SIZE]


### PR DESCRIPTION
# Code Pull Requests

This adds unit tests for `OutputFeature.concat_dependencies()` method.  One unit test confirms correct operation for single dependency.  A second unit test confirms correct operation for multiple dependencies.  The unit test uses all possible combination of shapes, i.e., `[b, h]` and `[b, s, h]`.     

The primary item validated in these two unit tests is the correct shape of the concatenated tensors.  The following table shows the expected shapes.

Tensor shape notation (`b` is batch size, `s` is sequence size):
* hidden layer: `[b, h1]` (vector) or `[b, s, h1]` (matrix)
* dependent feature last hidden layer: `[b, h2]` (vector) or `[b, s, h2]` (matrix)

Following table shows the expected shape after concatenation

|hidden layer|dependent hidden layer|concatenation shape|
|------------|----------------------|-------------------|
|`[b, h1]`|`[b, h2]`|`[b, h1 + h2]`|
|`[b, h1]`|`[b, s, h2]`|`[b, h1 + h2]`|
|`[b, s, h1]`|`[b, h2]`|`[b, s, h1 + h2]`|
|`[b, s, h1]`|`[b, s, h2]`|`[b, s, h1 + h2]`|

From what I can tell, the dependency concatenation is independent of the specific output feature.  These tests used numeric output feature as the foundation for the test.

The PR covers only validating the concatenation of tensors.  This PR did not address the issue of tf2 mask mechanism.


