### PR TITLE
Added collect_activations to extract intermediate output tensors

### DIFF
--- a/ludwig/features/audio_feature.py
+++ b/ludwig/features/audio_feature.py
@@ -370,6 +370,12 @@ class AudioInputFeature(AudioFeatureMixin, SequenceInputFeature):
 
         return encoder_output
 
+    def get_input_dtype(self):
+        return tf.float32
+
+    def get_input_shape(self):
+        return self.length, self.embedding_size
+
     @staticmethod
     def update_model_definition_with_metadata(
             input_feature,

--- a/ludwig/features/bag_feature.py
+++ b/ludwig/features/bag_feature.py
@@ -110,6 +110,12 @@ class BagInputFeature(BagFeatureMixin, InputFeature):
 
         return {'encoder_output': encoder_output}
 
+    def get_input_dtype(self):
+        return tf.float32
+
+    def get_input_shape(self):
+        return len(self.vocab),
+
     @staticmethod
     def update_model_definition_with_metadata(
             input_feature,

--- a/ludwig/features/base_feature.py
+++ b/ludwig/features/base_feature.py
@@ -160,6 +160,21 @@ class OutputFeature(BaseFeature, tf.keras.Model, ABC):
             default_dropout=self.dropout,
         )
 
+    def create_input(self):
+        return tf.keras.Input(shape=self.get_output_shape(),
+                              dtype=self.get_output_dtype(),
+                              name=self.name)
+
+    @abstractmethod
+    def get_output_dtype(self):
+        """Returns the Tensor data type feature outputs."""
+        pass
+
+    @abstractmethod
+    def get_output_shape(self):
+        """Returns a tuple representing the Tensor shape this feature outputs."""
+        pass
+
     @property
     @abstractmethod
     def decoder_registry(self):

--- a/ludwig/features/base_feature.py
+++ b/ludwig/features/base_feature.py
@@ -66,6 +66,20 @@ class InputFeature(BaseFeature, tf.keras.Model, ABC):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+    def create_input(self):
+        return tf.keras.Input(shape=self.get_input_shape(),
+                              dtype=self.get_input_dtype())
+
+    @abstractmethod
+    def get_input_dtype(self):
+        """Returns the Tensor data type this input accepts."""
+        pass
+
+    @abstractmethod
+    def get_input_shape(self):
+        """Returns a tuple representing the Tensor shape this input accepts."""
+        pass
+
     @staticmethod
     @abstractmethod
     def update_model_definition_with_metadata(

--- a/ludwig/features/base_feature.py
+++ b/ludwig/features/base_feature.py
@@ -69,7 +69,7 @@ class InputFeature(BaseFeature, tf.keras.Model, ABC):
     def create_input(self):
         return tf.keras.Input(shape=self.get_input_shape(),
                               dtype=self.get_input_dtype(),
-                              name=self.name)
+                              name=self.name + '_input')
 
     @abstractmethod
     def get_input_dtype(self):
@@ -163,7 +163,7 @@ class OutputFeature(BaseFeature, tf.keras.Model, ABC):
     def create_input(self):
         return tf.keras.Input(shape=self.get_output_shape(),
                               dtype=self.get_output_dtype(),
-                              name=self.name)
+                              name=self.name + '_input')
 
     @abstractmethod
     def get_output_dtype(self):

--- a/ludwig/features/base_feature.py
+++ b/ludwig/features/base_feature.py
@@ -68,7 +68,8 @@ class InputFeature(BaseFeature, tf.keras.Model, ABC):
 
     def create_input(self):
         return tf.keras.Input(shape=self.get_input_shape(),
-                              dtype=self.get_input_dtype())
+                              dtype=self.get_input_dtype(),
+                              name=self.name)
 
     @abstractmethod
     def get_input_dtype(self):

--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -93,6 +93,12 @@ class BinaryInputFeature(BinaryFeatureMixin, InputFeature):
 
         return encoder_outputs
 
+    def get_input_dtype(self):
+        return tf.bool
+
+    def get_input_shape(self):
+        return ()
+
     @staticmethod
     def update_model_definition_with_metadata(
             input_feature,

--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -199,6 +199,12 @@ class BinaryOutputFeature(BinaryFeatureMixin, OutputFeature):
 
     default_validation_metric = ACCURACY
 
+    def get_output_dtype(self):
+        return tf.bool
+
+    def get_output_shape(self):
+        return ()
+
     @staticmethod
     def update_model_definition_with_metadata(
             input_feature,

--- a/ludwig/features/category_feature.py
+++ b/ludwig/features/category_feature.py
@@ -120,6 +120,12 @@ class CategoryInputFeature(CategoryFeatureMixin, InputFeature):
 
         return {'encoder_output': encoder_output}
 
+    def get_input_dtype(self):
+        return tf.int32
+
+    def get_input_shape(self):
+        return ()
+
     @staticmethod
     def update_model_definition_with_metadata(
             input_feature,

--- a/ludwig/features/category_feature.py
+++ b/ludwig/features/category_feature.py
@@ -235,6 +235,12 @@ class CategoryOutputFeature(CategoryFeatureMixin, OutputFeature):
 
     default_validation_metric = ACCURACY
 
+    def get_output_dtype(self):
+        return tf.int64
+
+    def get_output_shape(self):
+        return ()
+
     @staticmethod
     def update_model_definition_with_metadata(
             output_feature,

--- a/ludwig/features/date_feature.py
+++ b/ludwig/features/date_feature.py
@@ -131,6 +131,12 @@ class DateInputFeature(DateFeatureMixin, InputFeature):
 
         return inputs_encoded
 
+    def get_input_dtype(self):
+        return tf.int16
+
+    def get_input_shape(self):
+        return DATE_VECTOR_LENGTH,
+
     @staticmethod
     def update_model_definition_with_metadata(
             input_feature,

--- a/ludwig/features/h3_feature.py
+++ b/ludwig/features/h3_feature.py
@@ -95,6 +95,12 @@ class H3InputFeature(H3FeatureMixin, InputFeature):
 
         return inputs_encoded
 
+    def get_input_dtype(self):
+        return tf.uint8
+
+    def get_input_shape(self):
+        return H3_VECTOR_LENGTH,
+
     @staticmethod
     def update_model_definition_with_metadata(
             input_feature,

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -364,6 +364,12 @@ class ImageInputFeature(ImageFeatureMixin, InputFeature):
 
         return inputs_encoded
 
+    def get_input_dtype(self):
+        return tf.uint8
+
+    def get_input_shape(self):
+        return self.height, self.width, self.num_channels
+
     # keep this here for now until it's refactored
     def build_input(
             self,

--- a/ludwig/features/numerical_feature.py
+++ b/ludwig/features/numerical_feature.py
@@ -265,6 +265,12 @@ class NumericalOutputFeature(NumericalFeatureMixin, OutputFeature):
 
     default_validation_metric = MEAN_SQUARED_ERROR
 
+    def get_output_dtype(self):
+        return tf.float32
+
+    def get_output_shape(self):
+        return ()
+
     @staticmethod
     def update_model_definition_with_metadata(
             output_feature,

--- a/ludwig/features/numerical_feature.py
+++ b/ludwig/features/numerical_feature.py
@@ -158,6 +158,12 @@ class NumericalInputFeature(NumericalFeatureMixin, InputFeature):
 
         return inputs_encoded
 
+    def get_input_dtype(self):
+        return tf.float32
+
+    def get_input_shape(self):
+        return ()
+
     @staticmethod
     def update_model_definition_with_metadata(
             input_feature,

--- a/ludwig/features/sequence_feature.py
+++ b/ludwig/features/sequence_feature.py
@@ -146,6 +146,12 @@ class SequenceInputFeature(SequenceFeatureMixin, InputFeature):
 
         return encoder_output
 
+    def get_input_dtype(self):
+        return tf.int32
+
+    def get_input_shape(self):
+        return None,
+
     @staticmethod
     def update_model_definition_with_metadata(
             input_feature,

--- a/ludwig/features/sequence_feature.py
+++ b/ludwig/features/sequence_feature.py
@@ -271,6 +271,12 @@ class SequenceOutputFeature(SequenceFeatureMixin, OutputFeature):
 
     default_validation_metric = LOSS
 
+    def get_output_dtype(self):
+        return tf.int32
+
+    def get_output_shape(self):
+        return self.max_sequence_length,
+
     @staticmethod
     def update_model_definition_with_metadata(
             output_feature,

--- a/ludwig/features/set_feature.py
+++ b/ludwig/features/set_feature.py
@@ -209,6 +209,12 @@ class SetOutputFeature(SetFeatureMixin, OutputFeature):
 
     default_validation_metric = JACCARD
 
+    def get_output_dtype(self):
+        return tf.bool
+
+    def get_output_shape(self):
+        return self.num_classes,
+
     @staticmethod
     def update_model_definition_with_metadata(
             output_feature,

--- a/ludwig/features/set_feature.py
+++ b/ludwig/features/set_feature.py
@@ -120,6 +120,12 @@ class SetInputFeature(SetFeatureMixin, InputFeature):
 
         return {'encoder_output': encoder_output}
 
+    def get_input_dtype(self):
+        return tf.bool
+
+    def get_input_shape(self):
+        return len(self.vocab),
+
     @staticmethod
     def update_model_definition_with_metadata(
             input_feature,

--- a/ludwig/features/text_feature.py
+++ b/ludwig/features/text_feature.py
@@ -252,6 +252,12 @@ class TextOutputFeature(TextFeatureMixin, SequenceOutputFeature):
         else:
             self.encoder_obj = self.initialize_decoder(feature)
 
+    def get_output_dtype(self):
+        return tf.int32
+
+    def get_output_shape(self):
+        return self.max_sequence_length,
+
     @staticmethod
     def update_model_definition_with_metadata(
             output_feature,

--- a/ludwig/features/text_feature.py
+++ b/ludwig/features/text_feature.py
@@ -200,6 +200,12 @@ class TextInputFeature(TextFeatureMixin, SequenceInputFeature):
 
         return encoder_output
 
+    def get_input_dtype(self):
+        return tf.int32
+
+    def get_input_shape(self):
+        return None,
+
     @staticmethod
     def update_model_definition_with_metadata(
             input_feature,

--- a/ludwig/features/timeseries_feature.py
+++ b/ludwig/features/timeseries_feature.py
@@ -144,6 +144,12 @@ class TimeseriesInputFeature(TimeseriesFeatureMixin, SequenceInputFeature):
 
         return encoder_output
 
+    def get_input_dtype(self):
+        return tf.float32
+
+    def get_input_shape(self):
+        return self.length,
+
     @staticmethod
     def update_model_definition_with_metadata(
             input_feature,

--- a/ludwig/features/timeseries_feature.py
+++ b/ludwig/features/timeseries_feature.py
@@ -366,6 +366,13 @@ class TimeseriesInputFeature(TimeseriesFeatureMixin, SequenceInputFeature):
 #         })
 #     ])
 #
+#     def get_output_dtype(self):
+#         return tf.float32
+#
+#     def get_output_shape(self):
+#         return self.max_sequence_length,
+#
+#
 #     @staticmethod
 #     def update_model_definition_with_metadata(
 #             output_feature,

--- a/ludwig/features/vector_feature.py
+++ b/ludwig/features/vector_feature.py
@@ -258,6 +258,12 @@ class VectorOutputFeature(VectorFeatureMixin, OutputFeature):
 
     default_validation_metric = MEAN_SQUARED_ERROR
 
+    def get_output_dtype(self):
+        return tf.float32
+
+    def get_output_shape(self):
+        return self.vector_size,
+
     @staticmethod
     def update_model_definition_with_metadata(
             output_feature,

--- a/ludwig/features/vector_feature.py
+++ b/ludwig/features/vector_feature.py
@@ -164,6 +164,12 @@ class VectorInputFeature(VectorFeatureMixin, InputFeature):
 
         return inputs_encoded
 
+    def get_input_dtype(self):
+        return tf.float32
+
+    def get_input_shape(self):
+        return self.vector_size,
+
     @staticmethod
     def update_model_definition_with_metadata(
             input_feature,

--- a/ludwig/models/ecd.py
+++ b/ludwig/models/ecd.py
@@ -52,7 +52,7 @@ class ECD(tf.keras.Model):
         # After constructing all layers, clear the cache to free up memory
         clear_data_cache()
 
-    def get_connected_model(self, training=True):
+    def get_model_inputs(self, training=True):
         inputs = {
             input_feature_name: input_feature.create_input()
             for input_feature_name, input_feature in self.input_features.items()
@@ -61,11 +61,12 @@ class ECD(tf.keras.Model):
             output_feature_name: output_feature.create_input()
             for output_feature_name, output_feature in self.output_features.items()
         } if training else None
+        return inputs, targets
 
-        input_tuple = (inputs, targets)
-        outputs = self.call(input_tuple)
-
-        return tf.keras.Model(inputs=input_tuple, outputs=outputs)
+    def get_connected_model(self, training=True, inputs=None):
+        inputs = inputs or self.get_model_inputs(training)
+        outputs = self.call(inputs)
+        return tf.keras.Model(inputs=inputs, outputs=outputs)
 
     def call(self, inputs, training=None, mask=None):
         # parameter inputs is a dict feature_name -> tensor / ndarray

--- a/ludwig/models/ecd.py
+++ b/ludwig/models/ecd.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 from collections import OrderedDict
 
@@ -51,7 +52,7 @@ class ECD(tf.keras.Model):
         # After constructing all layers, clear the cache to free up memory
         clear_data_cache()
 
-    def build_model_graph(self, training=True):
+    def get_connected_model(self, training=True):
         inputs = {
             input_feature_name: input_feature.create_input()
             for input_feature_name, input_feature in self.input_features.items()
@@ -61,7 +62,10 @@ class ECD(tf.keras.Model):
             for output_feature_name, output_feature in self.output_features.items()
         } if training else None
 
-        self.call((inputs, targets))
+        input_tuple = (inputs, targets)
+        outputs = self.call(input_tuple)
+
+        return tf.keras.Model(inputs=input_tuple, outputs=outputs)
 
     def call(self, inputs, training=None, mask=None):
         # parameter inputs is a dict feature_name -> tensor / ndarray
@@ -98,7 +102,7 @@ class ECD(tf.keras.Model):
 
             decoder_logits, decoder_last_hidden = decoder(
                 (
-                    (combiner_outputs, output_last_hidden),
+                    (combiner_outputs, copy.copy(output_last_hidden)),
                     target_to_use
                 ),
                 training=training,

--- a/ludwig/models/ecd.py
+++ b/ludwig/models/ecd.py
@@ -23,8 +23,6 @@ class ECD(tf.keras.Model):
             output_features_def,
             **kwargs
     ):
-        super().__init__()
-
         # ================ Inputs ================
         self.input_features = build_inputs(
             input_features_def
@@ -45,29 +43,33 @@ class ECD(tf.keras.Model):
             self.combiner
         )
 
+        inputs, outputs = self._get_inputs_and_outputs()
+        super().__init__(inputs=inputs, outputs=outputs)
+
         # ================ Combined loss metric ================
         self.eval_loss_metric = tf.keras.metrics.Mean()
 
         # After constructing all layers, clear the cache to free up memory
         clear_data_cache()
 
-    def call(self, inputs, training=None, mask=None):
+    def _get_inputs_and_outputs(self):
         # parameter inputs is a dict feature_name -> tensor / ndarray
         # or
         # parameter (inputs, targets) where
         #   inputs is a dict feature_name -> tensor/ndarray
         #   targets is dict feature_name -> tensor/ndarray
-        if isinstance(inputs, tuple):
-            inputs, targets = inputs
-        else:
-            targets = None
-        assert inputs.keys() == self.input_features.keys()
+        # if isinstance(inputs, tuple):
+        #     inputs, targets = inputs
+        # else:
+        #     targets = None
+        # assert inputs.keys() == self.input_features.keys()
 
+        inputs = []
         encoder_outputs = {}
-        for input_feature_name, input_values in inputs.items():
-            encoder = self.input_features[input_feature_name]
-            encoder_output = encoder(input_values, training=training,
-                                     mask=mask)
+        for input_feature_name, encoder in self.input_features.items():
+            input_value = encoder.create_input()
+            inputs.append(input_value)
+            encoder_output = encoder(input_value)
             encoder_outputs[input_feature_name] = encoder_output
 
         combiner_outputs = self.combiner(encoder_outputs)
@@ -75,30 +77,38 @@ class ECD(tf.keras.Model):
         output_logits = {}
         output_last_hidden = {}
         for output_feature_name, decoder in self.output_features.items():
-            # use presence or absence of targets to signal training or prediction
-            if targets is not None:
-                # doing training
-                target_to_use = tf.cast(targets[output_feature_name],
-                                        dtype=tf.int32)
-            else:
-                # doing prediction
-                target_to_use = None
+            # # use presence or absence of targets to signal training or prediction
+            # if targets is not None:
+            #     # doing training
+            #     target_to_use = tf.cast(targets[output_feature_name],
+            #                             dtype=tf.int32)
+            # else:
+            #     # doing prediction
+            #     target_to_use = None
+
+            # decoder_logits, decoder_last_hidden = decoder(
+            #     (
+            #         (combiner_outputs, output_last_hidden),
+            #         target_to_use
+            #     ),
+            #     training=training,
+            #     mask=mask
+            # )
 
             decoder_logits, decoder_last_hidden = decoder(
                 (
                     (combiner_outputs, output_last_hidden),
-                    target_to_use
+                    None
                 ),
-                training=training,
-                mask=mask
             )
+
             output_logits[output_feature_name] = {}
             output_logits[output_feature_name][LOGITS] = decoder_logits
             output_logits[output_feature_name][
                 LAST_HIDDEN] = decoder_last_hidden
             output_last_hidden[output_feature_name] = decoder_last_hidden
 
-        return output_logits
+        return inputs, output_logits
 
     def predictions(self, inputs, output_features=None):
         # check validity of output_features

--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -469,6 +469,8 @@ class Trainer:
                     disable=is_progressbar_disabled()
                 )
 
+            self.model.build_model_graph(training=True)
+
             # training step loop
             while not batcher.last_batch():
                 batch = batcher.next_batch()

--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -469,8 +469,6 @@ class Trainer:
                     disable=is_progressbar_disabled()
                 )
 
-            self.model.build_model_graph(training=True)
-
             # training step loop
             while not batcher.last_batch():
                 batch = batcher.next_batch()


### PR DESCRIPTION
Approach follows from https://github.com/tensorflow/tensorflow/issues/25036.

In order to get the intermediate outputs, we must first construct a static representation of the model graph using the functional Keras API.  From there, we re-route the layers of interest as outputs to a second model, which we run the forward pass on to obtain the activations.