### PR TITLE
TF2 porting: Regularizer Unit Test

### DIFF
--- a/ludwig/decoders/sequence_decoders.py
+++ b/ludwig/decoders/sequence_decoders.py
@@ -57,8 +57,6 @@ class SequenceGeneratorDecoder(Layer):
             num_layers=1,
             attention=None,
             tied_embeddings=None,
-            initializer=None,
-            regularize=True,
             is_timeseries=False,
             max_sequence_length=0,
             use_bias=True,
@@ -81,8 +79,6 @@ class SequenceGeneratorDecoder(Layer):
         self.attention = attention
         self.attention_mechanism = None
         self.tied_embeddings = tied_embeddings
-        self.initializer = initializer
-        self.regularize = regularize
         self.is_timeseries = is_timeseries
         self.num_classes = num_classes
         self.max_sequence_length = max_sequence_length
@@ -100,14 +96,34 @@ class SequenceGeneratorDecoder(Layer):
         self.END_SYMBOL = 0
 
         logger.debug('  project input Dense')
-        self.project = Dense(state_size)
+        self.project = Dense(
+            state_size,
+            use_bias=use_bias,
+            kernel_initializer=weights_initializer,
+            bias_initializer=bias_initializer,
+            kernel_regularizer=weights_regularizer,
+            bias_regularizer=bias_regularizer,
+            activity_regularizer=activity_regularizer
+        )
 
         logger.debug('  Embedding')
         self.decoder_embedding = Embedding(
             input_dim=self.num_classes + 1,  # account for GO_SYMBOL
-            output_dim=embedding_size)
+            output_dim=embedding_size,
+            embeddings_initializer=weights_initializer,
+            embeddings_regularizer=weights_regularizer,
+            activity_regularizer=activity_regularizer
+        )
         logger.debug('  project output Dense')
-        self.dense_layer = Dense(num_classes)
+        self.dense_layer = Dense(
+            num_classes,
+            use_bias=use_bias,
+            kernel_initializer=weights_initializer,
+            bias_initializer=bias_initializer,
+            kernel_regularizer=weights_regularizer,
+            bias_regularizer=bias_regularizer,
+            activity_regularizer=activity_regularizer
+        )
         self.decoder_rnncell = \
             get_from_registry(cell_type, rnn_layers_registry)(state_size)
         logger.debug('  {}'.format(self.decoder_rnncell))

--- a/ludwig/encoders/bag_encoders.py
+++ b/ludwig/encoders/bag_encoders.py
@@ -65,8 +65,8 @@ class BagEmbedWeightedEncoder(Layer):
             force_embedding_size=force_embedding_size,
             embeddings_on_cpu=embeddings_on_cpu,
             dropout_rate=dropout_rate,
-            initializer=weights_initializer,
-            regularizer=weights_regularizer
+            embedding_initializer=weights_initializer,
+            embedding_regularizer=weights_regularizer
         )
 
         logger.debug('  FCStack')

--- a/ludwig/encoders/category_encoders.py
+++ b/ludwig/encoders/category_encoders.py
@@ -33,8 +33,8 @@ class CategoricalEmbedEncoder(Layer):
             pretrained_embeddings=None,
             embeddings_on_cpu=False,
             dropout_rate=0.0,
-            initializer=None,
-            regularizer=None,
+            embedding_initializer=None,
+            embedding_regularizer=None,
             **kwargs
     ):
         super(CategoricalEmbedEncoder, self).__init__()
@@ -49,8 +49,8 @@ class CategoricalEmbedEncoder(Layer):
             pretrained_embeddings=pretrained_embeddings,
             embeddings_on_cpu=embeddings_on_cpu,
             dropout_rate=dropout_rate,
-            initializer=initializer,
-            regularizer=regularizer
+            embedding_initializer=embedding_initializer,
+            embedding_regularizer=embedding_regularizer
         )
 
     def call(self, inputs, training=None, mask=None):

--- a/ludwig/encoders/date_encoders.py
+++ b/ludwig/encoders/date_encoders.py
@@ -127,8 +127,8 @@ class DateEmbed(Layer):
             pretrained_embeddings=None,
             embeddings_on_cpu=embeddings_on_cpu,
             dropout_rate=dropout_rate,
-            initializer=weights_initializer,
-            regularizer=weights_regularizer
+            embedding_initializer=weights_initializer,
+            embedding_regularizer=weights_regularizer
         )
 
         logger.debug('  day Embed')
@@ -140,8 +140,8 @@ class DateEmbed(Layer):
             pretrained_embeddings=None,
             embeddings_on_cpu=embeddings_on_cpu,
             dropout_rate=dropout_rate,
-            initializer=weights_initializer,
-            regularizer=weights_regularizer
+            embedding_initializer=weights_initializer,
+            embedding_regularizer=weights_regularizer
         )
 
         logger.debug('  weekday Embed')
@@ -153,8 +153,8 @@ class DateEmbed(Layer):
             pretrained_embeddings=None,
             embeddings_on_cpu=embeddings_on_cpu,
             dropout_rate=dropout_rate,
-            initializer=weights_initializer,
-            regularizer=weights_regularizer
+            embedding_initializer=weights_initializer,
+            embedding_regularizer=weights_regularizer
         )
 
         logger.debug('  yearday Embed')
@@ -166,8 +166,8 @@ class DateEmbed(Layer):
             pretrained_embeddings=None,
             embeddings_on_cpu=embeddings_on_cpu,
             dropout_rate=dropout_rate,
-            initializer=weights_initializer,
-            regularizer=weights_regularizer
+            embedding_initializer=weights_initializer,
+            embedding_regularizer=weights_regularizer
         )
 
         logger.debug('  hour Embed')
@@ -179,8 +179,8 @@ class DateEmbed(Layer):
             pretrained_embeddings=None,
             embeddings_on_cpu=embeddings_on_cpu,
             dropout_rate=dropout_rate,
-            initializer=weights_initializer,
-            regularizer=weights_regularizer
+            embedding_initializer=weights_initializer,
+            embedding_regularizer=weights_regularizer
         )
 
         logger.debug('  minute Embed')
@@ -192,8 +192,8 @@ class DateEmbed(Layer):
             pretrained_embeddings=None,
             embeddings_on_cpu=embeddings_on_cpu,
             dropout_rate=dropout_rate,
-            initializer=weights_initializer,
-            regularizer=weights_regularizer
+            embedding_initializer=weights_initializer,
+            embedding_regularizer=weights_regularizer
         )
 
         logger.debug('  second Embed')
@@ -205,8 +205,8 @@ class DateEmbed(Layer):
             pretrained_embeddings=None,
             embeddings_on_cpu=embeddings_on_cpu,
             dropout_rate=dropout_rate,
-            initializer=weights_initializer,
-            regularizer=weights_regularizer
+            embedding_initializer=weights_initializer,
+            embedding_regularizer=weights_regularizer
         )
 
         logger.debug('  FCStack')

--- a/ludwig/encoders/h3_encoders.py
+++ b/ludwig/encoders/h3_encoders.py
@@ -106,8 +106,8 @@ class H3Embed(Layer):
             force_embedding_size=True,
             embeddings_on_cpu=embeddings_on_cpu,
             dropout_rate=dropout_rate,
-            initializer=weights_initializer,
-            regularizer=weights_regularizer
+            embedding_initializer=weights_initializer,
+            embedding_regularizer=weights_regularizer
         )
 
         logger.debug('  edge Embed')
@@ -120,8 +120,8 @@ class H3Embed(Layer):
             force_embedding_size=True,
             embeddings_on_cpu=embeddings_on_cpu,
             dropout_rate=dropout_rate,
-            initializer=weights_initializer,
-            regularizer=weights_regularizer
+            embedding_initializer=weights_initializer,
+            embedding_regularizer=weights_regularizer
         )
 
         logger.debug('  resolution Embed')
@@ -134,8 +134,8 @@ class H3Embed(Layer):
             force_embedding_size=True,
             embeddings_on_cpu=embeddings_on_cpu,
             dropout_rate=dropout_rate,
-            initializer=weights_initializer,
-            regularizer=weights_regularizer
+            embedding_initializer=weights_initializer,
+            embedding_regularizer=weights_regularizer
         )
 
         logger.debug('  base cell Embed')
@@ -148,8 +148,8 @@ class H3Embed(Layer):
             force_embedding_size=True,
             embeddings_on_cpu=embeddings_on_cpu,
             dropout_rate=dropout_rate,
-            initializer=weights_initializer,
-            regularizer=weights_regularizer
+            embedding_initializer=weights_initializer,
+            embedding_regularizer=weights_regularizer
         )
 
         logger.debug('  cells Embed')
@@ -162,8 +162,8 @@ class H3Embed(Layer):
             force_embedding_size=True,
             embeddings_on_cpu=embeddings_on_cpu,
             dropout_rate=dropout_rate,
-            initializer=weights_initializer,
-            regularizer=weights_regularizer
+            embedding_initializer=weights_initializer,
+            embedding_regularizer=weights_regularizer
         )
 
         logger.debug('  FCStack')

--- a/ludwig/encoders/sequence_encoders.py
+++ b/ludwig/encoders/sequence_encoders.py
@@ -191,8 +191,8 @@ class SequenceEmbedEncoder(Layer):
             pretrained_embeddings=pretrained_embeddings,
             embeddings_on_cpu=embeddings_on_cpu,
             dropout_rate=dropout_rate,
-            initializer=weights_initializer,
-            regularizer=weights_regularizer
+            embedding_initializer=weights_initializer,
+            embedding_regularizer=weights_regularizer
         )
 
     def call(self, inputs, training=None, mask=None):
@@ -440,8 +440,8 @@ class ParallelCNN(Layer):
                 pretrained_embeddings=pretrained_embeddings,
                 embeddings_on_cpu=embeddings_on_cpu,
                 dropout_rate=dropout_rate,
-                initializer=weights_initializer,
-                regularizer=weights_regularizer
+                embedding_initializer=weights_initializer,
+                embedding_regularizer=weights_regularizer
             )
 
         logger.debug('  ParallelConv1D')
@@ -786,8 +786,8 @@ class StackedCNN(Layer):
                 pretrained_embeddings=pretrained_embeddings,
                 embeddings_on_cpu=embeddings_on_cpu,
                 dropout_rate=dropout_rate,
-                initializer=weights_initializer,
-                regularizer=weights_regularizer
+                embedding_initializer=weights_initializer,
+                embedding_regularizer=weights_regularizer
             )
 
         logger.debug('  Conv1DStack')
@@ -1132,8 +1132,8 @@ class StackedParallelCNN(Layer):
                 pretrained_embeddings=pretrained_embeddings,
                 embeddings_on_cpu=embeddings_on_cpu,
                 dropout_rate=dropout_rate,
-                initializer=weights_initializer,
-                regularizer=weights_regularizer
+                embedding_initializer=weights_initializer,
+                embedding_regularizer=weights_regularizer
             )
 
         logger.debug('  ParallelConv1DStack')
@@ -1409,8 +1409,8 @@ class StackedRNN(Layer):
                 pretrained_embeddings=pretrained_embeddings,
                 embeddings_on_cpu=embeddings_on_cpu,
                 dropout_rate=fc_dropout_rate,
-                initializer=weights_initializer,
-                regularizer=weights_regularizer
+                embedding_initializer=weights_initializer,
+                embedding_regularizer=weights_regularizer
             )
 
         logger.debug('  RecurrentStack')
@@ -1689,8 +1689,8 @@ class StackedCNNRNN(Layer):
                 pretrained_embeddings=pretrained_embeddings,
                 embeddings_on_cpu=embeddings_on_cpu,
                 dropout_rate=fc_dropout_rate,
-                initializer=weights_initializer,
-                regularizer=weights_regularizer
+                embedding_initializer=weights_initializer,
+                embedding_regularizer=weights_regularizer
             )
 
         logger.debug('  Conv1DStack')

--- a/ludwig/encoders/set_encoders.py
+++ b/ludwig/encoders/set_encoders.py
@@ -64,8 +64,8 @@ class SetSparseEncoder(Layer):
             pretrained_embeddings=pretrained_embeddings,
             embeddings_on_cpu=embeddings_on_cpu,
             dropout_rate=dropout_rate,
-            initializer=weights_initializer,
-            regularizer=weights_regularizer,
+            embedding_initializer=weights_initializer,
+            embedding_regularizer=weights_regularizer,
             reduce_output=reduce_output,
         )
 

--- a/ludwig/modules/embedding_modules.py
+++ b/ludwig/modules/embedding_modules.py
@@ -203,8 +203,8 @@ class EmbedWeighted(Layer):
         self.vocab_length = len(vocab)
 
         if regularizer:
-            regularizer_obj = tf.keras.regularizers.get(regularizer)()
-            self.add_loss(regularizer_obj(self.embeddings))
+            regularizer_obj = tf.keras.regularizers.get(regularizer)
+            self.add_loss(lambda: regularizer_obj(self.embeddings))
 
         if dropout_rate > 0:
             self.dropout = Dropout(dropout_rate)
@@ -263,8 +263,8 @@ class EmbedSparse(Layer):
         )
 
         if regularizer:
-            regularizer_obj = tf.keras.regularizers.get(regularizer)()
-            self.add_loss(regularizer_obj(self.embeddings))
+            regularizer_obj = tf.keras.regularizers.get(regularizer)
+            self.add_loss(lambda: regularizer_obj(self.embeddings))
 
         if dropout_rate > 0:
             self.dropout = Dropout(dropout_rate)
@@ -326,8 +326,8 @@ class EmbedSequence(Layer):
         )
 
         if regularizer:
-            regularizer_obj = tf.keras.regularizers.get(regularizer)()
-            self.add_loss(regularizer_obj(self.embeddings))
+            regularizer_obj = tf.keras.regularizers.get(regularizer)
+            self.add_loss(lambda: regularizer_obj(self.embeddings))
 
         if dropout_rate > 0:
             self.dropout = Dropout(dropout_rate)

--- a/ludwig/modules/embedding_modules.py
+++ b/ludwig/modules/embedding_modules.py
@@ -33,7 +33,7 @@ def embedding_matrix(
         embeddings_trainable=True,
         pretrained_embeddings=None,
         force_embedding_size=False,
-        initializer=None,
+        embedding_initializer=None,
 ):
     vocab_size = len(vocab)
     if representation == 'dense':
@@ -49,7 +49,7 @@ def embedding_matrix(
                         embeddings_matrix.shape[-1],
                         embedding_size
                     ))
-            initializer_obj = tf.constant(embeddings_matrix, dtype=tf.float32)
+            embedding_initializer_obj = tf.constant(embeddings_matrix, dtype=tf.float32)
 
         else:
             if vocab_size < embedding_size and not force_embedding_size:
@@ -60,15 +60,15 @@ def embedding_matrix(
                     ))
                 embedding_size = vocab_size
 
-            if initializer is not None:
-                initializer_obj_ref = get_initializer(initializer)
+            if embedding_initializer is not None:
+                embedding_initializer_obj_ref = get_initializer(embedding_initializer)
             else:
-                initializer_obj_ref = get_initializer(
+                embedding_initializer_obj_ref = get_initializer(
                     {'type': 'uniform', 'minval': -1.0, 'maxval': 1.0})
-            initializer_obj = initializer_obj_ref([vocab_size, embedding_size])
+            embedding_initializer_obj = embedding_initializer_obj_ref([vocab_size, embedding_size])
 
         embeddings = tf.Variable(
-            initializer_obj,
+            embedding_initializer_obj,
             trainable=embeddings_trainable,
             name='embeddings'
         )
@@ -97,7 +97,7 @@ def embedding_matrix_on_device(
         pretrained_embeddings=None,
         force_embedding_size=False,
         embeddings_on_cpu=False,
-        initializer=None
+        embedding_initializer=None
 ):
     if embeddings_on_cpu:
         with tf.device('/cpu:0'):
@@ -108,7 +108,7 @@ def embedding_matrix_on_device(
                 embeddings_trainable=embeddings_trainable,
                 pretrained_embeddings=pretrained_embeddings,
                 force_embedding_size=force_embedding_size,
-                initializer=initializer
+                embedding_initializer=embedding_initializer
             )
     else:
         embeddings, embedding_size = embedding_matrix(
@@ -118,7 +118,7 @@ def embedding_matrix_on_device(
             embeddings_trainable=embeddings_trainable,
             pretrained_embeddings=pretrained_embeddings,
             force_embedding_size=force_embedding_size,
-            initializer=initializer
+            embedding_initializer=embedding_initializer
         )
 
     # logger.debug('  embeddings: {0}'.format(embeddings))
@@ -137,8 +137,8 @@ class Embed(Layer):
             force_embedding_size=False,
             embeddings_on_cpu=False,
             dropout_rate=0.0,
-            initializer=None,
-            regularizer=None
+            embedding_initializer=None,
+            embedding_regularizer=None
     ):
         super(Embed, self).__init__()
         self.supports_masking = True
@@ -151,12 +151,12 @@ class Embed(Layer):
             pretrained_embeddings=pretrained_embeddings,
             force_embedding_size=force_embedding_size,
             embeddings_on_cpu=embeddings_on_cpu,
-            initializer=initializer,
+            embedding_initializer=embedding_initializer,
         )
 
-        if regularizer:
-            regularizer_obj = tf.keras.regularizers.get(regularizer)
-            self.add_loss(lambda: regularizer_obj(self.embeddings))
+        if embedding_regularizer:
+            embedding_regularizer_obj = tf.keras.regularizers.get(embedding_regularizer)
+            self.add_loss(lambda: embedding_regularizer_obj(self.embeddings))
 
         if dropout_rate > 0:
             self.dropout = Dropout(dropout_rate)
@@ -185,8 +185,8 @@ class EmbedWeighted(Layer):
             force_embedding_size=False,
             embeddings_on_cpu=False,
             dropout_rate=0.0,
-            initializer=None,
-            regularizer=None
+            embedding_initializer=None,
+            embedding_regularizer=None
     ):
         super(EmbedWeighted, self).__init__()
 
@@ -198,13 +198,13 @@ class EmbedWeighted(Layer):
             pretrained_embeddings=pretrained_embeddings,
             force_embedding_size=force_embedding_size,
             embeddings_on_cpu=embeddings_on_cpu,
-            initializer=initializer,
+            embedding_initializer=embedding_initializer,
         )
         self.vocab_length = len(vocab)
 
-        if regularizer:
-            regularizer_obj = tf.keras.regularizers.get(regularizer)
-            self.add_loss(lambda: regularizer_obj(self.embeddings))
+        if embedding_regularizer:
+            embedding_regularizer_obj = tf.keras.regularizers.get(embedding_regularizer)
+            self.add_loss(lambda: embedding_regularizer_obj(self.embeddings))
 
         if dropout_rate > 0:
             self.dropout = Dropout(dropout_rate)
@@ -245,8 +245,8 @@ class EmbedSparse(Layer):
             force_embedding_size=False,
             embeddings_on_cpu=False,
             dropout_rate=0.0,
-            initializer=None,
-            regularizer=None,
+            embedding_initializer=None,
+            embedding_regularizer=None,
             reduce_output='sum'
     ):
         super(EmbedSparse, self).__init__()
@@ -259,12 +259,12 @@ class EmbedSparse(Layer):
             pretrained_embeddings=pretrained_embeddings,
             force_embedding_size=force_embedding_size,
             embeddings_on_cpu=embeddings_on_cpu,
-            initializer=initializer,
+            embedding_initializer=embedding_initializer,
         )
 
-        if regularizer:
-            regularizer_obj = tf.keras.regularizers.get(regularizer)
-            self.add_loss(lambda: regularizer_obj(self.embeddings))
+        if embedding_regularizer:
+            embedding_regularizer_obj = tf.keras.regularizers.get(embedding_regularizer)
+            self.add_loss(lambda: embedding_regularizer_obj(self.embeddings))
 
         if dropout_rate > 0:
             self.dropout = Dropout(dropout_rate)
@@ -308,8 +308,8 @@ class EmbedSequence(Layer):
             force_embedding_size=False,
             embeddings_on_cpu=False,
             dropout_rate=0.0,
-            initializer=None,
-            regularizer=None
+            embedding_initializer=None,
+            embedding_regularizer=None
     ):
         super(EmbedSequence, self).__init__()
         self.supports_masking = True
@@ -322,12 +322,12 @@ class EmbedSequence(Layer):
             pretrained_embeddings=pretrained_embeddings,
             force_embedding_size=force_embedding_size,
             embeddings_on_cpu=embeddings_on_cpu,
-            initializer=initializer,
+            embedding_initializer=embedding_initializer,
         )
 
-        if regularizer:
-            regularizer_obj = tf.keras.regularizers.get(regularizer)
-            self.add_loss(lambda: regularizer_obj(self.embeddings))
+        if embedding_regularizer:
+            embedding_regularizer_obj = tf.keras.regularizers.get(embedding_regularizer)
+            self.add_loss(lambda: embedding_regularizer_obj(self.embeddings))
 
         if dropout_rate > 0:
             self.dropout = Dropout(dropout_rate)

--- a/ludwig/modules/loss_modules.py
+++ b/ludwig/modules/loss_modules.py
@@ -458,20 +458,6 @@ def mean_squared_error(y, y_hat, weight=1.0):
     return tf.reduce_mean(tf.multiply(squared_loss(y, y_hat), weight))
 
 
-# todo tf2: TF2 requires regularization to be done at init time
-#  so this dictionary is useless, remove it and fix the tests that use it
-# regularizer_registry = {'l1': tf2.keras.regularizers.l1,
-#                         'l2': tf2.keras.regularizers.l2,
-#                         'l1_l2': tf2.keras.regularizers.l1_l2,
-#                         'None': lambda x: None,
-#                         None: lambda x: None}
-regularizer_registry = {'l1': lambda x: None,
-                        'l2': lambda x: None,
-                        'l1_l2': lambda x: None,
-                        'None': lambda x: None,
-                        None: lambda x: None}
-
-
 def sample_values_from_classes(labels, sampler, num_classes, negative_samples,
                                unique, class_counts, distortion):
     """returns sampled_values using the chosen sampler"""

--- a/tests/integration_tests/test_model_training_options.py
+++ b/tests/integration_tests/test_model_training_options.py
@@ -8,12 +8,16 @@ import pandas as pd
 import pytest
 from sklearn.model_selection import train_test_split
 
+import tensorflow as tf
+
 from ludwig.experiment import full_experiment
 from ludwig.utils.data_utils import load_json
 
+RANDOM_SEED = 42
+NUMBER_OBSERVATIONS = 500
+
 GeneratedData = namedtuple('GeneratedData',
                            'train_df validation_df test_df')
-
 
 def get_feature_definitions():
     input_features = [
@@ -32,7 +36,7 @@ def get_feature_definitions():
 def generated_data():
     # function generates simple training data that guarantee convergence
     # within 30 epochs for suitable model definition
-    NUMBER_OBSERVATIONS = 500
+
 
     # generate data
     np.random.seed(43)
@@ -325,3 +329,78 @@ def test_optimizers(optimizer_type, generated_data, tmp_path):
 
     # ensure train loss for last epoch is less than first epoch
     assert train_losses[last_epoch - 1] < train_losses[0]
+
+
+def test_regularization(generated_data, tmp_path):
+    input_features, output_features = get_feature_definitions()
+
+    model_definition = {
+        'input_features': input_features,
+        'output_features': output_features,
+        'combiner': {
+            'type': 'concat'
+        },
+        'training': {
+            'epochs': 5,
+            'batch_size': 16,
+            'regularization_lambda': 1
+        }
+    }
+
+
+    # create sub-directory to store results
+    results_dir = tmp_path / 'results'
+    results_dir.mkdir()
+
+    regularization_losses = []
+    for regularizer in [None, 'l1', 'l2', 'l1_l2']:
+        tf.keras.backend.clear_session()
+        np.random.seed(RANDOM_SEED)
+        tf.random.set_seed(RANDOM_SEED)
+
+        # setup regularization parameters
+        model_definition['output_features'][0]['weights_regularizer'] = regularizer
+        model_definition['output_features'][0]['bias_regularizer'] = regularizer
+        model_definition['output_features'][0]['activity_regularizer'] = regularizer
+
+        # run experiment
+        exp_dir_name = full_experiment(
+            data_train_df=generated_data.train_df,
+            data_validation_df=generated_data.validation_df,
+            data_test_df=generated_data.test_df,
+            output_directory=str(results_dir),
+            model_definition=model_definition,
+            experiment_name='regularization',
+            model_name=str(regularizer),
+            skip_save_processed_input=True,
+            skip_save_progress=True,
+            skip_save_unprocessed_output=True,
+            skip_save_model=True,
+            skip_save_log=True
+        )
+
+        # test existence of required files
+        train_stats_fp = os.path.join(exp_dir_name, 'training_statistics.json')
+        metadata_fp = os.path.join(exp_dir_name, 'description.json')
+        assert os.path.isfile(train_stats_fp)
+        assert os.path.isfile(metadata_fp)
+
+        # retrieve results so we can compare training loss with regularization
+        with open(train_stats_fp, 'r') as f:
+            train_stats = json.load(f)
+
+        # retrieve training losses for all epochs
+        train_losses = np.array(train_stats['training']['combined']['loss'])
+        regularization_losses.append(train_losses)
+
+    # prepare for comparing training losses
+    regularization_losses = np.array(regularization_losses).T
+
+    # extract training losses w/o regularization
+    reg_loss_none = regularization_losses[:, 0].reshape(-1, 1)
+
+    # extract training losses with regularization
+    reg_loss_l1_l2_l1l2 = regularization_losses[:, 1:]
+
+    # ensure loss value for l1, l2 and l1_l2 are greater than None
+    assert np.all(reg_loss_none < reg_loss_l1_l2_l1l2)

--- a/tests/integration_tests/test_regularizers.py
+++ b/tests/integration_tests/test_regularizers.py
@@ -83,7 +83,7 @@ TestCase = namedtuple('TestCase', 'syn_data XCoder_other_parms regularizer_parm_
             SyntheticData(BATCH_SIZE, category_feature, (), {}),
             {'representation': 'dense'},
             [
-                'regularizer',
+                'embedding_regularizer',
             ]
         ),
 
@@ -216,13 +216,13 @@ def test_encoder(test_case):
             ['activity_regularizer', 'weights_regularizer', 'bias_regularizer']
         ),
 
-        # # Generator Decoder todo need to propogate regularizers to layers
-        # TestCase(
-        #     SyntheticData(BATCH_SIZE, sequence_feature, (),
-        #                   {'max_len': SEQ_SIZE}),
-        #     {'decoder': 'generator', 'cell_type': 'gru'},
-        #     ['activity_regularizer', 'weights_regularizer', 'bias_regularizer']
-        # ),
+        # Generator Decoder
+        TestCase(
+            SyntheticData(BATCH_SIZE, sequence_feature, (),
+                          {'max_len': SEQ_SIZE}),
+            {'decoder': 'generator', 'cell_type': 'gru'},
+            ['activity_regularizer', 'weights_regularizer', 'bias_regularizer']
+        ),
 
     ]
 

--- a/tests/integration_tests/test_regularizers.py
+++ b/tests/integration_tests/test_regularizers.py
@@ -16,6 +16,7 @@ from ludwig.data.preprocessing import preprocess_for_training
 from ludwig.features.feature_utils import SEQUENCE_TYPES
 from ludwig.models.ecd import build_single_input, build_single_output
 from tests.integration_tests.utils import category_feature
+from tests.integration_tests.utils import date_feature
 from tests.integration_tests.utils import numerical_feature
 from tests.integration_tests.utils import sequence_feature
 from tests.integration_tests.utils import image_feature
@@ -84,6 +85,16 @@ TestCase = namedtuple('TestCase', 'syn_data XCoder_other_parms regularizer_parm_
             {'representation': 'dense'},
             [
                 'embedding_regularizer',
+            ]
+        ),
+
+        # Date encoder
+        TestCase(
+            SyntheticData(BATCH_SIZE, date_feature, (), {}),
+            {},
+            [
+                'activity_regularizer', 'weights_regularizer',
+                'bias_regularizer',
             ]
         ),
 

--- a/tests/integration_tests/test_regularizers.py
+++ b/tests/integration_tests/test_regularizers.py
@@ -1,0 +1,172 @@
+from collections import namedtuple
+import os
+import shutil
+
+import pandas as pd
+import numpy as np
+import pytest
+
+import tensorflow as tf
+
+from ludwig.data.dataset_synthesizer import build_synthetic_dataset
+from ludwig.encoders.generic_encoders import DenseEncoder
+from ludwig.encoders.sequence_encoders import ParallelCNN
+from ludwig.data.preprocessing import preprocess_for_training
+from ludwig.features.feature_utils import SEQUENCE_TYPES
+from ludwig.models.ecd import build_single_input
+from tests.integration_tests.utils import numerical_feature
+from tests.integration_tests.utils import sequence_feature
+from tests.integration_tests.utils import image_feature
+
+
+BATCH_SIZE = 128
+RANDOM_SEED = 42
+IMAGE_DIR = '/tmp/images'
+
+# SyntheticData namedtuple structure:
+# batch_size: Number of records to generate for a batch
+# feature_generator: Ludwwig synthentic generator class
+# feature_generator_args: tuple of required positional arguments
+# feature_generator_kwargs: dictionary of required keyword arguments
+SyntheticData = namedtuple(
+    'SyntheticData',
+    'batch_size feature_generator feature_generator_args feature_generator_kwargs'
+)
+
+# TestCase namedtuple structure:
+# inputs: SyntheticData namedtuple of data to create
+# XCoder_other_parms: dictionary for required encoder/decoder parameters
+# regularizer_parm_names: list of regularizer keyword parameter names
+TestCase = namedtuple('TestCase', 'inputs XCoder_other_parms regularizer_parm_names')
+
+
+#
+# Regularization Encoder Tests
+#
+@pytest.mark.parametrize(
+    'test_case',
+    [
+        # # DenseEncoder
+        TestCase(
+            SyntheticData(BATCH_SIZE, numerical_feature,(), {}),
+            {'num_layers': 2, 'encoder': 'dense', 'preprocessing':{'normalization': 'zscore'}},
+            ['activity_regularizer', 'weights_regularizer', 'bias_regularizer']
+        ),
+
+        # Image Encoders
+        TestCase(
+            SyntheticData(BATCH_SIZE, image_feature, (IMAGE_DIR,), {}),
+            {'encoder': 'stacked_cnn'},
+            [
+                'conv_activity_regularizer', 'conv_weights_regularizer',
+                'conv_bias_regularizer',
+                'fc_activity_regularizer', 'fc_weights_regularizer',
+                'fc_bias_regularizer',
+            ]
+        ),
+        TestCase(
+            SyntheticData(BATCH_SIZE, image_feature, (IMAGE_DIR,), {}),
+            {'encoder': 'resnet'},
+            [
+                'activity_regularizer', 'weights_regularizer',
+                'bias_regularizer',
+            ]
+        ),
+
+        # ParallelCNN Encoder
+        TestCase(
+            SyntheticData(BATCH_SIZE, sequence_feature, (), {}),
+            {'encoder': 'parallel_cnn', 'cell_type': 'gru'},
+            ['activity_regularizer', 'weights_regularizer', 'bias_regularizer']
+        ),
+
+    ]
+
+)
+def test_encoder(test_case):
+    # set up required directories for images if needed
+    shutil.rmtree(IMAGE_DIR, ignore_errors=True)
+    os.mkdir(IMAGE_DIR)
+
+
+    # reproducible synthetic data set
+    np.random.seed(RANDOM_SEED)
+    tf.random.set_seed(RANDOM_SEED)
+
+    # create synthetic data for the test
+    features = [
+        test_case.inputs.feature_generator(
+            *test_case.inputs.feature_generator_args,
+            **test_case.inputs.feature_generator_kwargs
+        )
+    ]
+    feature_name = features[0]['name']
+    data_generator = build_synthetic_dataset(BATCH_SIZE, features)
+    data_list = list(data_generator)
+    raw_data = [x[0] for x in data_list[1:]]
+    df = pd.DataFrame({data_list[0][0]: raw_data})
+
+    # minimal model definition sufficient to create the input feature
+    model_definition = {'input_features': features, 'output_features': []}
+    training_set, _, _, train_set_metadata = preprocess_for_training(
+        model_definition,
+        data_train_df=df,
+        skip_save_processed_input=True,
+        random_seed=RANDOM_SEED
+    )
+
+    # run through each type of regularizer for the encoder
+    regularizer_losses = []
+    for regularizer in [None, 'l1', 'l2', 'l1_l2']:
+        # start with clean slate and make reproducible
+        tf.keras.backend.clear_session()
+        np.random.seed(RANDOM_SEED)
+        tf.random.set_seed(RANDOM_SEED)
+
+        # setup kwarg for regularizer parms
+        x_coder_kwargs = dict(
+            zip(test_case.regularizer_parm_names,
+                len(test_case.regularizer_parm_names)*[regularizer])
+        )
+
+        # combine other other keyword parameters
+        x_coder_kwargs.update(test_case.XCoder_other_parms)
+
+        features[0].update(x_coder_kwargs)
+        if features[0]['type'] in SEQUENCE_TYPES:
+            features[0]['vocab'] = train_set_metadata[feature_name]['idx2str']
+            training_set.dataset[feature_name] = \
+                training_set.dataset[feature_name].astype(np.int32)
+
+        input_def_obj = build_single_input(features[0], None)
+
+        inputs = training_set.dataset[feature_name]
+        if len(inputs.shape) == 1:
+            inputs = inputs.reshape(-1, 1)
+
+        input_def_obj.encoder_obj(inputs)
+        regularizer_loss = tf.reduce_sum(input_def_obj.encoder_obj.losses)
+        regularizer_losses.append(regularizer_loss)
+
+    # check loss regularization loss values
+    # None should be zero
+    assert regularizer_losses[0] == 0
+
+    # l1, l2 and l1_l2 should be greater than zero
+    assert np.all([t > 0.0 for t in regularizer_losses[1:]])
+
+    # # using default setting l1 + l2 == l1_l2 losses
+    assert np.isclose(regularizer_losses[1].numpy() + regularizer_losses[2].numpy(),
+                      regularizer_losses[3].numpy())
+
+    # cleanup
+    shutil.rmtree(IMAGE_DIR, ignore_errors=True)
+
+
+
+
+
+
+
+
+

--- a/tests/ludwig/modules/test_encoder.py
+++ b/tests/ludwig/modules/test_encoder.py
@@ -26,12 +26,11 @@ from ludwig.encoders.sequence_encoders import StackedCNN
 from ludwig.encoders.sequence_encoders import StackedCNNRNN
 from ludwig.encoders.sequence_encoders import StackedParallelCNN
 from ludwig.encoders.sequence_encoders import StackedRNN
-from ludwig.modules.loss_modules import regularizer_registry
 
 # todo tf2: fix these tests to work with the TF2 way
 #  of doing regularization at init time
-L1_REGULARIZER = regularizer_registry['l1'](0.1)
-L2_REGULARIZER = regularizer_registry['l2'](0.1)
+L1_REGULARIZER = 'l1'
+L2_REGULARIZER = 'l2'
 NO_REGULARIZER = None
 DROPOUT_RATE = 0.5
 
@@ -71,8 +70,6 @@ def generate_random_sentences(num_sentences=10, max_len=10, vocab_size=10):
 def encoder_test(
         encoder,
         input_data,
-        regularizer,
-        dropout_rate,
         output_dtype,
         output_shape,
         output_data=None,
@@ -81,8 +78,6 @@ def encoder_test(
     Helper method to test different kinds of encoders
     :param encoder: encoder object
     :param input_data: data to encode
-    :param regularizer: regularizer
-    :param dropout_rate: dropout rate
     :param output_dtype: expected data type of the output (optional)
     :param output_shape: expected shape of the encoder output (optional)
     :param output_data: expected output data (optional)
@@ -107,7 +102,13 @@ def encoder_test(
 
 def test_image_encoders_resnet():
     # Test the resnet encoder for images
-    encoder_args = {'resnet_size': 8, 'num_filters': 8, 'fc_size': 28}
+    encoder_args = {
+        'resnet_size': 8, 'num_filters': 8, 'fc_size': 28,
+        'weights_regularizer': L1_REGULARIZER,
+        'bias_regularizer': L1_REGULARIZER,
+        'activity_regularizer': L1_REGULARIZER,
+        'dropout_rate': DROPOUT_RATE
+    }
     image_size = (10, 10, 3)
 
     output_shape = [1, 28]
@@ -117,8 +118,6 @@ def test_image_encoders_resnet():
     encoder_test(
         encoder=encoder,
         input_data=input_image,
-        regularizer=L1_REGULARIZER,
-        dropout_rate=DROPOUT_RATE,
         output_dtype=np.float,
         output_shape=output_shape,
         output_data=None
@@ -130,8 +129,6 @@ def test_image_encoders_resnet():
     encoder_test(
         encoder=encoder,
         input_data=input_images,
-        regularizer=L1_REGULARIZER,
-        dropout_rate=DROPOUT_RATE,
         output_dtype=np.float,
         output_shape=output_shape,
         output_data=None
@@ -151,7 +148,17 @@ def test_image_encoders_resnet():
 
 def test_image_encoders_stacked_2dcnn():
     # Test the resnet encoder for images
-    encoder_args = {'num_conv_layers': 2, 'num_filters': 16, 'fc_size': 28}
+    encoder_args = {
+        'num_conv_layers': 2, 'num_filters': 16, 'fc_size': 28,
+        'conv_activity_regularizer': L1_REGULARIZER,
+        'conv_weights_regularizer': L1_REGULARIZER,
+        'conv_bias_regularizer': L1_REGULARIZER,
+        'fc_activity_regularizer': L1_REGULARIZER,
+        'fc_weights_regularizer': L1_REGULARIZER,
+        'fc_bias_regularizer': L1_REGULARIZER,
+        'dropout_rate': DROPOUT_RATE
+
+    }
     image_size = (10, 10, 3)
 
     encoder = create_encoder(Stacked2DCNN, encoder_args)
@@ -175,8 +182,6 @@ def test_image_encoders_stacked_2dcnn():
     encoder_test(
         encoder=encoder,
         input_data=input_image,
-        regularizer=L1_REGULARIZER,
-        dropout_rate=DROPOUT_RATE,
         output_dtype=np.float,
         output_shape=output_shape,
         output_data=None
@@ -188,8 +193,6 @@ def test_image_encoders_stacked_2dcnn():
     encoder_test(
         encoder=encoder,
         input_data=input_images,
-        regularizer=L1_REGULARIZER,
-        dropout_rate=DROPOUT_RATE,
         output_dtype=np.float,
         output_shape=output_shape,
         output_data=None
@@ -222,23 +225,21 @@ def test_sequence_encoder_embed():
 
             encoder_args['reduce_output'] = reduce_output
             encoder_args['embeddings_trainable'] = trainable
+            encoder_args['weights_regularizer'] = L1_REGULARIZER
+            encoder_args['dropout_rate'] = DROPOUT_RATE
             encoder = create_encoder(SequenceEmbedEncoder, encoder_args)
 
             encoder_test(
                 encoder=encoder,
                 input_data=text,
-                regularizer=L1_REGULARIZER,
-                dropout_rate=DROPOUT_RATE,
                 output_dtype=np.float,
                 output_shape=output_shape,
                 output_data=None
             )
 
             embed = encoder.embed_sequence.embeddings
-            # assert embed.representation == 'dense'
             assert embed.trainable == trainable
-            # assert embed.regularize is True
-            assert encoder.embed_sequence.dropout is None
+            assert encoder.embed_sequence.dropout is not None
 
 
 def test_sequence_encoders():
@@ -281,13 +282,18 @@ def test_sequence_encoders():
                                  StackedCNNRNN]:
                 encoder_args['reduce_output'] = reduce_output
                 encoder_args['embeddings_trainable'] = trainable
+                encoder_args['weights_regularizer'] = L1_REGULARIZER
+                encoder_args['bias_regularizer'] = L1_REGULARIZER
+                encoder_args['activity_regularizer'] = L1_REGULARIZER
+                encoder_args['dropout_rate'] = DROPOUT_RATE
+                encoder_args['dropout'] = DROPOUT_RATE
+                encoder_args['recurrent_dropout_rate'] = DROPOUT_RATE
+                encoder_args['fc_dropout_rate'] = DROPOUT_RATE
                 encoder = create_encoder(encoder_type, encoder_args)
 
                 encoder_test(
                     encoder=encoder,
                     input_data=text,
-                    regularizer=L1_REGULARIZER,
-                    dropout_rate=DROPOUT_RATE,
                     output_dtype=np.float,
                     output_shape=output_shape,
                     output_data=None

--- a/tests/ludwig/modules/test_encoder.py
+++ b/tests/ludwig/modules/test_encoder.py
@@ -27,8 +27,6 @@ from ludwig.encoders.sequence_encoders import StackedCNNRNN
 from ludwig.encoders.sequence_encoders import StackedParallelCNN
 from ludwig.encoders.sequence_encoders import StackedRNN
 
-# todo tf2: fix these tests to work with the TF2 way
-#  of doing regularization at init time
 L1_REGULARIZER = 'l1'
 L2_REGULARIZER = 'l2'
 NO_REGULARIZER = None


### PR DESCRIPTION
# Code Pull Requests

This is the start for the regularizer unit tests.  This is the 'micro' version that tests encoder/decoder.  For each encoder/decoder, the test cycles through `None`, `l1`, `l2` and `l1_l2` as regularizer settings.   After cycling through the regularizer settings, various tests are done on the regularizer losses.  Additional unit tests are specified by adding entries to the `@pytest.mark.parametrize` decorator arguments.  

This current test covers:
* Input features: numerical and images
* output features numerical

Let me know if this approach looks reasonable.  If looks OK, I'll work on adding more encoders/decoders for other features.

While working on this, I noted some items to discuss.  I'll send a separate note.

Here is an example of a test run
```
pytest -v /opt/project/tests/integration_tests/test_regularizers.py
=========================================================== test session starts ============================================================
platform linux -- Python 3.6.9, pytest-6.0.1, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /opt/project
plugins: xdist-1.34.0, forked-1.3.0, pycharm-0.6.0, typeguard-2.9.1
collected 5 items

../../../tests/integration_tests/test_regularizers.py::test_encoder[test_case0] PASSED                                               [ 20%]
../../../tests/integration_tests/test_regularizers.py::test_encoder[test_case1] PASSED                                               [ 40%]
../../../tests/integration_tests/test_regularizers.py::test_encoder[test_case2] PASSED                                               [ 60%]
../../../tests/integration_tests/test_regularizers.py::test_encoder[test_case3] FAILED                                               [ 80%]
../../../tests/integration_tests/test_regularizers.py::test_decoder[test_case0] PASSED                                               [100%]

================================================================= FAILURES =================================================================

<<<<<<<<<<<<<<<<<<<< deleted lines>>>>>>>>>>>>>>>>>>>>>>>>>>>

../../../tests/integration_tests/test_regularizers.py:144:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../../../ludwig/models/ecd.py:253: in build_single_input
    input_feature_obj = input_feature_class(input_feature_def, encoder_obj)
../../../ludwig/features/sequence_feature.py:133: in __init__
    self.encoder_obj = self.initialize_encoder(feature)
../../../ludwig/features/base_feature.py:91: in initialize_encoder
    **encoder_parameters
../../../ludwig/encoders/sequence_encoders.py:444: in __init__
    regularizer=weights_regularizer
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <ludwig.modules.embedding_modules.EmbedSequence object at 0x7f5ee7a744a8>
vocab = ['<PAD>', '<UNK>', 'iPwNFJOkF', 'NXgGudoNfz', 'xvKwhK', 'QeAHd', ...], embedding_size = 8, representation = 'dense'
embeddings_trainable = True, pretrained_embeddings = None, force_embedding_size = False, embeddings_on_cpu = False, dropout_rate = 0
initializer = 'glorot_uniform', regularizer = 'l1'

    def __init__(
            self,
            vocab,
            embedding_size,
            representation='dense',
            embeddings_trainable=True,
            pretrained_embeddings=None,
            force_embedding_size=False,
            embeddings_on_cpu=False,
            dropout_rate=0.0,
            initializer=None,
            regularizer=None
    ):
        super(EmbedSequence, self).__init__()
        self.supports_masking = True

        self.embeddings, self.embedding_size = embedding_matrix_on_device(
            vocab,
            embedding_size,
            representation=representation,
            embeddings_trainable=embeddings_trainable,
            pretrained_embeddings=pretrained_embeddings,
            force_embedding_size=force_embedding_size,
            embeddings_on_cpu=embeddings_on_cpu,
            initializer=initializer,
        )

        if regularizer:
>           regularizer_obj = tf.keras.regularizers.get(regularizer)()
E           TypeError: __call__() missing 1 required positional argument: 'x'

../../../ludwig/modules/embedding_modules.py:329: TypeError
----------------------------------------------------------- Captured stdout call -----------------------------------------------------------
Using training dataframe
Building dataset (it may take a while)
------------------------------------------------------------ Captured log call -------------------------------------------------------------
INFO     ludwig.data.preprocessing:preprocessing.py:735 Using training dataframe
INFO     ludwig.data.preprocessing:preprocessing.py:736 Building dataset (it may take a while)
============================================================= warnings summary =============================================================
/opt/project/tests/integration_tests/test_regularizers.py:0
  /opt/project/tests/integration_tests/test_regularizers.py:0: PytestCollectionWarning: cannot collect test class 'TestCase' because it has a __new__ constructor (from: tests/integration_tests/test_regularizers.py)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
========================================================= short test summary info ==========================================================
FAILED ../../../tests/integration_tests/test_regularizers.py::test_encoder[test_case3] - TypeError: __call__() missing 1 required positio...
================================================== 1 failed, 4 passed, 1 warning in 3.17s ==================================================
```

One of the items I'd like to discuss is how to resolve the one failure.
