### PR TITLE
Switch from ValueError to Warning to make stratify work on non-output features

### DIFF
--- a/ludwig/utils/defaults.py
+++ b/ludwig/utils/defaults.py
@@ -181,11 +181,12 @@ def merge_with_defaults(model_definition):
     if stratify is not None:
         if stratify not in [x['name'] for x in
                             model_definition['output_features']]:
-            warnings.warn('Stratify must be in output features')
+            warnings.warn('Stratify is not in output features. '
+                          'Expecting type to be binary or category')
         elif ([x for x in model_definition['output_features'] if
              x['name'] == stratify][0][TYPE]
                 not in [BINARY, CATEGORY]):
-            warnings.warn('Stratify feature must be binary or category')
+            raise ValueError('Stratify feature must be binary or category')
     # ===== Model =====
     set_default_value(model_definition, 'combiner',
                       {'type': default_combiner_type})

--- a/ludwig/utils/defaults.py
+++ b/ludwig/utils/defaults.py
@@ -21,6 +21,7 @@ from ludwig.features.feature_registries import output_type_registry
 from ludwig.utils.misc_utils import get_from_registry
 from ludwig.utils.misc_utils import merge_dict
 from ludwig.utils.misc_utils import set_default_value
+import warnings
 
 default_random_seed = 42
 
@@ -180,11 +181,11 @@ def merge_with_defaults(model_definition):
     if stratify is not None:
         if stratify not in [x['name'] for x in
                             model_definition['output_features']]:
-            raise ValueError('Stratify must be in output features')
-        if ([x for x in model_definition['output_features'] if
+            warnings.warn('Stratify must be in output features')
+        elif ([x for x in model_definition['output_features'] if
              x['name'] == stratify][0][TYPE]
                 not in [BINARY, CATEGORY]):
-            raise ValueError('Stratify feature must be binary or category')
+            warnings.warn('Stratify feature must be binary or category')
     # ===== Model =====
     set_default_value(model_definition, 'combiner',
                       {'type': default_combiner_type})


### PR DESCRIPTION
This addresses feature request #850 
It seems to work fine (although I don't know how to actually check that stratification has been done in the corresponding hdf5 file).

The only concern is that the warning message might go unnoticed, since it's somewhat lost in the initialization printouts