### PR TITLE
TF2 porting: Refactor custom metrics R2Score and ErrorScore

### DIFF
--- a/tests/integration_tests/test_custom_metrics.py
+++ b/tests/integration_tests/test_custom_metrics.py
@@ -1,0 +1,103 @@
+from collections import namedtuple
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import tensorflow as tf
+
+from sklearn.model_selection import train_test_split
+
+from ludwig.modules.metric_modules import R2Score, ErrorScore
+
+RANDOM_SEED = 42
+NUMBER_OBSERVATIONS = 500
+SPLIT_POINT = NUMBER_OBSERVATIONS // 2
+
+GeneratedData = namedtuple('GeneratedData',
+                           'y_true y_good y_bad')
+@pytest.fixture()
+def generated_data():
+    np.random.seed(RANDOM_SEED)
+
+    # generate synthetic true values
+    y_true = np.array(range(NUMBER_OBSERVATIONS)).astype(np.float32).reshape(-1, 1)
+
+    # generate synthetic good predictions
+    y_good = y_true + np.random.normal(size=y_true.shape[0]).reshape(-1, 1)
+
+    # generate synthetic bad predictions
+    y_bad = y_true + 146 * np.random.normal(size=y_true.shape[0]).reshape(-1, 1)
+
+    return GeneratedData(y_true=y_true, y_good=y_good, y_bad=y_bad)
+
+
+def test_R2Score(generated_data):
+    r2_score = R2Score()
+
+    assert np.isnan(r2_score.result().numpy())
+
+    # test as single batch
+    r2_score.update_state(generated_data.y_true, generated_data.y_good)
+    good_single_batch = r2_score.result().numpy()
+    assert np.isreal(good_single_batch)
+
+    # test as two batches
+    r2_score.reset_states()
+    r2_score.update_state(generated_data.y_true[:SPLIT_POINT],
+                    generated_data.y_good[:SPLIT_POINT])
+    r2_score.update_state(generated_data.y_true[SPLIT_POINT:],
+                    generated_data.y_good[SPLIT_POINT:])
+    good_two_batch = r2_score.result().numpy()
+    assert np.isreal(good_two_batch)
+
+    # single batch and multi-batch should be very close
+    assert np.isclose(good_single_batch, good_two_batch)
+
+    # good predictions should be close to 1
+    assert np.abs(1.0 - good_two_batch) < 1e-3
+
+    # test for bad predictions
+    r2_score.reset_states()
+    r2_score.update_state(generated_data.y_true[:SPLIT_POINT],
+                    generated_data.y_bad[:SPLIT_POINT])
+    r2_score.update_state(generated_data.y_true[SPLIT_POINT:],
+                    generated_data.y_bad[SPLIT_POINT:])
+    bad_prediction_score = r2_score.result().numpy()
+
+    # r2 score for bad should be "far away" from 1
+    assert bad_prediction_score < 0.05
+
+def test_ErrorScore(generated_data):
+
+    error_score = ErrorScore()
+
+    assert np.isnan(error_score.result().numpy())
+
+    # test as single batch
+    error_score.update_state(generated_data.y_true, generated_data.y_good)
+    good_single_batch = error_score.result().numpy()
+    assert np.isreal(good_single_batch)
+
+    # test as two batches
+    error_score.reset_states()
+    error_score.update_state(generated_data.y_true[:SPLIT_POINT],
+                    generated_data.y_good[:SPLIT_POINT])
+    error_score.update_state(generated_data.y_true[SPLIT_POINT:],
+                    generated_data.y_good[SPLIT_POINT:])
+    good_two_batch = error_score.result().numpy()
+    assert np.isreal(good_two_batch)
+
+    # single batch and multi-batch should be very close
+    assert np.isclose(good_single_batch, good_two_batch)
+
+    # test for bad predictions
+    error_score.reset_states()
+    error_score.update_state(generated_data.y_true[:SPLIT_POINT],
+                    generated_data.y_bad[:SPLIT_POINT])
+    error_score.update_state(generated_data.y_true[SPLIT_POINT:],
+                    generated_data.y_bad[SPLIT_POINT:])
+    bad_prediction_score = error_score.result().numpy()
+
+    # magnitude of bad predictions should be greater than good predictions
+    assert  np.abs(bad_prediction_score) > np.abs(good_two_batch)


### PR DESCRIPTION
# Code Pull Requests

PR refactors Ludwig custom metrics `R2Score` and `ErrorScore` to use tensors.

This should address Issue #820.  Note:  While I could not recreate the error on my side, I believe this will address the problem because all internal data structures are now tensors.

In conjunction with the refactoring, I added unit test `test_custom_metrics.py` for the two modified custom metrics.
```
pytest -v /opt/project/tests/integration_tests/test_custom_metrics.py
============================================== test session starts ==============================================
platform linux -- Python 3.6.9, pytest-6.0.1, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /opt/project
plugins: pycharm-0.7.0, xdist-1.34.0, forked-1.3.0, typeguard-2.9.1
collected 2 items

../../../tests/integration_tests/test_custom_metrics.py::test_R2Score PASSED                              [ 50%]
../../../tests/integration_tests/test_custom_metrics.py::test_ErrorScore PASSED                           [100%]

=============================================== 2 passed in 0.19s ===============================================
```

@w4nderlust If this PR looks good, I recommend merging it so that @ifokeev can confirm the fix since I could not recreate the problem.  

There is one more custom metric to refactor.   I'll submit that as separate PR.


