### PR TITLE
TF2 porting: Add unit test for input feature 'tied' parameter

### DIFF
--- a/ludwig/features/audio_feature.py
+++ b/ludwig/features/audio_feature.py
@@ -359,6 +359,13 @@ class AudioInputFeature(AudioFeatureMixin, SequenceInputFeature):
                 'length has to be defined - '
                 'check "update_model_definition_with_metadata()"')
 
+        self.overwrite_defaults(feature)
+        if encoder_obj:
+            self.encoder_obj = encoder_obj
+        else:
+            self.encoder_obj = self.initialize_encoder(feature)
+
+
     def call(self, inputs, training=None, mask=None):
         assert isinstance(inputs, tf.Tensor)
         assert inputs.dtype == tf.float32

--- a/ludwig/features/text_feature.py
+++ b/ludwig/features/text_feature.py
@@ -186,6 +186,12 @@ class TextInputFeature(TextFeatureMixin, SequenceInputFeature):
 
     def __init__(self, feature, encoder_obj=None):
         super().__init__(feature)
+        self.overwrite_defaults(feature)
+        if encoder_obj:
+            self.encoder_obj = encoder_obj
+        else:
+            self.encoder_obj = self.initialize_encoder(feature)
+
 
     def call(self, inputs, training=None, mask=None):
         assert isinstance(inputs, tf.Tensor)

--- a/ludwig/features/timeseries_feature.py
+++ b/ludwig/features/timeseries_feature.py
@@ -130,6 +130,11 @@ class TimeseriesInputFeature(TimeseriesFeatureMixin, SequenceInputFeature):
 
     def __init__(self, feature, encoder_obj=None):
         super().__init__(feature)
+        self.overwrite_defaults(feature)
+        if encoder_obj:
+            self.encoder_obj = encoder_obj
+        else:
+            self.encoder_obj = self.initialize_encoder(feature)
 
     def call(self, inputs, training=None, mask=None):
         assert isinstance(inputs, tf.Tensor)

--- a/tests/integration_tests/test_input_feature_tied.py
+++ b/tests/integration_tests/test_input_feature_tied.py
@@ -12,6 +12,7 @@ from ludwig.models.ecd import build_inputs
 InputFeatureOptions = namedtuple('InputFeatureOptions', 'feature_type feature_options')
 
 
+# note: vocab parameter, below, is made up to facilitate creating input encoders
 @pytest.mark.parametrize(
     'input_feature_options',
     [
@@ -20,10 +21,16 @@ InputFeatureOptions = namedtuple('InputFeatureOptions', 'feature_type feature_op
             'numerical',
             {'preprocessing': {'normalization': 'zscore'}}
         ),
+        InputFeatureOptions('binary', {}),
         InputFeatureOptions('category', {'vocab': ['a', 'b', 'c']}),
         InputFeatureOptions('set', {'vocab': ['a', 'b', 'c']}),
         InputFeatureOptions('sequence', {'vocab': ['x', 'y', 'z']}),
         InputFeatureOptions('text', {'vocab': ['a', 'b', 'c']}),
+        InputFeatureOptions('timeseries', {'vocab': ['a', 'b', 'c']}),
+        InputFeatureOptions(
+            'audio',
+            {'embedding_size': 64, 'length': 16, 'vocab': ['a', 'b', 'c']}
+        ),
 
         # do not tie input features, encoders should be different
         InputFeatureOptions('numerical', None)

--- a/tests/integration_tests/test_input_feature_tied.py
+++ b/tests/integration_tests/test_input_feature_tied.py
@@ -1,0 +1,73 @@
+from collections import namedtuple
+
+import pytest
+
+from ludwig.models.ecd import build_inputs
+
+
+# InputFeatureOptions namedtuple structure:
+# feature_type: input feature type, e.g., numerical, category, etc.
+# feature_options: None or dictionary of required input feature specifications
+#   dictionary can be empty, None indicates not to tie the two input features
+InputFeatureOptions = namedtuple('InputFeatureOptions', 'feature_type feature_options')
+
+
+@pytest.mark.parametrize(
+    'input_feature_options',
+    [
+        InputFeatureOptions('numerical', {}),
+        InputFeatureOptions(
+            'numerical',
+            {'preprocessing': {'normalization': 'zscore'}}
+        ),
+        InputFeatureOptions('category', {'vocab': ['a', 'b', 'c']}),
+        InputFeatureOptions('set', {'vocab': ['a', 'b', 'c']}),
+        InputFeatureOptions('sequence', {'vocab': ['x', 'y', 'z']}),
+        InputFeatureOptions('text', {'vocab': ['a', 'b', 'c']}),
+
+        # do not tie input features, encoders should be different
+        InputFeatureOptions('numerical', None)
+    ]
+)
+def test_encoder_tied_weights(input_feature_options):
+
+    # build input feature definition
+    input_feature_definitions = []
+
+    input_feature_definitions.append({
+        'name': 'input_feature_1',
+        'type': input_feature_options.feature_type
+    })
+    if input_feature_options.feature_options is not None:
+        input_feature_definitions[0].update(input_feature_options.feature_options)
+
+    input_feature_definitions.append({
+        'name': 'input_feature_2',
+        'type': input_feature_options.feature_type
+    })
+    if input_feature_options.feature_options is not None:
+        input_feature_definitions[1].update(input_feature_options.feature_options)
+
+    # add tied option to the second feature
+    if input_feature_options.feature_options is not None:
+        input_feature_definitions[1]['tied'] = 'input_feature_1'
+
+    input_features = build_inputs(input_feature_definitions)
+
+    if input_feature_options.feature_options is not None:
+        # should be same encoder
+        assert input_features['input_feature_1'].encoder_obj is \
+            input_features['input_feature_2'].encoder_obj
+    else:
+        # no tied parameter, encoders should be different
+        assert input_features['input_feature_1'].encoder_obj is not \
+               input_features['input_feature_2'].encoder_obj
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
# Code Pull Requests

This adds micro level unit tests for input feature `tied` parameter and fixes constructors for `text`, `time series` and `audio` to support the `tied` parameter.  

The unit tests cover these feature types:
```
        InputFeatureOptions('numerical', {}),
        InputFeatureOptions(
            'numerical',
            {'preprocessing': {'normalization': 'zscore'}}
        ),
        InputFeatureOptions('binary', {}),
        InputFeatureOptions('category', {'vocab': ['a', 'b', 'c']}),
        InputFeatureOptions('set', {'vocab': ['a', 'b', 'c']}),
        InputFeatureOptions('sequence', {'vocab': ['x', 'y', 'z']}),
        InputFeatureOptions('text', {'vocab': ['a', 'b', 'c']}),
        InputFeatureOptions('timeseries', {'vocab': ['a', 'b', 'c']}),
        InputFeatureOptions(
            'audio',
            {'embedding_size': 64, 'length': 16, 'vocab': ['a', 'b', 'c']}
        ),

        # do not tie input features, encoders should be different
        InputFeatureOptions('numerical', None)
```

Sample run of this unit test
```
pytest -v  /opt/project/tests/integration_tests/test_input_feature_tied.py
=========================================================== test session starts ============================================================
platform linux -- Python 3.6.9, pytest-6.0.1, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /opt/project
plugins: xdist-2.0.0, forked-1.3.0, pycharm-0.7.0, typeguard-2.9.1
collected 10 items

../../tests/integration_tests/test_input_feature_tied.py::test_encoder_tied_weights[input_feature_options0] PASSED                   [ 10%]
../../tests/integration_tests/test_input_feature_tied.py::test_encoder_tied_weights[input_feature_options1] PASSED                   [ 20%]
../../tests/integration_tests/test_input_feature_tied.py::test_encoder_tied_weights[input_feature_options2] PASSED                   [ 30%]
../../tests/integration_tests/test_input_feature_tied.py::test_encoder_tied_weights[input_feature_options3] PASSED                   [ 40%]
../../tests/integration_tests/test_input_feature_tied.py::test_encoder_tied_weights[input_feature_options4] PASSED                   [ 50%]
../../tests/integration_tests/test_input_feature_tied.py::test_encoder_tied_weights[input_feature_options5] PASSED                   [ 60%]
../../tests/integration_tests/test_input_feature_tied.py::test_encoder_tied_weights[input_feature_options6] PASSED                   [ 70%]
../../tests/integration_tests/test_input_feature_tied.py::test_encoder_tied_weights[input_feature_options7] PASSED                   [ 80%]
../../tests/integration_tests/test_input_feature_tied.py::test_encoder_tied_weights[input_feature_options8] PASSED                   [ 90%]
../../tests/integration_tests/test_input_feature_tied.py::test_encoder_tied_weights[input_feature_options9] PASSED                   [100%]

============================================================ 10 passed in 0.83s ============================================================
```
