### PR TITLE
Enabled debugging with TensorFlow 2

### DIFF
--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -383,13 +383,16 @@ class Trainer:
                     )
                 )
 
-        # todo tf2: reintroduce debugging mode
-        # if self.debug:
-        #    session = tf_debug.LocalCLIDebugWrapperSession(session)
-        #    session.add_tensor_filter(
-        #        'has_inf_or_nan',
-        #        tf_debug.has_inf_or_nan
-        #    )
+        if self._debug and is_on_master():
+            # See https://www.tensorflow.org/tensorboard/debugger_v2 for usage.
+            debug_path = os.path.join(
+                save_path, 'debug'
+            )
+            tf.debugging.experimental.enable_dump_debug_info(
+                debug_path,
+                tensor_debug_mode='FULL_HEALTH',
+                circular_buffer_size=-1,
+            )
 
         # ================ Resume logic ================
         if resume:


### PR DESCRIPTION
This debugging feature replaces TensorFlow v1 debug session.  When enabled, allows the user to visually debug the graph execution in Tensorboard:

```
tensorboard --logdir experiment_name/model/debug
```

See https://www.tensorflow.org/tensorboard/debugger_v2 for more details.

Caveats:
1. Tensorboard visualization only works with Tensorboard 2.3 and above.
2. Graph tracing still does not work due to https://github.com/tensorflow/tensorflow/issues/39008.