### PR TITLE
Update TF2 and TFA with latest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ scipy>=0.18
 tabulate>=0.7
 scikit-learn
 tqdm
-tensorflow==2.3
+tensorflow>=2.2,<2.4
 tfa-nightly==0.12.0.dev20200820045606
 PyYAML>=3.12
 absl-py

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ scipy>=0.18
 tabulate>=0.7
 scikit-learn
 tqdm
-tensorflow==2.2
-tfa-nightly==0.12.0.dev20200807032152
+tensorflow==2.3
+tfa-nightly==0.12.0.dev20200820045606
 PyYAML>=3.12
 absl-py


### PR DESCRIPTION
I did some local quick tests and there seems to be no issue in updating Tensorflow to 2.3.
It's a month now it's released and no urgent fixes have been published, so it should be a stable one.
With the same logic I also updated the build version of the Tensorflow Addons nightly package.

I can run training, inference, testing, and the most common functions with no issue at all, with the same behavior as 2.2.
Let's see what the CI build spits out, but since 0.3.0 has yet to be finalized, it could be useful to start up to date (if no effort or minimal effort is required for shifting from 2.2 to 2.3)