### PR TITLE
TF2 porting: Add unit test for combiners

### DIFF
--- a/ludwig/combiners/combiners.py
+++ b/ludwig/combiners/combiners.py
@@ -146,7 +146,10 @@ class SequenceConcatCombiner(tf.keras.Model):
         if (self.main_sequence_feature is None or
                 self.main_sequence_feature not in inputs):
             for if_name, if_outputs in inputs.items():
-                if if_outputs['type'] in SEQUENCE_TYPES:
+                # todo: when https://github.com/uber/ludwig/issues/810 is closed
+                #       convert following test from using shape to use explicit
+                #       if_outputs['type'] values for sequence features
+                if len(if_outputs['encoder_output'].shape) == 3:
                     self.main_sequence_feature = if_name
                     break
 
@@ -165,7 +168,7 @@ class SequenceConcatCombiner(tf.keras.Model):
 
         # ================ Concat ================
         for if_name, if_outputs in inputs.items():
-            if if_name is not self.main_sequence_feature:
+            if if_name != self.main_sequence_feature:
                 if_representation = if_outputs['encoder_output']
                 if len(if_representation.shape) == 3:
                     # The following check makes sense when

--- a/tests/integration_tests/test_combiners.py
+++ b/tests/integration_tests/test_combiners.py
@@ -19,6 +19,7 @@ HIDDEN_SIZE = 128
 OTHER_HIDDEN_SIZE = 32
 FC_SIZE = 64
 
+
 # set up simulated encoder outputs
 @pytest.fixture
 def encoder_outputs():
@@ -50,6 +51,7 @@ def encoder_outputs():
     return encoder_outputs
 
 
+# test for simple concatenation combiner
 @pytest.mark.parametrize(
     'fc_layer',
     [None, [{'fc_size': 64}, {'fc_size':64}]]
@@ -79,6 +81,8 @@ def test_concat_combiner(encoder_outputs, fc_layer):
             hidden_size += encoder_outputs[k]['encoder_output'].shape[1]
         assert results['combiner_output'].shape.as_list() == [BATCH_SIZE, hidden_size]
 
+
+# test for sequence concatenation combiner
 @pytest.mark.parametrize('reduce_output', [None, 'sum'])
 @pytest.mark.parametrize('main_sequence_feature', [None, 'feature_3'])
 def test_sequence_concat_combiner(encoder_outputs, main_sequence_feature,

--- a/tests/integration_tests/test_combiners.py
+++ b/tests/integration_tests/test_combiners.py
@@ -23,6 +23,11 @@ FC_SIZE = 64
 # set up simulated encoder outputs
 @pytest.fixture
 def encoder_outputs():
+    # generates simulated encoder outputs dictionary:
+    #   feature_1: shape [b, h1] tensor
+    #   feature_2: shape [b, h2] tensor
+    #   feature_3: shape [b, s, h1] tensor
+    #   feature_4: shape [b, sh, h2] tensor
 
     encoder_outputs = {}
     shapes_list = [
@@ -67,6 +72,7 @@ def test_concat_combiner(encoder_outputs, fc_layer):
         fc_layers=fc_layer
     )
 
+    # concatenate encoder outputs
     results = combiner(encoder_outputs)
 
     # required key present
@@ -76,9 +82,11 @@ def test_concat_combiner(encoder_outputs, fc_layer):
     if fc_layer:
         assert results['combiner_output'].shape.as_list() == [BATCH_SIZE, FC_SIZE]
     else:
+        # calculate expected hidden size for concatenated tensors
         hidden_size = 0
         for k in encoder_outputs:
             hidden_size += encoder_outputs[k]['encoder_output'].shape[1]
+
         assert results['combiner_output'].shape.as_list() == [BATCH_SIZE, hidden_size]
 
 
@@ -93,10 +101,12 @@ def test_sequence_concat_combiner(encoder_outputs, main_sequence_feature,
         reduce_output=reduce_output
     )
 
+    # calculate expected hidden size for concatenated tensors
     hidden_size = 0
     for k in encoder_outputs:
         hidden_size += encoder_outputs[k]['encoder_output'].shape[-1]
 
+    # concatenate encoder outputs
     results = combiner(encoder_outputs)
 
     # required key present

--- a/tests/integration_tests/test_combiners.py
+++ b/tests/integration_tests/test_combiners.py
@@ -101,7 +101,7 @@ def test_sequence_concat_combiner(encoder_outputs, main_sequence_feature,
     # confirm correct shape
     if reduce_output is None:
         assert results['combiner_output'].shape.as_list() == \
-               [BATCH_SIZE, hidden_size]
+               [BATCH_SIZE, SEQ_SIZE, hidden_size]
     else:
         assert results['combiner_output'].shape.as_list() == \
-               [BATCH_SIZE, SEQ_SIZE, hidden_size]
+               [BATCH_SIZE, hidden_size]

--- a/tests/integration_tests/test_combiners.py
+++ b/tests/integration_tests/test_combiners.py
@@ -1,0 +1,107 @@
+import logging
+
+import numpy as np
+
+import pytest
+
+import tensorflow as tf
+
+from ludwig.combiners.combiners import ConcatCombiner, SequenceConcatCombiner
+
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+logging.getLogger("ludwig").setLevel(logging.INFO)
+
+BATCH_SIZE = 16
+SEQ_SIZE = 12
+HIDDEN_SIZE = 128
+OTHER_HIDDEN_SIZE = 32
+FC_SIZE = 64
+
+# set up simulated encoder outputs
+@pytest.fixture
+def encoder_outputs():
+
+    encoder_outputs = {}
+    shapes_list = [
+        [BATCH_SIZE, HIDDEN_SIZE],
+        [BATCH_SIZE, OTHER_HIDDEN_SIZE],
+        [BATCH_SIZE, SEQ_SIZE, HIDDEN_SIZE],
+        [BATCH_SIZE, SEQ_SIZE, OTHER_HIDDEN_SIZE]
+    ]
+    feature_names = ['feature_'+str(i+1) for i in range(len(shapes_list))]
+
+    for feature_name, batch_shape in zip(feature_names, shapes_list):
+        encoder_outputs[feature_name] = \
+            {
+                'encoder_output': tf.random.normal(
+                    batch_shape,
+                    dtype=tf.float32
+                )
+            }
+        if len(batch_shape) > 2:
+            encoder_outputs[feature_name]['encoder_output_state'] = \
+                tf.random.normal(
+                    [batch_shape[0], batch_shape[2]],
+                    dtype=tf.float32
+                )
+
+    return encoder_outputs
+
+
+@pytest.mark.parametrize(
+    'fc_layer',
+    [None, [{'fc_size': 64}, {'fc_size':64}]]
+)
+def test_concat_combiner(encoder_outputs, fc_layer):
+
+    # clean out unneeded encoder outputs
+    del encoder_outputs['feature_3']
+    del encoder_outputs['feature_4']
+
+    # setup combiner to test
+    combiner = ConcatCombiner(
+        fc_layers=fc_layer
+    )
+
+    results = combiner(encoder_outputs)
+
+    # required key present
+    assert 'combiner_output' in results
+
+    # confirm correct output shapes
+    if fc_layer:
+        assert results['combiner_output'].shape.as_list() == [BATCH_SIZE, FC_SIZE]
+    else:
+        hidden_size = 0
+        for k in encoder_outputs:
+            hidden_size += encoder_outputs[k]['encoder_output'].shape[1]
+        assert results['combiner_output'].shape.as_list() == [BATCH_SIZE, hidden_size]
+
+@pytest.mark.parametrize('reduce_output', [None, 'sum'])
+@pytest.mark.parametrize('main_sequence_feature', [None, 'feature_3'])
+def test_sequence_concat_combiner(encoder_outputs, main_sequence_feature,
+                                  reduce_output):
+
+    combiner = SequenceConcatCombiner(
+        main_sequence_feature=main_sequence_feature,
+        reduce_output=reduce_output
+    )
+
+    hidden_size = 0
+    for k in encoder_outputs:
+        hidden_size += encoder_outputs[k]['encoder_output'].shape[-1]
+
+    results = combiner(encoder_outputs)
+
+    # required key present
+    assert 'combiner_output' in results
+
+    # confirm correct shape
+    if reduce_output is None:
+        assert results['combiner_output'].shape.as_list() == \
+               [BATCH_SIZE, hidden_size]
+    else:
+        assert results['combiner_output'].shape.as_list() == \
+               [BATCH_SIZE, SEQ_SIZE, hidden_size]


### PR DESCRIPTION
# Code Pull Requests

Added unit tests for combiners.  Tests confirm presence of required dictionary keys and expected tensor shape from the combiner.  For each type of combiner, test combination of various parameters.

* Concat Combiner: 
  * with and without fully connected layers
* Sequence Concat Combiner: 
  * with and with output reduction, 
  * with and without `main_sequence_feature`
* Sequence Combiner
  * with and without `main_sequence_feature`
  * with and without output reduction
  * all registred encoders (stacked_cnn, parallel_cnn, stacked_parallel_cnn, rnn, cnnrnn)

test run
```
pytest -v /opt/project/tests/integration_tests/test_combiners.py
=========================================================== test session starts ===========================================================
platform linux -- Python 3.6.9, pytest-6.0.1, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /opt/project
plugins: xdist-1.34.0, forked-1.3.0, pycharm-0.6.0, typeguard-2.9.1
collected 26 items

../../../tests/integration_tests/test_combiners.py::test_concat_combiner[None] PASSED                                               [  3%]
../../../tests/integration_tests/test_combiners.py::test_concat_combiner[fc_layer1] PASSED                                          [  7%]
../../../tests/integration_tests/test_combiners.py::test_sequence_concat_combiner[None-None] PASSED                                 [ 11%]
../../../tests/integration_tests/test_combiners.py::test_sequence_concat_combiner[None-sum] PASSED                                  [ 15%]
../../../tests/integration_tests/test_combiners.py::test_sequence_concat_combiner[feature_3-None] PASSED                            [ 19%]
../../../tests/integration_tests/test_combiners.py::test_sequence_concat_combiner[feature_3-sum] PASSED                             [ 23%]
../../../tests/integration_tests/test_combiners.py::test_sequence_combiner[None-stacked_cnn-None] PASSED                            [ 26%]
../../../tests/integration_tests/test_combiners.py::test_sequence_combiner[None-stacked_cnn-sum] PASSED                             [ 30%]
../../../tests/integration_tests/test_combiners.py::test_sequence_combiner[None-parallel_cnn-None] PASSED                           [ 34%]
../../../tests/integration_tests/test_combiners.py::test_sequence_combiner[None-parallel_cnn-sum] PASSED                            [ 38%]
../../../tests/integration_tests/test_combiners.py::test_sequence_combiner[None-stacked_parallel_cnn-None] PASSED                   [ 42%]
../../../tests/integration_tests/test_combiners.py::test_sequence_combiner[None-stacked_parallel_cnn-sum] PASSED                    [ 46%]
../../../tests/integration_tests/test_combiners.py::test_sequence_combiner[None-rnn-None] PASSED                                    [ 50%]
../../../tests/integration_tests/test_combiners.py::test_sequence_combiner[None-rnn-sum] PASSED                                     [ 53%]
../../../tests/integration_tests/test_combiners.py::test_sequence_combiner[None-cnnrnn-None] PASSED                                 [ 57%]
../../../tests/integration_tests/test_combiners.py::test_sequence_combiner[None-cnnrnn-sum] PASSED                                  [ 61%]
../../../tests/integration_tests/test_combiners.py::test_sequence_combiner[feature_3-stacked_cnn-None] PASSED                       [ 65%]
../../../tests/integration_tests/test_combiners.py::test_sequence_combiner[feature_3-stacked_cnn-sum] PASSED                        [ 69%]
../../../tests/integration_tests/test_combiners.py::test_sequence_combiner[feature_3-parallel_cnn-None] PASSED                      [ 73%]
../../../tests/integration_tests/test_combiners.py::test_sequence_combiner[feature_3-parallel_cnn-sum] PASSED                       [ 76%]
../../../tests/integration_tests/test_combiners.py::test_sequence_combiner[feature_3-stacked_parallel_cnn-None] PASSED              [ 80%]
../../../tests/integration_tests/test_combiners.py::test_sequence_combiner[feature_3-stacked_parallel_cnn-sum] PASSED               [ 84%]
../../../tests/integration_tests/test_combiners.py::test_sequence_combiner[feature_3-rnn-None] PASSED                               [ 88%]
../../../tests/integration_tests/test_combiners.py::test_sequence_combiner[feature_3-rnn-sum] PASSED                                [ 92%]
../../../tests/integration_tests/test_combiners.py::test_sequence_combiner[feature_3-cnnrnn-None] PASSED                            [ 96%]
../../../tests/integration_tests/test_combiners.py::test_sequence_combiner[feature_3-cnnrnn-sum] PASSED                             [100%]

=========================================================== 26 passed in 1.96s ============================================================
```
