### PR TITLE
Fixed merge issue by restoring usage of postprocess_predictions

### DIFF
--- a/ludwig/data/postprocessing.py
+++ b/ludwig/data/postprocessing.py
@@ -52,8 +52,7 @@ def postprocess_dict(
 ):
     postprocessed = {}
     for of_name, output_feature in output_features.items():
-        output_feature.postprocess_results(
-            output_feature,
+        postprocessed[of_name] = output_feature.postprocess_predictions(
             predictions[of_name],
             training_set_metadata.get(of_name, {}),
             experiment_dir_name=experiment_dir_name,

--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -269,16 +269,15 @@ class BinaryOutputFeature(BinaryFeatureMixin, OutputFeature):
             average='samples'
         )
 
-    @staticmethod
-    def postprocess_results(
-            output_feature,
+    def postprocess_predictions(
+            self,
             result,
             metadata,
             experiment_dir_name,
             skip_save_unprocessed_output=False,
     ):
         postprocessed = {}
-        name = output_feature['name']
+        name = self.feature_name
 
         npy_filename = None
         if is_on_master():

--- a/ludwig/features/numerical_feature.py
+++ b/ludwig/features/numerical_feature.py
@@ -291,7 +291,7 @@ class NumericalOutputFeature(NumericalFeatureMixin, OutputFeature):
     ):
         pass
 
-    def postprocess_results(
+    def postprocess_predictions(
             self,
             predictions,
             metadata,

--- a/ludwig/features/sequence_feature.py
+++ b/ludwig/features/sequence_feature.py
@@ -385,16 +385,15 @@ class SequenceOutputFeature(SequenceFeatureMixin, OutputFeature):
         stats['overall_stats'] = confusion_matrix.stats()
         stats['per_class_stats'] = confusion_matrix.per_class_stats()
 
-    @staticmethod
-    def postprocess_results(
-            output_feature,
+    def postprocess_predictions(
+            self,
             result,
             metadata,
             experiment_dir_name,
             skip_save_unprocessed_output=False,
     ):
         postprocessed = {}
-        name = output_feature['name']
+        name = self.feature_name
 
         npy_filename = None
         if is_on_master():

--- a/ludwig/features/set_feature.py
+++ b/ludwig/features/set_feature.py
@@ -234,16 +234,15 @@ class SetOutputFeature(SetFeatureMixin, OutputFeature):
     ):
         pass
 
-    @staticmethod
-    def postprocess_results(
-            output_feature,
+    def postprocess_predictions(
+            self,
             result,
             metadata,
             experiment_dir_name,
             skip_save_unprocessed_output=False,
     ):
         postprocessed = {}
-        name = output_feature['name']
+        name = self.feature_name
 
         npy_filename = None
         if is_on_master():

--- a/ludwig/features/text_feature.py
+++ b/ludwig/features/text_feature.py
@@ -412,18 +412,17 @@ class TextOutputFeature(TextFeatureMixin, SequenceOutputFeature):
         stats['overall_stats'] = confusion_matrix.stats()
         stats['per_class_stats'] = confusion_matrix.per_class_stats()
 
-    @staticmethod
-    def postprocess_results(
-            output_feature,
+    def postprocess_predictions(
+            self,
             result,
             metadata,
             experiment_dir_name,
             skip_save_unprocessed_output=False,
     ):
-        # todo: refactor to reuse SeuuqnceOutputFeature.postprocess_results
+        # todo: refactor to reuse SequenceOutputFeature.postprocess_predictions
         postprocessed = {}
-        name = output_feature['name']
-        level_idx2str = '{}_{}'.format(output_feature['level'], 'idx2str')
+        name = self.feature_name
+        level_idx2str = '{}_{}'.format(self.level, 'idx2str')
 
         npy_filename = None
         if is_on_master():

--- a/ludwig/features/timeseries_feature.py
+++ b/ludwig/features/timeseries_feature.py
@@ -408,9 +408,9 @@ class TimeseriesInputFeature(TimeseriesFeatureMixin, SequenceInputFeature):
 #     ):
 #         pass
 #
-#     @staticmethod
-#     def postprocess_results(
-#             output_feature,
+#
+#     def postprocess_predictions(
+#             self,
 #             result,
 #             metadata,
 #             experiment_dir_name,

--- a/ludwig/features/vector_feature.py
+++ b/ludwig/features/vector_feature.py
@@ -283,16 +283,15 @@ class VectorOutputFeature(VectorFeatureMixin, OutputFeature):
     ):
         pass
 
-    @staticmethod
-    def postprocess_results(
-            output_feature,
+    def postprocess_predictions(
+            self,
             result,
             metadata,
             experiment_dir_name,
             skip_save_unprocessed_output=False,
     ):
         postprocessed = {}
-        name = output_feature['name']
+        name = self.feature_name
 
         npy_filename = None
         if is_on_master():

--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -684,7 +684,8 @@ class Trainer:
                 if is_on_master():
                     if not self._skip_save_model:
                         model.save_weights(model_weights_path)
-                        model.save_definition(model_hyperparameters_path)
+                        # TODO(refactor): this is currently handled by LudwigModel
+                        # model.save_definition(model_hyperparameters_path)
 
             # ========== Save training progress ==========
             if is_on_master():
@@ -696,10 +697,11 @@ class Trainer:
                             TRAINING_PROGRESS_TRACKER_FILE_NAME
                         )
                     )
-                    if self._skip_save_model:
-                        model.save_definition(
-                            model_hyperparameters_path
-                        )
+                    # TODO(refactor): this is currently handled by LudwigModel
+                    # if self._skip_save_model:
+                    #     model.save_definition(
+                    #         model_hyperparameters_path
+                    #     )
 
             if is_on_master():
                 contrib_command("train_epoch_end", progress_tracker)
@@ -843,7 +845,8 @@ class Trainer:
             if is_on_master():
                 if not skip_save_model:
                     model.save_weights(model_weights_path)
-                    model.save_definition(model_hyperparameters_path)
+                    # TODO(refactor): this is currently handled by LudwigModel
+                    # model.save_definition(model_hyperparameters_path)
                     logger.info(
                         'Validation {} on {} improved, model saved'.format(
                             validation_metric,


### PR DESCRIPTION
Restored `postprocess_predictions` method from https://github.com/uber/ludwig/pull/801/commits/8985702823a515f706824f208e406740211765d6 that was reverted during an upstream merge.

Also comments out usage of `model.save_definition` in `Trainer` until we have a solution in place.