### PR TITLE
TF2: fix image unit test to run with refactored trainer

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -56,8 +56,7 @@ from ludwig.models.predictor import Predictor, save_prediction_outputs, \
     calculate_overall_stats, print_evaluation_stats, save_evaluation_stats
 from ludwig.models.trainer import Trainer
 from ludwig.modules.metric_modules import get_best_function
-from ludwig.utils.data_utils import save_json, override_in_memory_flag, \
-    load_json, generate_kfold_splits
+from ludwig.utils.data_utils import save_json, load_json, generate_kfold_splits
 from ludwig.utils.horovod_utils import should_use_horovod
 from ludwig.utils.misc_utils import get_experiment_dir_name, get_file_names, \
     get_experiment_description, find_non_existing_dir_by_adding_suffix
@@ -558,17 +557,6 @@ class LudwigModel:
         # which you definitely don't want to do
         features_to_load = self.model_definition['input_features'][:]
 
-        # todo refactoring: this is needed for image features as we expect all
-        #  inputs to predict to be in memory, but doublecheck
-        num_overrides = override_in_memory_flag(
-            self.model_definition['input_features'],
-            True
-        )
-        if num_overrides > 0:
-            logger.warning(
-                'Using in_memory = False is not supported for Ludwig API.'
-            )
-
         # preprocessing
         dataset, training_set_metadata = preprocess_for_prediction(
             self.model_definition,
@@ -661,15 +649,6 @@ class LudwigModel:
         # which you definitely don't want to do
         features_to_load = self.model_definition['input_features'] + \
                            self.model_definition['output_features']
-
-        num_overrides = override_in_memory_flag(
-            self.model_definition['input_features'],
-            True
-        )
-        if num_overrides > 0:
-            logger.warning(
-                'Using in_memory = False is not supported for Ludwig API.'
-            )
 
         # preprocessing
         # todo refactoring: maybe replace the self.model_definition paramter
@@ -879,17 +858,6 @@ class LudwigModel:
         # modifying the input feature list when you add output features,
         # which you definitely don't want to do
         features_to_load = self.model_definition['input_features'][:]
-
-        # todo refactoring: this is needed for image features as we expect all
-        #  inputs to predict to be in memory, but doublecheck
-        num_overrides = override_in_memory_flag(
-            self.model_definition['input_features'],
-            True
-        )
-        if num_overrides > 0:
-            logger.warning(
-                'Using in_memory = False is not supported for Ludwig API.'
-            )
 
         # preprocessing
         dataset, training_set_metadata = preprocess_for_prediction(
@@ -1178,15 +1146,15 @@ def kfold_cross_validate(
             logger.info("training on fold {:d}".format(fold_num))
 
             model = LudwigModel(
-                    model_definition=model_definition,
-                    model_definition_fp=model_definition_file,
-                    logging_level=logging_level,
-                    use_horovod=use_horovod,
-                    gpus=gpus,
-                    gpu_memory_limit=gpu_memory_limit,
-                    allow_parallel_threads=allow_parallel_threads,
-                    random_seed=random_seed
-                )
+                model_definition=model_definition,
+                model_definition_fp=model_definition_file,
+                logging_level=logging_level,
+                use_horovod=use_horovod,
+                gpus=gpus,
+                gpu_memory_limit=gpu_memory_limit,
+                allow_parallel_threads=allow_parallel_threads,
+                random_seed=random_seed
+            )
             (
                 test_results,
                 train_stats,
@@ -1269,6 +1237,7 @@ def kfold_cross_validate(
     logger.info('completed {:d}-fold cross validation'.format(num_folds))
 
     return kfold_cv_stats, kfold_split_indices
+
 
 # todo refactoring: this shouldn't exist,
 #  all api tests should be done in a proper integration test,
@@ -1487,5 +1456,3 @@ def main(sys_argv):
 
 if __name__ == '__main__':
     main(sys.argv[1:])
-
-

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -718,17 +718,6 @@ def preprocess_for_prediction(
         data_format = figure_data_format(dataset)
 
     # manage the in_memory parameter
-    # for input_feature in model_definition['input_features']:
-    #     if PREPROCESSING in input_feature:
-    #         if 'in_memory' in input_feature[PREPROCESSING]:
-    #             if not input_feature[PREPROCESSING]['in_memory']:
-    #                 logger.warning(
-    #                     'WARNING: When running predict in_memory flag should '
-    #                     'be true. Overriding and setting it to true for '
-    #                     'feature <{}>'.format(input_feature[NAME])
-    #                 )
-    #                 input_feature[PREPROCESSING]['in_memory'] = True
-
     if data_format not in HDF5_FORMATS:
         num_overrides = override_in_memory_flag(
             model_definition['input_features'],

--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -30,7 +30,7 @@ import pandas as pd
 from pandas.errors import ParserError
 from sklearn.model_selection import KFold
 
-from ludwig.constants import SPLIT
+from ludwig.constants import SPLIT, PREPROCESSING
 from ludwig.globals import MODEL_HYPERPARAMETERS_FILE_NAME, \
     TRAIN_SET_METADATA_FILE_NAME, MODEL_WEIGHTS_FILE_NAME
 
@@ -423,9 +423,9 @@ def add_sequence_feature_column(df, col_name, seq_length):
 def override_in_memory_flag(input_features, override_value):
     num_overrides = 0
     for feature in input_features:
-        if 'preprocessing' in feature:
-            if 'in_memory' in feature['preprocessing']:
-                feature['preprocessing']['in_memory'] = override_value
+        if PREPROCESSING in feature:
+            if 'in_memory' in feature[PREPROCESSING]:
+                feature[PREPROCESSING]['in_memory'] = override_value
                 num_overrides += 1
     return num_overrides
 

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -20,6 +20,7 @@ from collections import namedtuple
 
 import pytest
 import yaml
+
 from ludwig.data.concatenate_datasets import concatenate_df
 from ludwig.experiment import experiment_cli
 from ludwig.features.h3_feature import H3InputFeature
@@ -245,6 +246,8 @@ ImageParms = namedtuple(
     'ImageTestParms',
     'image_encoder in_memory_flag skip_save_processed_input'
 )
+
+
 @pytest.mark.parametrize(
     'image_parms',
     [
@@ -253,7 +256,7 @@ ImageParms = namedtuple(
         ImageParms('stacked_cnn', False, False)
     ]
 )
-def test_experiment_image_inputs(image_parms, csv_filename):
+def test_experiment_image_inputs(image_parms: ImageParms, csv_filename: str):
     # Image Inputs
     image_dest_folder = os.path.join(os.getcwd(), 'generated_images')
 


### PR DESCRIPTION
# Code Pull Requests

This is the start of the work to address the issue.  Initial commit is to use the `@pytest.mark.parametrize` to externalize running multiple image tests.  Two of the three tests work. 
