### PR TITLE
Fixed remaining visualization tests

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -701,7 +701,6 @@ class LudwigModel:
 
         if collect_predictions:
             logger.debug('Postprocessing')
-            print('predictions: {} {}'.format(type(predictions), predictions))
             postproc_predictions = postprocess(
                 predictions,
                 self.model.output_features,

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -373,9 +373,7 @@ class LudwigModel:
                 random_seed=random_seed
             )
             if not skip_save_training_description:
-                # todo refactoring: datasets are not JSON serializable
-                # save_json(description_fn, description)
-                pass
+                save_json(description_fn, description)
             # print description
             logger.info('Experiment name: {}'.format(experiment_name))
             logger.info('Model name: {}'.format(model_name))

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -361,7 +361,6 @@ class LudwigModel:
 
         # save description
         if is_on_master():
-            # todo refactoring: fix this
             description = get_experiment_description(
                 self.model_definition,
                 dataset=dataset,
@@ -763,7 +762,7 @@ class LudwigModel:
             skip_save_progress=False,
             skip_save_log=False,
             skip_save_processed_input=False,
-            skip_save_unprocessed_output=False,  # skipcq: PYL-W0613
+            skip_save_unprocessed_output=False,
             skip_save_predictions=False,
             skip_save_eval_stats=False,
             skip_collect_predictions=False,
@@ -797,6 +796,7 @@ class LudwigModel:
             skip_save_progress=skip_save_progress,
             skip_save_log=skip_save_log,
             skip_save_processed_input=skip_save_processed_input,
+            skip_save_unprocessed_output=skip_save_unprocessed_output,
             output_directory=output_directory,
             gpus=gpus,
             gpu_memory_limit=gpu_memory_limit,
@@ -832,6 +832,7 @@ class LudwigModel:
                 test_set,
                 data_format=data_format,
                 batch_size=batch_size,
+                skip_save_unprocessed_output=skip_save_unprocessed_output,
                 skip_save_predictions=skip_save_predictions,
                 skip_save_eval_stats=skip_save_eval_stats,
                 collect_predictions=not skip_collect_predictions,

--- a/ludwig/experiment.py
+++ b/ludwig/experiment.py
@@ -215,6 +215,7 @@ def experiment_cli(
         skip_save_progress=skip_save_progress,
         skip_save_log=skip_save_log,
         skip_save_processed_input=skip_save_processed_input,
+        skip_save_unprocessed_output=skip_save_unprocessed_output,
         skip_save_predictions=skip_save_predictions,
         skip_save_eval_stats=skip_save_eval_stats,
         skip_collect_predictions=skip_collect_predictions,

--- a/ludwig/models/predictor.py
+++ b/ludwig/models/predictor.py
@@ -278,14 +278,18 @@ def calculate_overall_stats(
 def save_prediction_outputs(
         postprocessed_output,
         experiment_dir_name,
+        skip_output_types=None
 ):
-    csv_filename = os.path.join(experiment_dir_name, '{}.csv')
+    if skip_output_types is None:
+        skip_output_types = set()
+    csv_filename = os.path.join(experiment_dir_name, '{}_{}.csv')
     for output_field, outputs in postprocessed_output.items():
-        values = outputs.to_numpy()
-        save_csv(
-            csv_filename.format(output_field),
-            values
-        )
+        for output_type, values in outputs.items():
+            if output_type not in skip_output_types:
+                save_csv(
+                    csv_filename.format(output_field, output_type),
+                    values
+                )
 
 
 def save_evaluation_stats(test_stats, experiment_dir_name):

--- a/ludwig/utils/misc_utils.py
+++ b/ludwig/utils/misc_utils.py
@@ -26,8 +26,7 @@ from collections.abc import Mapping
 import numpy
 
 import ludwig.globals
-from ludwig.utils.data_utils import figure_data_format, CSV_FORMATS, \
-    HDF5_FORMATS
+from ludwig.utils.data_utils import figure_data_format
 
 
 def get_experiment_description(
@@ -59,26 +58,30 @@ def get_experiment_description(
     if random_seed is not None:
         description['random_seed'] = random_seed
 
+    if isinstance(dataset, str):
+        description['dataset'] = dataset
+    if isinstance(training_set, str):
+        description['training_set'] = training_set
+    if isinstance(validation_set, str):
+        description['validation_set'] = validation_set
+    if isinstance(test_set, str):
+        description['test_set'] = test_set
+    if training_set_metadata is not None:
+        description['training_set_metadata'] = training_set_metadata
+
     # determine data format if not provided or auto
     if not data_format or data_format == 'auto':
         data_format = figure_data_format(
             dataset, training_set, validation_set, test_set
         )
 
-    if data_format in CSV_FORMATS or data_format in HDF5_FORMATS:
-        if dataset: description['dataset'] = dataset
-        if training_set: description['training_set'] = training_set
-        if validation_set: description['validation_set'] = validation_set
-        if test_set: description['test_set'] = test_set
-        if training_set_metadata:
-            description['training_set_metadata'] = training_set_metadata
-
-    if data_format: description['data_format'] = data_format
+    if data_format:
+        description['data_format'] = str(data_format)
 
     description['model_definition'] = model_definition
 
-    from tensorflow.version import VERSION as tf_version
-    description['tf_version'] = tf_version
+    import tensorflow as tf
+    description['tf_version'] = tf.__version__
 
     return description
 

--- a/tests/integration_tests/test_visualization_api.py
+++ b/tests/integration_tests/test_visualization_api.py
@@ -289,7 +289,7 @@ def test_compare_classifiers_multiclass_multimetric_vis_api(csv_filename):
     """
     experiment = Experiment(csv_filename)
     # extract test stats only
-    test_stats = experiment.test_stats_full[1][0]
+    test_stats = experiment.test_stats_full
     viz_outputs = ('pdf', 'png')
     for viz_output in viz_outputs:
         vis_output_pattern_pdf = experiment.model.exp_dir_name + '/*.{}'.format(
@@ -502,16 +502,17 @@ def test_confidence_thresholding_2thresholds_2d_vis_api(csv_filename):
         training_set=train_df,
         validation_set=val_df
     )
-    test_stats, _ = model.evaluate(
-        dataset=test_df
+    test_stats, predictions = model.evaluate(
+        dataset=test_df,
+        collect_predictions=True,
     )
 
     output_feature_name1 = output_features[0]['name']
     output_feature_name2 = output_features[1]['name']
     # probabilities need to be list of lists containing each row data from the
     # probability columns ref: https://ludwig-ai.github.io/ludwig-docs/api/#test - Return
-    probability1 = test_stats[0].iloc[:, [2, 3, 4]].values
-    probability2 = test_stats[0].iloc[:, [7, 8, 9]].values
+    probability1 = predictions.iloc[:, [2, 3, 4]].values
+    probability2 = predictions.iloc[:, [7, 8, 9]].values
 
     ground_truth_metadata = model.training_set_metadata
     target_predictions1 = test_df[output_feature_name1]
@@ -568,16 +569,17 @@ def test_confidence_thresholding_2thresholds_3d_vis_api(csv_filename):
         training_set=train_df,
         validation_set=val_df
     )
-    test_stats, _ = model.evaluate(
-        dataset=test_df
+    test_stats, predictions = model.evaluate(
+        dataset=test_df,
+        collect_predictions=True,
     )
 
     output_feature_name1 = output_features[0]['name']
     output_feature_name2 = output_features[1]['name']
     # probabilities need to be list of lists containing each row data from the
     # probability columns ref: https://ludwig-ai.github.io/ludwig-docs/api/#test - Return
-    probability1 = test_stats[0].iloc[:, [2, 3, 4]].values
-    probability2 = test_stats[0].iloc[:, [7, 8, 9]].values
+    probability1 = predictions.iloc[:, [2, 3, 4]].values
+    probability2 = predictions.iloc[:, [7, 8, 9]].values
 
     ground_truth_metadata = model.training_set_metadata
     target_predictions1 = test_df[output_feature_name1]
@@ -680,7 +682,7 @@ def test_roc_curves_from_test_statistics_vis_api(csv_filename):
     model.train(dataset=data_df)
     # extract test metrics
     test_stats, _ = model.evaluate(dataset=data_df)
-    test_stats = test_stats[1][0]
+    test_stats = test_stats
     viz_outputs = ('pdf', 'png')
     for viz_output in viz_outputs:
         vis_output_pattern_pdf = model.exp_dir_name + '/*.{}'.format(
@@ -758,7 +760,7 @@ def test_confusion_matrix_vis_api(csv_filename):
     """
     experiment = Experiment(csv_filename)
     # extract test stats only
-    test_stats = experiment.test_stats_full[1][0]
+    test_stats = experiment.test_stats_full
     viz_outputs = ('pdf', 'png')
     for viz_output in viz_outputs:
         vis_output_pattern_pdf = experiment.model.exp_dir_name + '/*.{}'.format(
@@ -787,7 +789,7 @@ def test_frequency_vs_f1_vis_api(csv_filename):
     """
     experiment = Experiment(csv_filename)
     # extract test stats
-    test_stats = experiment.test_stats_full[1][0]
+    test_stats = experiment.test_stats_full
     viz_outputs = ('pdf', 'png')
     for viz_output in viz_outputs:
         vis_output_pattern_pdf = experiment.model.exp_dir_name + '/*.{}'.format(

--- a/tests/integration_tests/test_visualization_api.py
+++ b/tests/integration_tests/test_visualization_api.py
@@ -681,7 +681,8 @@ def test_roc_curves_from_test_statistics_vis_api(csv_filename):
     data_df = read_csv(data_csv)
     model.train(dataset=data_df)
     # extract test metrics
-    test_stats, _ = model.evaluate(dataset=data_df)
+    test_stats, _ = model.evaluate(dataset=data_df,
+                                   collect_overall_stats=True)
     test_stats = test_stats
     viz_outputs = ('pdf', 'png')
     for viz_output in viz_outputs:


### PR DESCRIPTION
- Divided postprocessing into two steps: first for postprocess and second for converting to desired output format, so predictions can be saved from a consistent format
- Fixed get_experiment_description
- Plumb through skip_save_unprocessed_output