### PR TITLE
Fixed beam search decoding to use predictions from FinalBeamSearchDecoderOutput

### DIFF
--- a/ludwig/decoders/sequence_decoders.py
+++ b/ludwig/decoders/sequence_decoders.py
@@ -413,7 +413,7 @@ class SequenceGeneratorDecoder(Layer):
             ),
         )
 
-        predictions = decoder_output.beam_search_decoder_output.predicted_ids[:, :, 0]
+        predictions = decoder_output.predicted_ids[:, :, 0]
         logits = decoder_output.beam_search_decoder_output.scores[:, :, 0, :]
         lengths = decoder_lengths[:, 0]
 


### PR DESCRIPTION
Previously we were using the "raw" predictions.  However, the actual predictions need to be reconstructed by following the parent IDs at each step to reconstruct the full beam sequence, which is what is contained in [FinalBeamSearchDecoderOutput](https://www.tensorflow.org/addons/api_docs/python/tfa/seq2seq/FinalBeamSearchDecoderOutput).

Related: #859.

