### PR TITLE
Fixed TF 2.3 compatibility by not passing None values as layer input during symbolic model construction

### DIFF
--- a/ludwig/features/base_feature.py
+++ b/ludwig/features/base_feature.py
@@ -225,12 +225,12 @@ class OutputFeature(BaseFeature, tf.keras.Model, ABC):
 
     def call(
             self,
-            inputs,  # ((hidden, other_output_hidden), target)
+            inputs,  # ((hidden, other_output_hidden), target) or (hidden, other_output_hidden)
             training=None,
             mask=None
     ):
         # account for output feature target
-        if isinstance(inputs, tuple):
+        if isinstance(inputs[0], tuple):
             local_inputs, target = inputs
         else:
             local_inputs = inputs

--- a/ludwig/models/ecd.py
+++ b/ludwig/models/ecd.py
@@ -98,19 +98,15 @@ class ECD(tf.keras.Model):
         output_last_hidden = {}
         for output_feature_name, decoder in self.output_features.items():
             # use presence or absence of targets to signal training or prediction
+            decoder_inputs = (combiner_outputs, copy.copy(output_last_hidden))
             if targets is not None:
-                # doing training
+                # targets are only used during training, during prediction they are omitted
                 target_to_use = tf.cast(targets[output_feature_name],
                                         dtype=tf.int32)
-            else:
-                # doing prediction
-                target_to_use = None
+                decoder_inputs = (decoder_inputs, target_to_use)
 
             decoder_logits, decoder_last_hidden = decoder(
-                (
-                    (combiner_outputs, copy.copy(output_last_hidden)),
-                    target_to_use
-                ),
+                decoder_inputs,
                 training=training,
                 mask=mask
             )

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ scipy>=0.18
 tabulate>=0.7
 scikit-learn
 tqdm
-tensorflow>=2.2,<2.3
+tensorflow>=2.2,<2.4
 tfa-nightly==0.12.0.dev20200820045606
 PyYAML>=3.12
 absl-py


### PR DESCRIPTION
This was accomplished by changing the input signature of `OutputFeature.call` to omit `None` targets during prediction.