### PR TITLE
TF2 porting: Conversion of feed forward attention reducer to TF2

### DIFF
--- a/ludwig/combiners/combiners.py
+++ b/ludwig/combiners/combiners.py
@@ -25,7 +25,7 @@ from ludwig.encoders.sequence_encoders import StackedCNNRNN
 from ludwig.encoders.sequence_encoders import StackedParallelCNN
 from ludwig.encoders.sequence_encoders import StackedRNN
 from ludwig.modules.fully_connected_modules import FCStack
-from ludwig.modules.reduction_modules import reduce_sequence
+from ludwig.modules.reduction_modules import SequenceReducer
 from ludwig.utils.misc_utils import get_from_registry
 from ludwig.utils.tf_utils import sequence_length_3D
 
@@ -131,6 +131,7 @@ class SequenceConcatCombiner(tf.keras.Model):
         logger.debug(' {}'.format(self.name))
 
         self.reduce_output = reduce_output
+        self.reduce_sequence = SequenceReducer(reduce_mode=reduce_output)
         if self.reduce_output is None:
             self.supports_masking = True
         self.main_sequence_feature = main_sequence_feature
@@ -246,10 +247,7 @@ class SequenceConcatCombiner(tf.keras.Model):
         )
 
         # ================ Reduce ================
-        hidden = reduce_sequence(
-            hidden,
-            self.reduce_output
-        )
+        hidden = self.reduce_sequence(hidden)
 
         return_data = {'combiner_output': hidden}
 

--- a/ludwig/decoders/sequence_decoders.py
+++ b/ludwig/decoders/sequence_decoders.py
@@ -86,7 +86,7 @@ class SequenceGeneratorDecoder(Layer):
         self.attention_mechanism = None
 
         self.reduce_input = reduce_input if reduce_input else 'sum'
-        self.reduce_sequence = SequenceReducer(reduce_mode=reduce_input)
+        self.reduce_sequence = SequenceReducer(reduce_mode=self.reduce_input)
 
         if is_timeseries:
             self.vocab_size = 1

--- a/ludwig/decoders/sequence_decoders.py
+++ b/ludwig/decoders/sequence_decoders.py
@@ -26,7 +26,7 @@ from tensorflow_addons.seq2seq import BahdanauAttention
 from tensorflow_addons.seq2seq import LuongAttention
 
 from ludwig.constants import *
-from ludwig.modules.reduction_modules import SequenceReducerMixin
+from ludwig.modules.reduction_modules import SequenceReducer
 from ludwig.utils.misc_utils import get_from_registry
 from ludwig.utils.tf_utils import sequence_length_3D, sequence_length_2D
 
@@ -45,7 +45,7 @@ rnn_layers_registry = {
 }
 
 
-class SequenceGeneratorDecoder(SequenceReducerMixin, Layer):
+class SequenceGeneratorDecoder(Layer):
 
     def __init__(
             self,
@@ -68,8 +68,7 @@ class SequenceGeneratorDecoder(SequenceReducerMixin, Layer):
             reduce_input='sum',
             **kwargs
     ):
-        reduce_input_parm = reduce_input if reduce_input else 'sum'
-        super(SequenceGeneratorDecoder, self).__init__(reduce_mode=reduce_input_parm)
+        super(SequenceGeneratorDecoder, self).__init__()
         logger.debug(' {}'.format(self.name))
 
         self.cell_type = cell_type
@@ -86,7 +85,8 @@ class SequenceGeneratorDecoder(SequenceReducerMixin, Layer):
         self.state_size = state_size
         self.attention_mechanism = None
 
-        self.reduce_input = reduce_input_parm
+        self.reduce_input = reduce_input if reduce_input else 'sum'
+        self.reduce_sequence = SequenceReducer(reduce_mode=reduce_input)
 
         if is_timeseries:
             self.vocab_size = 1

--- a/ludwig/decoders/sequence_decoders.py
+++ b/ludwig/decoders/sequence_decoders.py
@@ -30,12 +30,6 @@ from ludwig.modules.reduction_modules import SequenceReducer
 from ludwig.utils.misc_utils import get_from_registry
 from ludwig.utils.tf_utils import sequence_length_3D, sequence_length_2D
 
-# todo tf2 clean up
-# from ludwig.models.modules.attention_modules import \
-#     feed_forward_memory_attention
-# from ludwig.models.modules.initializer_modules import get_initializer
-# from ludwig.models.modules.recurrent_modules import recurrent_decoder
-
 logger = logging.getLogger(__name__)
 
 rnn_layers_registry = {

--- a/ludwig/encoders/sequence_encoders.py
+++ b/ludwig/encoders/sequence_encoders.py
@@ -32,7 +32,7 @@ from ludwig.modules.reduction_modules import SequenceReducerMixin
 logger = logging.getLogger(__name__)
 
 
-class SequencePassthroughEncoder(Layer):
+class SequencePassthroughEncoder(SequenceReducerMixin, Layer):
 
     def __init__(
             self,
@@ -49,7 +49,7 @@ class SequencePassthroughEncoder(Layer):
                    and returns the full tensor).
             :type reduce_output: str
         """
-        super(SequencePassthroughEncoder, self).__init__()
+        super(SequencePassthroughEncoder, self).__init__(reduce_mode=reduce_output)
         logger.debug(' {}'.format(self.name))
 
         self.reduce_output = reduce_output
@@ -75,7 +75,7 @@ class SequencePassthroughEncoder(Layer):
             input_sequence = tf.expand_dims(
                 input_sequence, -1
             )
-        hidden = reduce_sequence(input_sequence, self.reduce_output)
+        hidden = self.reduce_sequence(input_sequence)
 
         return {'encoder_output': hidden}
 
@@ -175,10 +175,10 @@ class SequenceEmbedEncoder(SequenceReducerMixin, Layer):
             :type dropout: Tensor
 
         """
-        super(SequenceEmbedEncoder, self).__init__(reduce_output=reduce_output)
+        super(SequenceEmbedEncoder, self).__init__(reduce_mode=reduce_output)
         logger.debug(' {}'.format(self.name))
 
-        #self.reduce_output = reduce_output
+        self.reduce_output = reduce_output
         if self.reduce_output is None:
             self.supports_masking = True
 
@@ -211,11 +211,10 @@ class SequenceEmbedEncoder(SequenceReducerMixin, Layer):
 
         hidden = self.reduce_sequence(embedded_sequence)
 
-
         return {'encoder_output': hidden}
 
 
-class ParallelCNN(Layer):
+class ParallelCNN(SequenceReducerMixin, Layer):
 
     def __init__(
             self,
@@ -385,7 +384,7 @@ class ParallelCNN(Layer):
                    (which does not reduce and returns the full tensor).
             :type reduce_output: str
         """
-        super(ParallelCNN, self).__init__()
+        super(ParallelCNN, self).__init__(reduce_mode=reduce_output)
         logger.debug(' {}'.format(self.name))
 
         if conv_layers is not None and num_conv_layers is None:
@@ -517,7 +516,7 @@ class ParallelCNN(Layer):
 
         # ================ Sequence Reduction ================
         if self.reduce_output is not None:
-            hidden = reduce_sequence(hidden, self.reduce_output)
+            hidden = self.reduce_sequence(hidden)
 
             # ================ FC Layers ================
             hidden = self.fc_stack(
@@ -529,7 +528,7 @@ class ParallelCNN(Layer):
         return {'encoder_output': hidden}
 
 
-class StackedCNN(Layer):
+class StackedCNN(SequenceReducerMixin, Layer):
 
     def __init__(
             self,
@@ -705,7 +704,7 @@ class StackedCNN(Layer):
                    (which does not reduce and returns the full tensor).
             :type reduce_output: str
         """
-        super(StackedCNN, self).__init__()
+        super(StackedCNN, self).__init__(reduce_mode=reduce_output)
         logger.debug(' {}'.format(self.name))
 
         if conv_layers is not None and num_conv_layers is None:
@@ -873,7 +872,7 @@ class StackedCNN(Layer):
 
         # ================ Sequence Reduction ================
         if self.reduce_output is not None:
-            hidden = reduce_sequence(hidden, self.reduce_output)
+            hidden = self.reduce_sequence(hidden)
 
             # ================ FC Layers ================
             hidden = self.fc_stack(
@@ -885,7 +884,7 @@ class StackedCNN(Layer):
         return {'encoder_output': hidden}
 
 
-class StackedParallelCNN(Layer):
+class StackedParallelCNN(SequenceReducerMixin, Layer):
 
     def __init__(
             self,
@@ -1063,7 +1062,7 @@ class StackedParallelCNN(Layer):
                    (which does not reduce and returns the full tensor).
             :type reduce_output: str
         """
-        super(StackedParallelCNN, self).__init__()
+        super(StackedParallelCNN, self).__init__(reduce_mode=reduce_output)
         logger.debug(' {}'.format(self.name))
 
         if stacked_layers is not None and num_stacked_layers is None:
@@ -1214,7 +1213,7 @@ class StackedParallelCNN(Layer):
 
         # ================ Sequence Reduction ================
         if self.reduce_output is not None:
-            hidden = reduce_sequence(hidden, self.reduce_output)
+            hidden = self.reduce_sequence(hidden)
 
             # ================ FC Layers ================
             hidden = self.fc_stack(
@@ -1226,7 +1225,7 @@ class StackedParallelCNN(Layer):
         return {'encoder_output': hidden}
 
 
-class StackedRNN(Layer):
+class StackedRNN(SequenceReducerMixin, Layer):
 
     def __init__(
             self,
@@ -1390,7 +1389,7 @@ class StackedRNN(Layer):
                    (which does not reduce and returns the full tensor).
             :type reduce_output: str
         """
-        super(StackedRNN, self).__init__()
+        super(StackedRNN, self).__init__(reduce_mode=reduce_output)
         logger.debug(' {}'.format(self.name))
 
         self.reduce_output = reduce_output
@@ -1494,7 +1493,7 @@ class StackedRNN(Layer):
 
         # ================ Sequence Reduction ================
         if self.reduce_output is not None:
-            hidden = reduce_sequence(hidden, self.reduce_output)
+            hidden = self.reduce_sequence(hidden)
 
             # ================ FC Layers ================
             hidden = self.fc_stack(
@@ -1509,7 +1508,7 @@ class StackedRNN(Layer):
         }
 
 
-class StackedCNNRNN(Layer):
+class StackedCNNRNN(SequenceReducerMixin, Layer):
 
     def __init__(
             self,
@@ -1652,7 +1651,7 @@ class StackedCNNRNN(Layer):
                    (which does not reduce and returns the full tensor).
             :type reduce_output: str
         """
-        super(StackedCNNRNN, self).__init__()
+        super(StackedCNNRNN, self).__init__(reduce_mode=reduce_output)
         logger.debug(' {}'.format(self.name))
 
         if conv_layers is not None and num_conv_layers is None:
@@ -1806,7 +1805,7 @@ class StackedCNNRNN(Layer):
 
         # ================ Sequence Reduction ================
         if self.reduce_output is not None:
-            hidden = reduce_sequence(hidden, self.reduce_output)
+            hidden = self.reduce_sequence(hidden)
 
             # ================ FC Layers ================
             hidden = self.fc_stack(

--- a/ludwig/encoders/sequence_encoders.py
+++ b/ludwig/encoders/sequence_encoders.py
@@ -27,7 +27,7 @@ from ludwig.modules.convolutional_modules import Conv1DStack, \
 from ludwig.modules.embedding_modules import EmbedSequence
 from ludwig.modules.fully_connected_modules import FCStack
 from ludwig.modules.recurrent_modules import RecurrentStack
-from ludwig.modules.reduction_modules import reduce_sequence
+from ludwig.modules.reduction_modules import SequenceReducerMixin
 
 logger = logging.getLogger(__name__)
 
@@ -80,7 +80,7 @@ class SequencePassthroughEncoder(Layer):
         return {'encoder_output': hidden}
 
 
-class SequenceEmbedEncoder(Layer):
+class SequenceEmbedEncoder(SequenceReducerMixin, Layer):
 
     def __init__(
             self,
@@ -175,10 +175,10 @@ class SequenceEmbedEncoder(Layer):
             :type dropout: Tensor
 
         """
-        super(SequenceEmbedEncoder, self).__init__()
+        super(SequenceEmbedEncoder, self).__init__(reduce_output=reduce_output)
         logger.debug(' {}'.format(self.name))
 
-        self.reduce_output = reduce_output
+        #self.reduce_output = reduce_output
         if self.reduce_output is None:
             self.supports_masking = True
 
@@ -209,7 +209,8 @@ class SequenceEmbedEncoder(Layer):
             inputs, training=training, mask=mask
         )
 
-        hidden = reduce_sequence(embedded_sequence, self.reduce_output)
+        hidden = self.reduce_sequence(embedded_sequence)
+
 
         return {'encoder_output': hidden}
 

--- a/ludwig/encoders/sequence_encoders.py
+++ b/ludwig/encoders/sequence_encoders.py
@@ -27,12 +27,12 @@ from ludwig.modules.convolutional_modules import Conv1DStack, \
 from ludwig.modules.embedding_modules import EmbedSequence
 from ludwig.modules.fully_connected_modules import FCStack
 from ludwig.modules.recurrent_modules import RecurrentStack
-from ludwig.modules.reduction_modules import SequenceReducerMixin
+from ludwig.modules.reduction_modules import SequenceReducer
 
 logger = logging.getLogger(__name__)
 
 
-class SequencePassthroughEncoder(SequenceReducerMixin, Layer):
+class SequencePassthroughEncoder(Layer):
 
     def __init__(
             self,
@@ -49,10 +49,11 @@ class SequencePassthroughEncoder(SequenceReducerMixin, Layer):
                    and returns the full tensor).
             :type reduce_output: str
         """
-        super(SequencePassthroughEncoder, self).__init__(reduce_mode=reduce_output)
+        super(SequencePassthroughEncoder, self).__init__()
         logger.debug(' {}'.format(self.name))
 
         self.reduce_output = reduce_output
+        self.reduce_sequence = SequenceReducer(reduce_mode=reduce_output)
         if self.reduce_output is None:
             self.supports_masking = True
 
@@ -80,7 +81,7 @@ class SequencePassthroughEncoder(SequenceReducerMixin, Layer):
         return {'encoder_output': hidden}
 
 
-class SequenceEmbedEncoder(SequenceReducerMixin, Layer):
+class SequenceEmbedEncoder(Layer):
 
     def __init__(
             self,
@@ -175,12 +176,14 @@ class SequenceEmbedEncoder(SequenceReducerMixin, Layer):
             :type dropout: Tensor
 
         """
-        super(SequenceEmbedEncoder, self).__init__(reduce_mode=reduce_output)
+        super(SequenceEmbedEncoder, self).__init__()
         logger.debug(' {}'.format(self.name))
 
         self.reduce_output = reduce_output
         if self.reduce_output is None:
             self.supports_masking = True
+
+        self.reduce_sequence = SequenceReducer(reduce_mode=reduce_output)
 
         logger.debug('  EmbedSequence')
         self.embed_sequence = EmbedSequence(
@@ -214,7 +217,7 @@ class SequenceEmbedEncoder(SequenceReducerMixin, Layer):
         return {'encoder_output': hidden}
 
 
-class ParallelCNN(SequenceReducerMixin, Layer):
+class ParallelCNN(Layer):
 
     def __init__(
             self,
@@ -384,7 +387,7 @@ class ParallelCNN(SequenceReducerMixin, Layer):
                    (which does not reduce and returns the full tensor).
             :type reduce_output: str
         """
-        super(ParallelCNN, self).__init__(reduce_mode=reduce_output)
+        super(ParallelCNN, self).__init__()
         logger.debug(' {}'.format(self.name))
 
         if conv_layers is not None and num_conv_layers is None:
@@ -427,6 +430,7 @@ class ParallelCNN(SequenceReducerMixin, Layer):
             )
 
         self.reduce_output = reduce_output
+        self.reduce_sequence = SequenceReducer(reduce_mode=reduce_output)
         self.should_embed = should_embed
         self.embed_sequence = None
 
@@ -528,7 +532,7 @@ class ParallelCNN(SequenceReducerMixin, Layer):
         return {'encoder_output': hidden}
 
 
-class StackedCNN(SequenceReducerMixin, Layer):
+class StackedCNN(Layer):
 
     def __init__(
             self,
@@ -704,7 +708,7 @@ class StackedCNN(SequenceReducerMixin, Layer):
                    (which does not reduce and returns the full tensor).
             :type reduce_output: str
         """
-        super(StackedCNN, self).__init__(reduce_mode=reduce_output)
+        super(StackedCNN, self).__init__()
         logger.debug(' {}'.format(self.name))
 
         if conv_layers is not None and num_conv_layers is None:
@@ -773,6 +777,7 @@ class StackedCNN(SequenceReducerMixin, Layer):
             )
 
         self.reduce_output = reduce_output
+        self.reduce_sequence = SequenceReducer(reduce_mode=reduce_output)
         self.should_embed = should_embed
         self.embed_sequence = None
 
@@ -884,7 +889,7 @@ class StackedCNN(SequenceReducerMixin, Layer):
         return {'encoder_output': hidden}
 
 
-class StackedParallelCNN(SequenceReducerMixin, Layer):
+class StackedParallelCNN(Layer):
 
     def __init__(
             self,
@@ -1062,7 +1067,7 @@ class StackedParallelCNN(SequenceReducerMixin, Layer):
                    (which does not reduce and returns the full tensor).
             :type reduce_output: str
         """
-        super(StackedParallelCNN, self).__init__(reduce_mode=reduce_output)
+        super(StackedParallelCNN, self).__init__()
         logger.debug(' {}'.format(self.name))
 
         if stacked_layers is not None and num_stacked_layers is None:
@@ -1119,6 +1124,7 @@ class StackedParallelCNN(SequenceReducerMixin, Layer):
             )
 
         self.reduce_output = reduce_output
+        self.reduce_sequence = SequenceReducer(reduce_mode=reduce_output)
         self.should_embed = should_embed
         self.embed_sequence = None
 
@@ -1225,7 +1231,7 @@ class StackedParallelCNN(SequenceReducerMixin, Layer):
         return {'encoder_output': hidden}
 
 
-class StackedRNN(SequenceReducerMixin, Layer):
+class StackedRNN(Layer):
 
     def __init__(
             self,
@@ -1389,10 +1395,11 @@ class StackedRNN(SequenceReducerMixin, Layer):
                    (which does not reduce and returns the full tensor).
             :type reduce_output: str
         """
-        super(StackedRNN, self).__init__(reduce_mode=reduce_output)
+        super(StackedRNN, self).__init__()
         logger.debug(' {}'.format(self.name))
 
         self.reduce_output = reduce_output
+        self.reduce_sequence = SequenceReducer(reduce_mode=reduce_output)
         if self.reduce_output is None:
             self.supports_masking = True
 
@@ -1508,7 +1515,7 @@ class StackedRNN(SequenceReducerMixin, Layer):
         }
 
 
-class StackedCNNRNN(SequenceReducerMixin, Layer):
+class StackedCNNRNN(Layer):
 
     def __init__(
             self,
@@ -1651,7 +1658,7 @@ class StackedCNNRNN(SequenceReducerMixin, Layer):
                    (which does not reduce and returns the full tensor).
             :type reduce_output: str
         """
-        super(StackedCNNRNN, self).__init__(reduce_mode=reduce_output)
+        super(StackedCNNRNN, self).__init__()
         logger.debug(' {}'.format(self.name))
 
         if conv_layers is not None and num_conv_layers is None:
@@ -1676,6 +1683,7 @@ class StackedCNNRNN(SequenceReducerMixin, Layer):
             )
 
         self.reduce_output = reduce_output
+        self.reduce_sequence = SequenceReducer(reduce_mode=reduce_output)
         self.should_embed = should_embed
         self.embed_sequence = None
 

--- a/ludwig/features/base_feature.py
+++ b/ludwig/features/base_feature.py
@@ -162,9 +162,12 @@ class OutputFeature(BaseFeature, tf.keras.Model, ABC):
         self.reduce_sequence_input = SequenceReducer(
             reduce_mode=self.reduce_input
         )
-        self.reduce_sequence_dependencies = SequenceReducer(
-            reduce_mode=self.reduce_dependencies
-        )
+        if self.dependencies:
+            self.dependency_reducers = {}
+            for dependency in self.dependencies:
+                self.dependency_reducers[dependency] = SequenceReducer(
+                    reduce_mode=self.reduce_dependencies
+                )
 
     def create_input(self):
         return tf.keras.Input(shape=self.get_output_shape(),
@@ -345,10 +348,9 @@ class OutputFeature(BaseFeature, tf.keras.Model, ABC):
                 else:
                     if len(dependency_final_hidden.shape) > 2:
                         # vector matrix -> reduce concat
+                        reducer = self.dependency_reducers[dependency]
                         dependencies_hidden.append(
-                            self.reduce_sequence_dependencies(
-                                dependency_final_hidden
-                            )
+                            reducer(dependency_final_hidden)
                         )
                     else:
                         # vector vector -> concat

--- a/ludwig/modules/attention_modules.py
+++ b/ludwig/modules/attention_modules.py
@@ -20,6 +20,11 @@ from tensorflow.keras.layers import Layer, Dense
 
 logger = logging.getLogger(__name__)
 
+# todo tf2 remove reduce_feed_forward_attention() once method for
+#   incorporating new FeedForwardAttentionReducer class is implemented.
+def reduce_feed_forward_attention(current_inputs, hidden_size=256):
+    pass
+
 
 class FeedForwardAttentionReducer(Layer):
     def __init__(self, hidden_size=256):

--- a/ludwig/modules/attention_modules.py
+++ b/ludwig/modules/attention_modules.py
@@ -20,11 +20,6 @@ from tensorflow.keras.layers import Layer, Dense
 
 logger = logging.getLogger(__name__)
 
-# todo tf2 remove reduce_feed_forward_attention() once method for
-#   incorporating new FeedForwardAttentionReducer class is implemented.
-def reduce_feed_forward_attention(current_inputs, hidden_size=256):
-    pass
-
 
 class FeedForwardAttentionReducer(Layer):
     def __init__(self, hidden_size=256):

--- a/ludwig/modules/attention_modules.py
+++ b/ludwig/modules/attention_modules.py
@@ -39,18 +39,11 @@ class FeedForwardAttentionReducer(Layer):
 
     def call(self, current_inputs, training=None, mask=None):
         # current_inputs shape [b, s, h]
-
-        hidden = self.layer1(current_inputs, training=training) # [b, s, h`], h`=hidden_size
+        hidden = self.layer1(current_inputs,
+                             training=training)  # [b, s, h`], h`=hidden_size
         hidden = self.layer2(hidden, training=training)  # [b, s, 1]
-        attention = tf.nn.softmax(  # [b, s]
-            tf.reshape(
-                hidden,
-                [-1, tf.shape(current_inputs)[1]]
-            )
-        )
-        geated_inputs = tf.reduce_sum(  # [b, h]
-            tf.expand_dims(attention, -1) * current_inputs, 1)
-
+        attention = tf.nn.softmax(hidden, axis=1)
+        geated_inputs = tf.reduce_sum(attention * current_inputs, 1)  # [b, h]
         return geated_inputs  # [b, h]
 
 

--- a/ludwig/modules/attention_modules.py
+++ b/ludwig/modules/attention_modules.py
@@ -28,22 +28,20 @@ class FeedForwardAttentionReducer(Layer):
         self.layer1 = Dense(
             hidden_size,
             activation='tanh',
-            name='ffa_reducer_layer1'
         )
         self.layer2 = Dense(
             1,
             activation='linear',
             use_bias=False,
-            name='ffa_reducer_layer2'
         )
 
-    def call(self, current_inputs, training=None, mask=None):
+    def call(self, inputs, training=None, mask=None):
         # current_inputs shape [b, s, h]
-        hidden = self.layer1(current_inputs,
+        hidden = self.layer1(inputs,
                              training=training)  # [b, s, h`], h`=hidden_size
         hidden = self.layer2(hidden, training=training)  # [b, s, 1]
         attention = tf.nn.softmax(hidden, axis=1)
-        geated_inputs = tf.reduce_sum(attention * current_inputs, 1)  # [b, h]
+        geated_inputs = tf.reduce_sum(attention * inputs, 1)  # [b, h]
         return geated_inputs  # [b, h]
 
 

--- a/ludwig/modules/attention_modules.py
+++ b/ludwig/modules/attention_modules.py
@@ -32,12 +32,14 @@ class FeedForwardAttentionReducer(Layer):
 
         self.layer1 = Dense(
             hidden_size,
-            activation='tanh'
+            activation='tanh',
+            name='ffa_reducer_layer1'
         )
         self.layer2 = Dense(
             1,
             activation='linear',
-            use_bias=False
+            use_bias=False,
+            name='ffa_reducer_layer2'
         )
 
     def call(self, current_inputs, training=None, mask=None):

--- a/ludwig/modules/attention_modules.py
+++ b/ludwig/modules/attention_modules.py
@@ -28,7 +28,7 @@ def reduce_feed_forward_attention(current_inputs, hidden_size=256):
 
 class FeedForwardAttentionReducer(Layer):
     def __init__(self, hidden_size=256):
-        super(FeedForwardAttentionReducer, self).__init__()
+        super().__init__()
 
         self.layer1 = Dense(
             hidden_size,

--- a/ludwig/modules/attention_modules.py
+++ b/ludwig/modules/attention_modules.py
@@ -20,6 +20,7 @@ from tensorflow.keras.layers import Layer, Dense
 
 logger = logging.getLogger(__name__)
 
+
 class FeedForwardAttentionReducer(Layer):
     def __init__(self, hidden_size=256):
         super(FeedForwardAttentionReducer, self).__init__()

--- a/ludwig/modules/attention_modules.py
+++ b/ludwig/modules/attention_modules.py
@@ -16,8 +16,38 @@
 import logging
 
 import tensorflow as tf
+from tensorflow.keras.layers import Layer, Dense
 
 logger = logging.getLogger(__name__)
+
+class FeedForwardAttentionReducer(Layer):
+    def __init__(self, hidden_size=256):
+        super(FeedForwardAttentionReducer, self).__init__()
+
+        self.layer1 = Dense(
+            hidden_size,
+            activation='tanh'
+        )
+        self.layer2 = Dense(
+            hidden_size,
+            activation='linear',
+            use_bias=False
+        )
+
+    def call(self, current_inputs, **kwargs):
+        hidden = self.layer1(current_inputs)
+        hidden = self.layer2(hidden)
+        attention = tf.nn.softmax(
+            tf.reshape(
+                hidden,
+                [-1, tf.shape(current_inputs)[1]]
+            )
+        )
+        geated_inputs = tf.reduce_sum(
+            tf.expand_dims(attention, -1) * current_inputs, 1)
+
+        return geated_inputs
+
 
 # todo tf2: port all these functions to tf2
 def reduce_feed_forward_attention(current_inputs, hidden_size=256):
@@ -47,82 +77,84 @@ def reduce_feed_forward_attention(current_inputs, hidden_size=256):
         logger.debug('  att_geated_inputs: {}'.format(geated_inputs))
     return geated_inputs
 
-
-def feed_forward_attention(current_inputs, feature_hidden_size,
-                           hidden_size=256):
-    with tf.variable_scope('ff_attention'):
-        geated_inputs = reduce_feed_forward_attention(current_inputs,
-                                                      hidden_size=hidden_size)
-
-        # stacking inputs and attention vectors
-        tiled_geated_inputs = tf.tile(tf.expand_dims(geated_inputs, 1),
-                                      [1, tf.shape(current_inputs)[1], 1])
-        logger.debug(
-            '  att_tiled_geated_inputs: {}'.format(tiled_geated_inputs))
-        outputs = tf.concat([current_inputs, tiled_geated_inputs],
-                            axis=-1)  # [bs x s1 x 2*h]
-        logger.debug('  att_outputs: {}'.format(outputs))
-        # outputs = current_inputs + context # [bs x s1 x h]
-
-    return outputs, feature_hidden_size * 2
-
-
-def simple_memory_attention(current_inputs, context):
-    assert current_inputs.shape[2] == context.shape[2]
-    # calculating attention
-    attention = tf.nn.softmax(
-        tf.matmul(current_inputs, context, transpose_b=True))  # [bs x s1 x s2]
-    logger.debug('  att_outputs: {}'.format(attention))
-
-    # weighted_sum(attention, encoding_sequence_embedded)
-    exp_ese = tf.expand_dims(context, 1)  # [bs x 1 x s2 x h]
-    exp_att = tf.expand_dims(attention, -1)  # [bs x s1 x s2 x 1]
-    weighted_sum = tf.multiply(exp_ese, exp_att)  # [bs x s1 x s2 x h]
-    reduced_weighted_sum = tf.reduce_sum(weighted_sum, axis=2)  # [bs x s1 x h]
-    logger.debug('  att_reduced_weighted_sum: {}'.format(reduced_weighted_sum))
-
-    # stacking inputs and attention vectors
-    outputs = tf.concat([current_inputs, reduced_weighted_sum],
-                        axis=-1)  # [bs x s1 x 2*h]
-    logger.debug('  att_outputs: {}'.format(outputs))
-
-    return outputs, outputs.shape[-1]
-
-
-def feed_forward_memory_attention(current_inputs, memory, hidden_size=256):
-    seq_len = tf.shape(current_inputs)[1]
-    mem_len = tf.shape(current_inputs)[1]
-    seq_width = current_inputs.shape[2]
-    mem_width = memory.shape[2]
-
-    inputs_tile = tf.reshape(tf.tile(current_inputs, [1, 1, mem_len]),
-                             [-1, seq_len, mem_len, seq_width])
-    context_tile = tf.reshape(tf.tile(memory, [1, seq_len, 1]),
-                              [-1, seq_len, mem_len, mem_width])
-    concat_tile = tf.concat([inputs_tile, context_tile],
-                            axis=-1)  # [bs, seq, seq, seq_w + ctx_w]
-    logger.debug('  att_input_context_concat: {}'.format(concat_tile))
-
-    with tf.variable_scope('reduce_contextual_ff_attention'):
-        weights_1 = tf.get_variable('weights_1',
-                                    [concat_tile.shape[-1], hidden_size])
-        logger.debug('  att_weights_1: {}'.format(weights_1))
-        biases_1 = tf.get_variable('biases_1', [hidden_size])
-        logger.debug('  att_biases_1: {}'.format(biases_1))
-        weights_2 = tf.get_variable('weights_2', [hidden_size, 1])
-        logger.debug('  att_weights_2: {}'.format(weights_2))
-
-        current_inputs_reshape = tf.reshape(concat_tile,
-                                            [-1, concat_tile.shape[-1]])
-        hidden = tf.tanh(
-            tf.matmul(current_inputs_reshape, weights_1) + biases_1)
-        logger.debug('  att_hidden: {}'.format(hidden))
-        attention = tf.nn.softmax(
-            tf.reshape(tf.matmul(hidden, weights_2), [-1, seq_len, mem_len]))
-        logger.debug('  att_attention: {}'.format(attention))
-        # attention [bs x seq]
-        geated_inputs = tf.reduce_sum(
-            tf.expand_dims(attention, -1) * inputs_tile, 2)
-        logger.debug('  att_geated_inputs: {}'.format(geated_inputs))
-
-    return geated_inputs, geated_inputs.shape.as_list()[-1]
+# todo future
+# def feed_forward_attention(current_inputs, feature_hidden_size,
+#                            hidden_size=256):
+#     with tf.variable_scope('ff_attention'):
+#         geated_inputs = reduce_feed_forward_attention(current_inputs,
+#                                                       hidden_size=hidden_size)
+#
+#         # stacking inputs and attention vectors
+#         tiled_geated_inputs = tf.tile(tf.expand_dims(geated_inputs, 1),
+#                                       [1, tf.shape(current_inputs)[1], 1])
+#         logger.debug(
+#             '  att_tiled_geated_inputs: {}'.format(tiled_geated_inputs))
+#         outputs = tf.concat([current_inputs, tiled_geated_inputs],
+#                             axis=-1)  # [bs x s1 x 2*h]
+#         logger.debug('  att_outputs: {}'.format(outputs))
+#         # outputs = current_inputs + context # [bs x s1 x h]
+#
+#     return outputs, feature_hidden_size * 2
+#
+#
+# todo future
+# def simple_memory_attention(current_inputs, context):
+#     assert current_inputs.shape[2] == context.shape[2]
+#     # calculating attention
+#     attention = tf.nn.softmax(
+#         tf.matmul(current_inputs, context, transpose_b=True))  # [bs x s1 x s2]
+#     logger.debug('  att_outputs: {}'.format(attention))
+#
+#     # weighted_sum(attention, encoding_sequence_embedded)
+#     exp_ese = tf.expand_dims(context, 1)  # [bs x 1 x s2 x h]
+#     exp_att = tf.expand_dims(attention, -1)  # [bs x s1 x s2 x 1]
+#     weighted_sum = tf.multiply(exp_ese, exp_att)  # [bs x s1 x s2 x h]
+#     reduced_weighted_sum = tf.reduce_sum(weighted_sum, axis=2)  # [bs x s1 x h]
+#     logger.debug('  att_reduced_weighted_sum: {}'.format(reduced_weighted_sum))
+#
+#     # stacking inputs and attention vectors
+#     outputs = tf.concat([current_inputs, reduced_weighted_sum],
+#                         axis=-1)  # [bs x s1 x 2*h]
+#     logger.debug('  att_outputs: {}'.format(outputs))
+#
+#     return outputs, outputs.shape[-1]
+#
+#
+# todo future
+# def feed_forward_memory_attention(current_inputs, memory, hidden_size=256):
+#     seq_len = tf.shape(current_inputs)[1]
+#     mem_len = tf.shape(current_inputs)[1]
+#     seq_width = current_inputs.shape[2]
+#     mem_width = memory.shape[2]
+#
+#     inputs_tile = tf.reshape(tf.tile(current_inputs, [1, 1, mem_len]),
+#                              [-1, seq_len, mem_len, seq_width])
+#     context_tile = tf.reshape(tf.tile(memory, [1, seq_len, 1]),
+#                               [-1, seq_len, mem_len, mem_width])
+#     concat_tile = tf.concat([inputs_tile, context_tile],
+#                             axis=-1)  # [bs, seq, seq, seq_w + ctx_w]
+#     logger.debug('  att_input_context_concat: {}'.format(concat_tile))
+#
+#     with tf.variable_scope('reduce_contextual_ff_attention'):
+#         weights_1 = tf.get_variable('weights_1',
+#                                     [concat_tile.shape[-1], hidden_size])
+#         logger.debug('  att_weights_1: {}'.format(weights_1))
+#         biases_1 = tf.get_variable('biases_1', [hidden_size])
+#         logger.debug('  att_biases_1: {}'.format(biases_1))
+#         weights_2 = tf.get_variable('weights_2', [hidden_size, 1])
+#         logger.debug('  att_weights_2: {}'.format(weights_2))
+#
+#         current_inputs_reshape = tf.reshape(concat_tile,
+#                                             [-1, concat_tile.shape[-1]])
+#         hidden = tf.tanh(
+#             tf.matmul(current_inputs_reshape, weights_1) + biases_1)
+#         logger.debug('  att_hidden: {}'.format(hidden))
+#         attention = tf.nn.softmax(
+#             tf.reshape(tf.matmul(hidden, weights_2), [-1, seq_len, mem_len]))
+#         logger.debug('  att_attention: {}'.format(attention))
+#         # attention [bs x seq]
+#         geated_inputs = tf.reduce_sum(
+#             tf.expand_dims(attention, -1) * inputs_tile, 2)
+#         logger.debug('  att_geated_inputs: {}'.format(geated_inputs))
+#
+#     return geated_inputs, geated_inputs.shape.as_list()[-1]

--- a/ludwig/modules/reduction_modules.py
+++ b/ludwig/modules/reduction_modules.py
@@ -122,30 +122,3 @@ reduce_mode_registry = {
     'None': dont_reduce,
     None: dont_reduce
 }
-
-# todo tf2 clean up after confirming SequenceReducerMixin is working
-# references found in BaseOutputFeature
-def reduce_sequence(sequence, mode):
-    reduce_mode = get_from_registry(
-        mode,
-        reduce_mode_registry
-    )
-    return reduce_mode(sequence)
-
-
-def reduce_sequence_list(sequence_list, mode):
-    reduce_mode = get_from_registry(
-        mode,
-        reduce_mode_registry
-    )
-    reduced_list = []
-    for sequence in sequence_list:
-        reduced_list.append(reduce_mode(sequence))
-    if len(reduced_list) > 1:
-        if reduce_mode == dont_reduce:
-            reduced_output = tf.concat(reduced_list, 2)
-        else:
-            reduced_output = tf.concat(reduced_list, 1)
-    else:
-        reduced_output = reduced_list[0]
-    return reduced_output

--- a/ludwig/modules/reduction_modules.py
+++ b/ludwig/modules/reduction_modules.py
@@ -102,12 +102,14 @@ reduce_mode_registry = {
     'max': reduce_max,
     'concat': reduce_concat,
     'attention': FeedForwardAttentionReducer(),
+    'null': dont_reduce,  # todo tf2 do we need this value,added to support text_feature()
     'none': dont_reduce,
     'None': dont_reduce,
     None: dont_reduce
 }
 
-
+# todo tf2 clean up after confirming SequenceReducerMixin is working
+# references found in BaseOutputFeature
 def reduce_sequence(sequence, mode):
     reduce_mode = get_from_registry(
         mode,

--- a/ludwig/modules/reduction_modules.py
+++ b/ludwig/modules/reduction_modules.py
@@ -16,6 +16,7 @@
 import logging
 
 import tensorflow as tf
+from tensorflow.keras.layers import Layer
 
 from ludwig.modules.attention_modules import \
     FeedForwardAttentionReducer
@@ -23,6 +24,20 @@ from ludwig.utils.misc_utils import get_from_registry
 from ludwig.utils.tf_utils import sequence_length_3D
 
 logger = logging.getLogger(__name__)
+
+
+class SequenceReducerMixin(object):
+
+    def __init__(self, reduce_output=None):
+        super().__init__()
+        self.reduce_output = reduce_output
+        self._reduce_func = get_from_registry(
+            reduce_output,
+            reduce_mode_registry
+        )
+
+    def reduce_sequence(self, inputs, **kwargs):
+        return self._reduce_func(inputs, **kwargs)
 
 
 def reduce_last(sequence, **kwargs):

--- a/ludwig/modules/reduction_modules.py
+++ b/ludwig/modules/reduction_modules.py
@@ -16,7 +16,6 @@
 import logging
 
 import tensorflow as tf
-from tensorflow.keras.layers import Layer
 
 from ludwig.modules.attention_modules import \
     FeedForwardAttentionReducer
@@ -30,7 +29,10 @@ class SequenceReducerMixin(object):
 
     def __init__(self, reduce_mode=None):
         super().__init__()
-        self.reduce_mode = reduce_mode
+        # save as private variable for debugging
+        self._reduce_mode = reduce_mode
+
+        # use registry to find required reduction function
         self._reduce_func = get_from_registry(
             reduce_mode,
             reduce_mode_registry
@@ -40,16 +42,22 @@ class SequenceReducerMixin(object):
         return self._reduce_func(inputs, **kwargs)
 
     def reduce_sequence_list(self, sequence_list, **kwargs):
+        # setup list for reduced sequence
         reduced_list = []
+
+        # for sequence provided  reduce it
         for sequence in sequence_list:
             reduced_list.append(self.reduce_sequence(sequence, **kwargs))
+
+        # consolidate reduced sequences into a single return result
         if len(reduced_list) > 1:
-            if self.reduce_mode == dont_reduce:
+            if self._reduce_mode == dont_reduce:
                 reduced_output = tf.concat(reduced_list, 2)
             else:
                 reduced_output = tf.concat(reduced_list, 1)
         else:
             reduced_output = reduced_list[0]
+
         return reduced_output
 
 

--- a/ludwig/modules/reduction_modules.py
+++ b/ludwig/modules/reduction_modules.py
@@ -43,31 +43,6 @@ class SequenceReducer(Layer):
         return self._reduce_func(inputs, **kwargs)
 
 
-class SequenceListReducer(Layer):
-    def __init__(self, reduce_mode=None):
-        super().__init__()
-        self.sequence_reducer = SequenceReducer(reduce_mode=reduce_mode)
-
-    def call(self, sequence_list, **kwargs):
-        # setup list for reduced sequence
-        reduced_list = []
-
-        # for sequence provided  reduce it
-        for sequence in sequence_list:
-            reduced_list.append(self.sequence_reducer(sequence, **kwargs))
-
-        # consolidate reduced sequences into a single return result
-        if len(reduced_list) > 1:
-            if self.sequence_reducer._reduce_func is dont_reduce:
-                reduced_output = tf.concat(reduced_list, 2)
-            else:
-                reduced_output = tf.concat(reduced_list, 1)
-        else:
-            reduced_output = reduced_list[0]
-
-        return reduced_output
-
-
 def reduce_last(sequence, **kwargs):
     batch_size = tf.shape(sequence)[0]
     sequence_length = sequence_length_3D(sequence)

--- a/ludwig/modules/reduction_modules.py
+++ b/ludwig/modules/reduction_modules.py
@@ -18,7 +18,7 @@ import logging
 import tensorflow as tf
 
 from ludwig.modules.attention_modules import \
-    reduce_feed_forward_attention
+    FeedForwardAttentionReducer
 from ludwig.utils.misc_utils import get_from_registry
 from ludwig.utils.tf_utils import sequence_length_3D
 
@@ -73,7 +73,7 @@ reduce_mode_registry = {
     'avg': reduce_mean,
     'max': reduce_max,
     'concat': reduce_concat,
-    'attention': reduce_feed_forward_attention,
+    'attention': FeedForwardAttentionReducer(),
     'none': dont_reduce,
     'None': dont_reduce,
     None: dont_reduce

--- a/ludwig/modules/reduction_modules.py
+++ b/ludwig/modules/reduction_modules.py
@@ -46,7 +46,7 @@ class SequenceReducer(Layer):
 class SequenceListReducer(Layer):
     def __init__(self, reduce_mode=None):
         super().__init__()
-        self.sequence_reducer = SequenceReducer()
+        self.sequence_reducer = SequenceReducer(reduce_mode=reduce_mode)
 
     def call(self, sequence_list, **kwargs):
         # setup list for reduced sequence
@@ -58,7 +58,7 @@ class SequenceListReducer(Layer):
 
         # consolidate reduced sequences into a single return result
         if len(reduced_list) > 1:
-            if self._reduce_mode == dont_reduce:
+            if self.sequence_reducer._reduce_func is dont_reduce:
                 reduced_output = tf.concat(reduced_list, 2)
             else:
                 reduced_output = tf.concat(reduced_list, 1)

--- a/ludwig/modules/reduction_modules.py
+++ b/ludwig/modules/reduction_modules.py
@@ -92,7 +92,6 @@ reduce_mode_registry = {
     'max': reduce_max,
     'concat': reduce_concat,
     'attention': FeedForwardAttentionReducer(),
-    'null': dont_reduce,  # todo tf2 do we need this value,added to support text_feature()
     'none': dont_reduce,
     'None': dont_reduce,
     None: dont_reduce

--- a/ludwig/modules/reduction_modules.py
+++ b/ludwig/modules/reduction_modules.py
@@ -39,8 +39,8 @@ class SequenceReducer(Layer):
             reduce_mode_registry
         )()
 
-    def call(self, inputs, **kwargs):
-        return self._reduce_obj(inputs, **kwargs)
+    def call(self, inputs, training=None, mask=None):
+        return self._reduce_obj(inputs, training=training, mask=mask)
 
 
 class ReduceLast(Layer):
@@ -49,27 +49,32 @@ class ReduceLast(Layer):
         batch_size = tf.shape(inputs)[0]
         sequence_length = sequence_length_3D(inputs)
         # gather the correct outputs from the the RNN outputs (the outputs after sequence_length are all 0s)
-        return tf.gather_nd(inputs, tf.stack(
-            [tf.range(batch_size),
-             tf.maximum(sequence_length - 1, 0)], axis=1))
+        gathered = tf.gather_nd(
+            inputs,
+            tf.stack(
+                [tf.range(batch_size), tf.maximum(sequence_length - 1, 0)],
+                axis=1
+            )
+        )
+        return gathered
 
 
 class ReduceSum(Layer):
 
     def call(self, inputs, training=None, mask=None):
-        tf.reduce_sum(inputs, axis=1)
+        return tf.reduce_sum(inputs, axis=1)
 
 
 class ReduceMean(Layer):
 
     def call(self, inputs, training=None, mask=None):
-        tf.reduce_mean(inputs, axis=1)
+        return tf.reduce_mean(inputs, axis=1)
 
 
 class ReduceMax(Layer):
 
     def call(self, inputs, training=None, mask=None):
-        tf.reduce_max(inputs, axis=1)
+        return tf.reduce_max(inputs, axis=1)
 
 
 class ReduceConcat(Layer):

--- a/ludwig/modules/reduction_modules.py
+++ b/ludwig/modules/reduction_modules.py
@@ -16,6 +16,7 @@
 import logging
 
 import tensorflow as tf
+from tensorflow.keras.layers import Layer
 
 from ludwig.modules.attention_modules import \
     FeedForwardAttentionReducer
@@ -25,7 +26,7 @@ from ludwig.utils.tf_utils import sequence_length_3D
 logger = logging.getLogger(__name__)
 
 
-class SequenceReducerMixin(object):
+class SequenceReducer(Layer):
 
     def __init__(self, reduce_mode=None):
         super().__init__()
@@ -38,16 +39,22 @@ class SequenceReducerMixin(object):
             reduce_mode_registry
         )
 
-    def reduce_sequence(self, inputs, **kwargs):
+    def call(self, inputs, **kwargs):
         return self._reduce_func(inputs, **kwargs)
 
-    def reduce_sequence_list(self, sequence_list, **kwargs):
+
+class SequenceListReducer(Layer):
+    def __init__(self, reduce_mode=None):
+        super().__init__()
+        self.sequence_reducer = SequenceReducer()
+
+    def call(self, sequence_list, **kwargs):
         # setup list for reduced sequence
         reduced_list = []
 
         # for sequence provided  reduce it
         for sequence in sequence_list:
-            reduced_list.append(self.reduce_sequence(sequence, **kwargs))
+            reduced_list.append(self.sequence_reducer(sequence, **kwargs))
 
         # consolidate reduced sequences into a single return result
         if len(reduced_list) > 1:

--- a/ludwig/modules/reduction_modules.py
+++ b/ludwig/modules/reduction_modules.py
@@ -28,16 +28,29 @@ logger = logging.getLogger(__name__)
 
 class SequenceReducerMixin(object):
 
-    def __init__(self, reduce_output=None):
+    def __init__(self, reduce_mode=None):
         super().__init__()
-        self.reduce_output = reduce_output
+        self.reduce_mode = reduce_mode
         self._reduce_func = get_from_registry(
-            reduce_output,
+            reduce_mode,
             reduce_mode_registry
         )
 
     def reduce_sequence(self, inputs, **kwargs):
         return self._reduce_func(inputs, **kwargs)
+
+    def reduce_sequence_list(self, sequence_list, **kwargs):
+        reduced_list = []
+        for sequence in sequence_list:
+            reduced_list.append(self.reduce_sequence(sequence, **kwargs))
+        if len(reduced_list) > 1:
+            if self.reduce_mode == dont_reduce:
+                reduced_output = tf.concat(reduced_list, 2)
+            else:
+                reduced_output = tf.concat(reduced_list, 1)
+        else:
+            reduced_output = reduced_list[0]
+        return reduced_output
 
 
 def reduce_last(sequence, **kwargs):

--- a/tests/integration_tests/test_dependencies.py
+++ b/tests/integration_tests/test_dependencies.py
@@ -66,19 +66,22 @@ def test_multiple_dependencies(
         'feature_name': other_hidden_layer,
     }
 
+    # setup dummy output feature to be root of dependency list
     num_feature_defn = numerical_feature()
     num_feature_defn['loss'] = {'type': 'mean_squared_error'}
     num_feature_defn['dependencies'] = ['feature_name']
     if len(dependent_hidden_shape) > 2:
         num_feature_defn['reduce_dependencies'] = reduce_dependencies
-        # expected_hidden_size = HIDDEN_SIZE + SEQ_SIZE * OTHER_HIDDEN_SIZE
 
-    if reduce_dependencies == 'concat' and len(dependent_hidden_shape) > 2:
-        expected_hidden_size = HIDDEN_SIZE + OTHER_HIDDEN_SIZE * SEQ_SIZE
+    # Based on specification calculate expected resulting hidden size for
+    # with one dependencies
+    if reduce_dependencies == 'concat' and len(hidden_shape) == 2 and \
+            len(dependent_hidden_shape) == 3:
+            expected_hidden_size = HIDDEN_SIZE + OTHER_HIDDEN_SIZE * SEQ_SIZE
     else:
         expected_hidden_size = HIDDEN_SIZE + OTHER_HIDDEN_SIZE
 
-    # set up if multiple dependencies specified
+    # set up if multiple dependencies specified, setup second depdendent feature
     if dependent_hidden_shape2:
         other_hidden_layer2 = tf.random.normal(
             dependent_hidden_shape2,
@@ -88,10 +91,12 @@ def test_multiple_dependencies(
         num_feature_defn['dependencies'].append('feature_name2')
         if len(dependent_hidden_shape2) > 2:
             num_feature_defn['reduce_dependencies'] = reduce_dependencies
-            # expected_hidden_size += SEQ_SIZE * OTHER_HIDDEN_SIZE2
 
-        if reduce_dependencies == 'concat' and len(dependent_hidden_shape2) > 2:
-            expected_hidden_size += OTHER_HIDDEN_SIZE2 * SEQ_SIZE
+        # Based on specification calculate marginal increase in resulting
+        # hidden size with two dependencies
+        if reduce_dependencies == 'concat' and len(hidden_shape) == 2 and \
+                len(dependent_hidden_shape2) == 3:
+                expected_hidden_size += OTHER_HIDDEN_SIZE2 * SEQ_SIZE
         else:
             expected_hidden_size += OTHER_HIDDEN_SIZE2
 
@@ -102,6 +107,7 @@ def test_multiple_dependencies(
         other_dependencies
     )
 
+    # confirm size of resutling concat_dependencies() call
     if len(hidden_shape) > 2:
         assert results.shape.as_list() == \
                [BATCH_SIZE, SEQ_SIZE, expected_hidden_size]

--- a/tests/integration_tests/test_dependencies.py
+++ b/tests/integration_tests/test_dependencies.py
@@ -86,8 +86,8 @@ def test_multiple_dependencies(
     if dependent_hidden_shape2:
         if reduce_dependencies == 'attention' and \
                 dependent_hidden_shape[-1] != dependent_hidden_shape2[-1]:
-                pytest.skip("Skipping: 'reduce_dependencies==attention' and "
-                            "hidden sizes not equal, {} and {}.  Invalid test"
+                pytest.skip("Invalid test case: 'reduce_dependencies==attention' and "
+                            "hidden sizes not equal, {} and {}."
                             "case".format(dependent_hidden_shape,
                                           dependent_hidden_shape2))
         other_hidden_layer2 = tf.random.normal(

--- a/tests/integration_tests/test_dependencies.py
+++ b/tests/integration_tests/test_dependencies.py
@@ -1,13 +1,10 @@
 import logging
 
 import pytest
-
 import tensorflow as tf
 
 from ludwig.features.numerical_feature import NumericalOutputFeature
-from ludwig.modules.reduction_modules import reduce_mode_registry
 from tests.integration_tests.utils import numerical_feature
-
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -84,12 +81,6 @@ def test_multiple_dependencies(
 
     # set up if multiple dependencies specified, setup second dependent feature
     if dependent_hidden_shape2:
-        if reduce_dependencies == 'attention' and \
-                dependent_hidden_shape[-1] != dependent_hidden_shape2[-1]:
-                pytest.skip("Invalid test case: 'reduce_dependencies==attention' and "
-                            "hidden sizes not equal, {} and {}."
-                            "case".format(dependent_hidden_shape,
-                                          dependent_hidden_shape2))
         other_hidden_layer2 = tf.random.normal(
             dependent_hidden_shape2,
             dtype=tf.float32

--- a/tests/integration_tests/test_dependencies.py
+++ b/tests/integration_tests/test_dependencies.py
@@ -71,8 +71,12 @@ def test_multiple_dependencies(
     num_feature_defn['dependencies'] = ['feature_name']
     if len(dependent_hidden_shape) > 2:
         num_feature_defn['reduce_dependencies'] = reduce_dependencies
+        # expected_hidden_size = HIDDEN_SIZE + SEQ_SIZE * OTHER_HIDDEN_SIZE
 
-    expected_hidden_size = HIDDEN_SIZE + OTHER_HIDDEN_SIZE
+    if reduce_dependencies == 'concat' and len(dependent_hidden_shape) > 2:
+        expected_hidden_size = HIDDEN_SIZE + OTHER_HIDDEN_SIZE * SEQ_SIZE
+    else:
+        expected_hidden_size = HIDDEN_SIZE + OTHER_HIDDEN_SIZE
 
     # set up if multiple dependencies specified
     if dependent_hidden_shape2:
@@ -84,7 +88,12 @@ def test_multiple_dependencies(
         num_feature_defn['dependencies'].append('feature_name2')
         if len(dependent_hidden_shape2) > 2:
             num_feature_defn['reduce_dependencies'] = reduce_dependencies
-        expected_hidden_size += OTHER_HIDDEN_SIZE2
+            # expected_hidden_size += SEQ_SIZE * OTHER_HIDDEN_SIZE2
+
+        if reduce_dependencies == 'concat' and len(dependent_hidden_shape2) > 2:
+            expected_hidden_size += OTHER_HIDDEN_SIZE2 * SEQ_SIZE
+        else:
+            expected_hidden_size += OTHER_HIDDEN_SIZE2
 
     # test dependency concatenation
     out_feature = NumericalOutputFeature(num_feature_defn)

--- a/tests/integration_tests/test_dependencies.py
+++ b/tests/integration_tests/test_dependencies.py
@@ -44,7 +44,8 @@ OTHER_HIDDEN_SIZE2 = 18
     ]
 )
 @pytest.mark.parametrize(
-    'reduce_dependencies', ['sum', 'mean', 'avg', 'max', 'concat', 'last']
+    'reduce_dependencies', ['sum', 'mean', 'avg', 'max',
+                            'concat', 'last', 'attention']
 )
 def test_multiple_dependencies(
         reduce_dependencies,

--- a/tests/integration_tests/test_reducers.py
+++ b/tests/integration_tests/test_reducers.py
@@ -21,22 +21,4 @@ def test_reduction(reduce_output, csv_filename):
     run_experiment(input_features, output_features, data_csv=rel_path)
 
 
-def test_dependencies_reduction(csv_filename):
-    input_features = [
-        sequence_feature(reduce_output=None)
-    ]
-
-    output_features = [
-        category_feature(reduce_input=None, reduce_dependencies='sum'),
-        category_feature(reduce_input=None, reduce_dependencies='sum')
-    ]
-    feature1_name = output_features[0]['name']
-    output_features[1]['dependencies'] = [feature1_name]
-
-    rel_path = generate_data(input_features, output_features, csv_filename)
-    run_experiment(input_features, output_features, data_csv=rel_path)
-
-
-
-
 

--- a/tests/integration_tests/test_reducers.py
+++ b/tests/integration_tests/test_reducers.py
@@ -20,5 +20,8 @@ def test_reduction(reduce_output, csv_filename):
     rel_path = generate_data(input_features, output_features, csv_filename)
     run_experiment(input_features, output_features, data_csv=rel_path)
 
+    del(input_features)
+    del(output_features)
+
 
 

--- a/tests/integration_tests/test_reducers.py
+++ b/tests/integration_tests/test_reducers.py
@@ -1,0 +1,20 @@
+import pytest
+
+from ludwig.modules.reduction_modules import reduce_mode_registry
+from tests.integration_tests.utils import generate_data, run_experiment
+from tests.integration_tests.utils import sequence_feature, category_feature
+
+
+@pytest.mark.parametrize('reduce_output', reduce_mode_registry)
+def test_reduction(reduce_output, csv_filename):
+
+    input_features = [
+        sequence_feature(reduce_output=reduce_output)
+    ]
+
+    output_features = [
+        category_feature()
+    ]
+
+    rel_path = generate_data(input_features, output_features, csv_filename)
+    run_experiment(input_features, output_features, data_csv=rel_path)

--- a/tests/integration_tests/test_reducers.py
+++ b/tests/integration_tests/test_reducers.py
@@ -1,4 +1,5 @@
 import pytest
+import tensorflow as tf
 
 from ludwig.modules.reduction_modules import reduce_mode_registry
 from tests.integration_tests.utils import generate_data, run_experiment
@@ -18,3 +19,24 @@ def test_reduction(reduce_output, csv_filename):
 
     rel_path = generate_data(input_features, output_features, csv_filename)
     run_experiment(input_features, output_features, data_csv=rel_path)
+
+
+def test_dependencies_reduction(csv_filename):
+    input_features = [
+        sequence_feature(reduce_output=None)
+    ]
+
+    output_features = [
+        category_feature(reduce_input=None, reduce_dependencies='sum'),
+        category_feature(reduce_input=None, reduce_dependencies='sum')
+    ]
+    feature1_name = output_features[0]['name']
+    output_features[1]['dependencies'] = [feature1_name]
+
+    rel_path = generate_data(input_features, output_features, csv_filename)
+    run_experiment(input_features, output_features, data_csv=rel_path)
+
+
+
+
+

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -88,7 +88,7 @@ def text_feature(**kwargs):
     feature = {
         'name': 'text_' + random_string(),
         'type': 'text',
-        'reduce_input': 'null',
+        'reduce_input': None,
         'vocab_size': 5,
         'min_len': 7,
         'max_len': 7,

--- a/tests/ludwig/modules/test_attention.py
+++ b/tests/ludwig/modules/test_attention.py
@@ -4,15 +4,13 @@ import tensorflow as tf
 from ludwig.modules.attention_modules import FeedForwardAttentionReducer
 
 
-@pytest.mark.parametrize('reducer_hidden_size', [128, 256, 512])
-@pytest.mark.parametrize('input_hidden_size', [128, 256])
+@pytest.mark.parametrize('input_hidden_size', [128, 256, 512])
 @pytest.mark.parametrize('input_seq_size', [10, 20])
 @pytest.mark.parametrize('input_batch_size', [16, 32])
 def test_feed_forward_attention_reducer(
         input_batch_size,
         input_seq_size,
-        input_hidden_size,
-        reducer_hidden_size
+        input_hidden_size
 ):
 
     # Generate synthetic data
@@ -22,9 +20,7 @@ def test_feed_forward_attention_reducer(
     )
 
     # instantiate feed forward attention reducer
-    feed_forward_attention_reducer = FeedForwardAttentionReducer(
-        hidden_size=reducer_hidden_size
-    )
+    feed_forward_attention_reducer = FeedForwardAttentionReducer()
 
     result = feed_forward_attention_reducer(current_inputs)
 

--- a/tests/ludwig/modules/test_attention.py
+++ b/tests/ludwig/modules/test_attention.py
@@ -1,0 +1,33 @@
+import pytest
+
+import tensorflow as tf
+from ludwig.modules.attention_modules import FeedForwardAttentionReducer
+
+
+@pytest.mark.parametrize('reducer_hidden_size', [128, 256, 512])
+@pytest.mark.parametrize('input_hidden_size', [128, 256])
+@pytest.mark.parametrize('input_seq_size', [10, 20])
+@pytest.mark.parametrize('input_batch_size', [16, 32])
+def test_feed_forward_attention_reducer(
+        input_batch_size,
+        input_seq_size,
+        input_hidden_size,
+        reducer_hidden_size
+):
+
+    # Generate synthetic data
+    current_inputs = tf.random.normal(
+        [input_batch_size, input_seq_size, input_hidden_size],
+        dtype=tf.float32
+    )
+
+    # instantiate feed forward attention reducer
+    feed_forward_attention_reducer = FeedForwardAttentionReducer(
+        hidden_size=reducer_hidden_size
+    )
+
+    result = feed_forward_attention_reducer(current_inputs)
+
+    # ensure returned tensor is the correct shape
+    assert result.shape.as_list() == [input_batch_size, input_hidden_size]
+


### PR DESCRIPTION
# Code Pull Requests

Converted this function from TF1 to TF2 implementation
```
# # todo tf2: port all these functions to tf2
# def reduce_feed_forward_attention(current_inputs, hidden_size=256):
```

Converted function to `tf.keras.layers.Layer` subclass.

In addition to converting the function, added unit test `tests/ludwig/modules/test_attention.py` for the converted function.  Current scope of test is confirming correct output tensor shape for various input tensor sizes and specification of the reducer's `hidden_size` parameter.
```
 pytest -v /opt/project/tests/ludwig/modules/test_attention.py
=========================================================== test session starts ============================================================
platform linux -- Python 3.6.9, pytest-6.0.1, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /opt/project
plugins: xdist-2.0.0, forked-1.3.0, pycharm-0.7.0, typeguard-2.9.1
collected 24 items

../../tests/ludwig/modules/test_attention.py::test_feed_forward_attention_reducer[16-10-128-128] PASSED                              [  4%]
../../tests/ludwig/modules/test_attention.py::test_feed_forward_attention_reducer[16-10-128-256] PASSED                              [  8%]
../../tests/ludwig/modules/test_attention.py::test_feed_forward_attention_reducer[16-10-128-512] PASSED                              [ 12%]
../../tests/ludwig/modules/test_attention.py::test_feed_forward_attention_reducer[16-10-256-128] PASSED                              [ 16%]
../../tests/ludwig/modules/test_attention.py::test_feed_forward_attention_reducer[16-10-256-256] PASSED                              [ 20%]
../../tests/ludwig/modules/test_attention.py::test_feed_forward_attention_reducer[16-10-256-512] PASSED                              [ 25%]
../../tests/ludwig/modules/test_attention.py::test_feed_forward_attention_reducer[16-20-128-128] PASSED                              [ 29%]
../../tests/ludwig/modules/test_attention.py::test_feed_forward_attention_reducer[16-20-128-256] PASSED                              [ 33%]
../../tests/ludwig/modules/test_attention.py::test_feed_forward_attention_reducer[16-20-128-512] PASSED                              [ 37%]
../../tests/ludwig/modules/test_attention.py::test_feed_forward_attention_reducer[16-20-256-128] PASSED                              [ 41%]
../../tests/ludwig/modules/test_attention.py::test_feed_forward_attention_reducer[16-20-256-256] PASSED                              [ 45%]
../../tests/ludwig/modules/test_attention.py::test_feed_forward_attention_reducer[16-20-256-512] PASSED                              [ 50%]
../../tests/ludwig/modules/test_attention.py::test_feed_forward_attention_reducer[32-10-128-128] PASSED                              [ 54%]
../../tests/ludwig/modules/test_attention.py::test_feed_forward_attention_reducer[32-10-128-256] PASSED                              [ 58%]
../../tests/ludwig/modules/test_attention.py::test_feed_forward_attention_reducer[32-10-128-512] PASSED                              [ 62%]
../../tests/ludwig/modules/test_attention.py::test_feed_forward_attention_reducer[32-10-256-128] PASSED                              [ 66%]
../../tests/ludwig/modules/test_attention.py::test_feed_forward_attention_reducer[32-10-256-256] PASSED                              [ 70%]
../../tests/ludwig/modules/test_attention.py::test_feed_forward_attention_reducer[32-10-256-512] PASSED                              [ 75%]
../../tests/ludwig/modules/test_attention.py::test_feed_forward_attention_reducer[32-20-128-128] PASSED                              [ 79%]
../../tests/ludwig/modules/test_attention.py::test_feed_forward_attention_reducer[32-20-128-256] PASSED                              [ 83%]
../../tests/ludwig/modules/test_attention.py::test_feed_forward_attention_reducer[32-20-128-512] PASSED                              [ 87%]
../../tests/ludwig/modules/test_attention.py::test_feed_forward_attention_reducer[32-20-256-128] PASSED                              [ 91%]
../../tests/ludwig/modules/test_attention.py::test_feed_forward_attention_reducer[32-20-256-256] PASSED                              [ 95%]
../../tests/ludwig/modules/test_attention.py::test_feed_forward_attention_reducer[32-20-256-512] PASSED                              [100%]

============================================================ 24 passed in 0.55s ============================================================
```