### PR TITLE
Unpin pydantic to support fastapi 0.61.0

### DIFF
--- a/requirements_serve.txt
+++ b/requirements_serve.txt
@@ -1,5 +1,5 @@
 uvicorn
 fastapi
-pydantic==0.32.2
+pydantic
 python-multipart
 neuropod


### PR DESCRIPTION
FastAPI 0.61.0 requires pydantic >= 1.0.