### PR TITLE
Fixed horovod tests

### DIFF
--- a/ludwig/hyperopt/execution.py
+++ b/ludwig/hyperopt/execution.py
@@ -60,7 +60,7 @@ class HyperoptExecutor(ABC):
             gpus=None,
             gpu_memory_limit=None,
             allow_parallel_threads=True,
-            use_horovod=False,
+            use_horovod=None,
             random_seed=default_random_seed,
             debug=False,
             **kwargs
@@ -103,7 +103,7 @@ class SerialExecutor(HyperoptExecutor):
             gpus=None,
             gpu_memory_limit=None,
             allow_parallel_threads=True,
-            use_horovod=False,
+            use_horovod=None,
             random_seed=default_random_seed,
             debug=False,
             **kwargs
@@ -251,7 +251,7 @@ class ParallelExecutor(HyperoptExecutor):
             gpus=None,
             gpu_memory_limit=None,
             allow_parallel_threads=True,
-            use_horovod=False,
+            use_horovod=None,
             random_seed=default_random_seed,
             debug=False,
             **kwargs
@@ -503,7 +503,7 @@ class FiberExecutor(HyperoptExecutor):
             gpus=None,
             gpu_memory_limit=None,
             allow_parallel_threads=True,
-            use_horovod=False,
+            use_horovod=None,
             random_seed=default_random_seed,
             debug=False,
             **kwargs
@@ -661,7 +661,7 @@ def train_and_eval_on_split(
         gpus=None,
         gpu_memory_limit=None,
         allow_parallel_threads=True,
-        use_horovod=False,
+        use_horovod=None,
         random_seed=default_random_seed,
         debug=False,
         **kwargs

--- a/ludwig/hyperopt_cli.py
+++ b/ludwig/hyperopt_cli.py
@@ -77,7 +77,7 @@ def hyperopt(
         gpus=None,
         gpu_memory_limit=None,
         allow_parallel_threads=True,
-        use_horovod=False,
+        use_horovod=None,
         random_seed=default_random_seed,
         debug=False,
         **kwargs,

--- a/ludwig/models/new_ludwig_model.py
+++ b/ludwig/models/new_ludwig_model.py
@@ -40,7 +40,7 @@ class NewLudwigModel:
                  model_definition=None,
                  model_definition_fp=None,
                  logging_level=logging.ERROR,
-                 use_horovod=False,
+                 use_horovod=None,
                  gpus=None,
                  gpu_memory_limit=None,
                  allow_parallel_threads=True,
@@ -890,7 +890,7 @@ class NewLudwigModel:
     @staticmethod
     def load(model_dir,
              logging_level=logging.ERROR,
-             use_horovod=False,
+             use_horovod=None,
              gpus=None,
              gpu_memory_limit=None,
              allow_parallel_threads=True):

--- a/tests/integration_tests/scripts/run_train_horovod.py
+++ b/tests/integration_tests/scripts/run_train_horovod.py
@@ -37,7 +37,7 @@ parser.add_argument('--output-features', required=True)
 parser.add_argument('--ludwig-kwargs', required=True)
 
 
-def run_api_experiment(input_features, output_features, data_csv, **kwargs):
+def run_api_experiment(input_features, output_features, dataset, **kwargs):
     model_definition = {
         'input_features': input_features,
         'output_features': output_features,
@@ -50,11 +50,11 @@ def run_api_experiment(input_features, output_features, data_csv, **kwargs):
     try:
         # Training with csv
         model.train(
-            data_csv=data_csv,
+            dataset=dataset,
             **kwargs
         )
 
-        model.predict(data_csv=data_csv)
+        model.predict(dataset=dataset)
     finally:
         if model.exp_dir_name:
             shutil.rmtree(model.exp_dir_name, ignore_errors=True)
@@ -62,7 +62,9 @@ def run_api_experiment(input_features, output_features, data_csv, **kwargs):
 
 def test_horovod_intent_classification(rel_path, input_features,
                                        output_features, **kwargs):
-    run_api_experiment(input_features, output_features, data_csv=rel_path,
+    run_api_experiment(input_features,
+                       output_features,
+                       dataset=rel_path,
                        **kwargs)
 
     # Horovod should be initialized following training. If not, this will raise an exception.

--- a/tests/integration_tests/test_graph_execution.py
+++ b/tests/integration_tests/test_graph_execution.py
@@ -83,7 +83,7 @@ def test_experiment_multiple_seq_seq(csv_filename, output_features):
         output_features = output_features
 
         rel_path = generate_data(input_features, output_features, csv_filename)
-        run_experiment(input_features, output_features, data_csv=rel_path)
+        run_experiment(input_features, output_features, dataset=rel_path)
 
 
 @pytest.mark.parametrize('dec_beam_width', [3])
@@ -134,4 +134,4 @@ def test_sequence_generator(
         output_features[0]['beam_width'] = dec_beam_width
 
         # run the experiment
-        run_experiment(input_features, output_features, data_csv=rel_path)
+        run_experiment(input_features, output_features, dataset=rel_path)


### PR DESCRIPTION
Set param `use_horovod` default to `None` to enable implicit usage of Horovod from `horovodrun`.