### PR TITLE
Port collect_weights to TensorFlow 2

### DIFF
--- a/ludwig/collect.py
+++ b/ludwig/collect.py
@@ -113,8 +113,6 @@ def collect_activations(
         batch_size
     )
 
-    model.close_session()
-
     # saving
     os.makedirs(experiment_dir_name)
     save_tensors(collected_tensors, experiment_dir_name)
@@ -141,22 +139,25 @@ def collect_weights(
     # collect weights
     print_boxed('COLLECT WEIGHTS')
     collected_tensors = model.collect_weights(tensors)
-    model.close_session()
 
     # saving
     os.makedirs(experiment_dir_name)
-    save_tensors(collected_tensors, experiment_dir_name)
+    saved_filenames = save_tensors(collected_tensors, experiment_dir_name)
 
     logger.info('Saved to: {0}'.format(experiment_dir_name))
+    return saved_filenames
 
 
 def save_tensors(collected_tensors, experiment_dir_name):
-    for tensor_name, tensor_values in collected_tensors.items():
+    filenames = []
+    for tensor_name, tensor_value in collected_tensors:
         np_filename = os.path.join(
             experiment_dir_name,
             make_safe_filename(tensor_name) + '.npy'
         )
-        np.save(np_filename, tensor_values)
+        np.save(np_filename, tensor_value.numpy())
+        filenames.append(np_filename)
+    return filenames
 
 
 def cli_collect_activations(sys_argv):

--- a/ludwig/collect.py
+++ b/ludwig/collect.py
@@ -160,6 +160,17 @@ def save_tensors(collected_tensors, experiment_dir_name):
     return filenames
 
 
+def print_weight_names(
+        model_path,
+        **kwargs
+):
+    model, model_definition = load_model_and_definition(model_path)
+    collected_tensors = model.collect_weights()
+    names = [name for name, w in collected_tensors]
+    for name in names:
+        print(name)
+
+
 def cli_collect_activations(sys_argv):
     """Command Line Interface to communicate with the collection of tensors and
     there are several options that can specified when calling this function:
@@ -368,6 +379,53 @@ def cli_collect_weights(sys_argv):
     collect_weights(**vars(args))
 
 
+def cli_collect_names(sys_argv):
+    """Command Line Interface to collecting the weight names of the model
+    --m: Input model that is necessary to collect to the tensors, this is a
+         required *option*
+    --v: Verbose: Defines the logging level that the user will be exposed to
+    """
+    parser = argparse.ArgumentParser(
+        description='This script loads a pretrained model '
+                    'and uses it collect weight names.',
+        prog='ludwig collect_names',
+        usage='%(prog)s [options]'
+    )
+
+    # ----------------
+    # Model parameters
+    # ----------------
+    parser.add_argument(
+        '-m',
+        '--model_path',
+        help='model to load',
+        required=True
+    )
+
+    # ------------------
+    # Runtime parameters
+    # ------------------
+    parser.add_argument(
+        '-l',
+        '--logging_level',
+        default='info',
+        help='the level of logging to use',
+        choices=['critical', 'error', 'warning', 'info', 'debug', 'notset']
+    )
+
+    args = parser.parse_args(sys_argv)
+
+    logging.getLogger('ludwig').setLevel(
+        logging_level_registry[args.logging_level]
+    )
+    global logger
+    logger = logging.getLogger('ludwig.collect')
+
+    print_ludwig('Collect Names', LUDWIG_VERSION)
+
+    print_weight_names(**vars(args))
+
+
 if __name__ == '__main__':
     if len(sys.argv) > 1:
         if sys.argv[1] == 'activations':
@@ -376,6 +434,9 @@ if __name__ == '__main__':
         elif sys.argv[1] == 'weights':
             contrib_command("collect_weights", *sys.argv)
             cli_collect_weights(sys.argv[2:])
+        elif sys.argv[1] == 'names':
+            contrib_command("collect_names", *sys.argv)
+            cli_collect_names(sys.argv[2:])
         else:
             print('Unrecognized command')
     else:

--- a/tests/integration_tests/test_collect.py
+++ b/tests/integration_tests/test_collect.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import os
+import shutil
+import tempfile
+
+import numpy as np
+import tensorflow as tf
+
+from ludwig.api import LudwigModel
+from ludwig.collect import collect_weights
+
+from tests.integration_tests.utils import category_feature, generate_data, sequence_feature, \
+    ENCODERS
+
+
+def _prepare_data(csv_filename):
+    # Single sequence input, single category output
+    input_features = [sequence_feature(reduce_output='sum')]
+    output_features = [category_feature(vocab_size=2, reduce_input='sum')]
+
+    input_features[0]['encoder'] = ENCODERS[0]
+
+    # Generate test data
+    data_csv = generate_data(input_features, output_features, csv_filename)
+    return input_features, output_features, data_csv
+
+
+def _train(input_features, output_features, data_csv, **kwargs):
+    model_definition = {
+        'input_features': input_features,
+        'output_features': output_features,
+        'combiner': {'type': 'concat', 'fc_size': 14},
+        'training': {'epochs': 2}
+    }
+
+    model = LudwigModel(model_definition)
+    model.train(
+        data_csv=data_csv,
+        **kwargs
+    )
+    return model
+
+
+def test_collect_weights(csv_filename):
+    model = None
+    try:
+        # This will reset the layer numbering scheme TensorFlow uses.
+        # Otherwise, when we load the model, its layer names will be appended
+        # with "_1".
+        tf.keras.backend.reset_uids()
+
+        model = _train(*_prepare_data(csv_filename))
+        model_path = os.path.join(model.exp_dir_name, 'model')
+
+        weights = model.model.collect_weights()
+        assert len(weights) == 11
+
+        tensors = [name for name, w in weights[:5]]
+        assert len(tensors) == 5
+
+        tf.keras.backend.reset_uids()
+        with tempfile.TemporaryDirectory() as output_directory:
+            filenames = collect_weights(model_path, tensors, output_directory)
+            assert len(filenames) == 5
+
+            for (name, weight), filename in zip(weights[:5], filenames):
+                saved_weight = np.load(filename)
+                assert np.allclose(weight.numpy(), saved_weight), name
+    finally:
+        if model and model.exp_dir_name:
+            shutil.rmtree(model.exp_dir_name, ignore_errors=True)


### PR DESCRIPTION
This PR ports the weight collection API to TensorFlow 2 and provides a new CLI command `ludwig collect names` that allows the user to get the unique names for each weight in the model (for selection).

Activations will be handled in a follow-up PR, as changes need to be made to be made to the model to incorporate Input and Output layers for this to work.