### PR TITLE
TF2: additional image unit tests for different types of data sets

### DIFF
--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -370,8 +370,10 @@ def preprocess_for_training(
                     'of the csv, using them instead'
                 )
                 dataset = replace_file_extension(dataset, 'hdf5')
-                training_set_metadata_fname = replace_file_extension(dataset, 'json')
-                training_set_metadata = data_utils.load_json(training_set_metadata_fname)
+                training_set_metadata_fname = replace_file_extension(dataset,
+                                                                     'json')
+                training_set_metadata = data_utils.load_json(
+                    training_set_metadata_fname)
                 model_definition['data_hdf5_fp'] = dataset
                 data_format = 'hdf5'
 
@@ -383,8 +385,10 @@ def preprocess_for_training(
                     'of the csv, using them instead'
                 )
                 training_set = replace_file_extension(training_set, 'hdf5')
-                training_set_metadata_fname = replace_file_extension(training_set, 'json')
-                training_set_metadata = data_utils.load_json(training_set_metadata_fname)
+                training_set_metadata_fname = replace_file_extension(
+                    training_set, 'json')
+                training_set_metadata = data_utils.load_json(
+                    training_set_metadata_fname)
                 validation_set = replace_file_extension(validation_set,
                                                         'hdf5')
                 test_set = replace_file_extension(test_set, 'hdf5')
@@ -448,6 +452,24 @@ def preprocess_for_training(
                              'training_set_metadata must not be None.')
 
         logger.info('Using full hdf5 and json')
+
+        if DATA_TRAIN_HDF5_FP not in training_set_metadata:
+            logger.warning(
+                'data_train_hdf5_fp not present in training_set_metadata. '
+                'Adding it with the current HDF5 file path {}'.format(dataset)
+            )
+            training_set_metadata[DATA_TRAIN_HDF5_FP] = dataset
+        elif training_set_metadata[DATA_TRAIN_HDF5_FP] != dataset:
+            logger.warning(
+                'data_train_hdf5_fp in training_set_metadata is {}, '
+                'different from the current HDF5 file path {}. '
+                'Replacing it'.format(
+                    training_set_metadata[DATA_TRAIN_HDF5_FP],
+                    dataset
+                )
+            )
+            training_set_metadata[DATA_TRAIN_HDF5_FP] = dataset
+
         training_set, test_set, validation_set = load_hdf5(
             dataset,
             model_definition['input_features'],
@@ -456,6 +478,16 @@ def preprocess_for_training(
         )
 
     elif data_format in DICT_FORMATS:
+        num_overrides = override_in_memory_flag(
+            model_definition['input_features'],
+            True
+        )
+        if num_overrides > 0:
+            logger.warning(
+                'Using in_memory = False is not supported '
+                'with {} data format.'.format(data_format)
+            )
+
         dataset = dataset or pd.DataFormat(dataset)
         training_set = training_set or pd.DataFrame(training_set)
         validation_set = validation_set or pd.DataFrame(validation_set)
@@ -723,6 +755,8 @@ def preprocess_for_prediction(
     if isinstance(dataset, Dataset):
         return dataset, training_set_metadata
 
+    hdf5_fp = training_set_metadata.get(DATA_TRAIN_HDF5_FP)
+
     # determine data format if not provided or auto
     if not data_format or data_format == 'auto':
         data_format = figure_data_format(dataset)
@@ -785,16 +819,7 @@ def preprocess_for_prediction(
         )
 
     elif data_format in HDF5_FORMATS:
-        num_overrides = override_in_memory_flag(
-            model_definition['input_features'],
-            True
-        )
-        if num_overrides > 0:
-            logger.warning(
-                'Using in_memory = False is not supported '
-                'with {} data format.'.format(data_format)
-            )
-
+        hdf5_fp = dataset
         dataset = load_hdf5(
             dataset,
             model_definition['input_features'],
@@ -822,7 +847,7 @@ def preprocess_for_prediction(
         dataset,
         model_definition['input_features'],
         output_features,
-        training_set_metadata.get(DATA_TRAIN_HDF5_FP)
+        hdf5_fp
     )
 
     return dataset, training_set_metadata

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -755,8 +755,6 @@ def preprocess_for_prediction(
     if isinstance(dataset, Dataset):
         return dataset, training_set_metadata
 
-    hdf5_fp = training_set_metadata.get(DATA_TRAIN_HDF5_FP)
-
     # determine data format if not provided or auto
     if not data_format or data_format == 'auto':
         data_format = figure_data_format(dataset)
@@ -781,6 +779,8 @@ def preprocess_for_prediction(
     # if training_set_metadata is a string, assume it's a path to load the json
     if training_set_metadata and isinstance(training_set_metadata, str):
         training_set_metadata = load_metadata(training_set_metadata)
+
+    hdf5_fp = training_set_metadata.get(DATA_TRAIN_HDF5_FP, None)
 
     # setup
     output_features = []

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -785,6 +785,16 @@ def preprocess_for_prediction(
         )
 
     elif data_format in HDF5_FORMATS:
+        num_overrides = override_in_memory_flag(
+            model_definition['input_features'],
+            True
+        )
+        if num_overrides > 0:
+            logger.warning(
+                'Using in_memory = False is not supported '
+                'with {} data format.'.format(data_format)
+            )
+
         dataset = load_hdf5(
             dataset,
             model_definition['input_features'],

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -392,6 +392,16 @@ def preprocess_for_training(
                 data_format = 'hdf5'
 
     if data_format in DATAFRAME_FORMATS:
+        num_overrides = override_in_memory_flag(
+            model_definition['input_features'],
+            True
+        )
+        if num_overrides > 0:
+            logger.warning(
+                'Using in_memory = False is not supported '
+                'with {} data format.'.format(data_format)
+            )
+
         (
             training_set,
             test_set,

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -285,11 +285,6 @@ class ImageFeatureMixin(object):
         all_file_paths = [get_abs_path(csv_path, file_path)
                           for file_path in dataset_df[feature['name']]]
 
-        # check if original data source of the dataframe is csv dataset
-        if not hasattr(dataset_df, 'csv'):
-            # not csv source, override in_memory and set to True
-            feature['preprocessing']['in_memory'] = True
-
         if feature['preprocessing']['in_memory']:
             # Number of processes to run in parallel for preprocessing
             num_processes = feature['preprocessing']['num_processes']

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -285,6 +285,11 @@ class ImageFeatureMixin(object):
         all_file_paths = [get_abs_path(csv_path, file_path)
                           for file_path in dataset_df[feature['name']]]
 
+        # check if original data source of the dataframe is csv dataset
+        if not hasattr(dataset_df, 'csv'):
+            # not csv source, override in_memory and set to True
+            feature['preprocessing']['in_memory'] = True
+
         if feature['preprocessing']['in_memory']:
             # Number of processes to run in parallel for preprocessing
             num_processes = feature['preprocessing']['num_processes']

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -334,6 +334,7 @@ class ImageFeatureMixin(object):
                     image_dataset[i, :height, :width, :] = (
                         read_image_and_resize(filepath)
                     )
+                h5_file.flush()
 
             dataset[feature['name']] = np.arange(num_images)
 

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -362,6 +362,7 @@ def test_experiment_image_dataset(test_format, train_format):
             'in_memory'] = True
         train_dataset_to_use = pd.read_csv(train_data)
     else:
+        # hdf5 format
         model_definition['input_features'][0]['preprocessing'][
             'in_memory'] = False
         train_set, _, _, training_set_metadata = preprocess_for_training(
@@ -381,13 +382,16 @@ def test_experiment_image_dataset(test_format, train_format):
             'in_memory'] = True
         test_dataset_to_use = pd.read_csv(test_data)
     else:
-        model_definition['input_features'][0]['preprocessing'][
-            'in_memory'] = False
-        test_set, _ = preprocess_for_prediction(
+        # hdf5 format
+        # model_definition['input_features'][0]['preprocessing'][
+        #     'in_memory'] = False  # this causes exception when training set is dataframe
+        # create hdf5 data set
+        _, test_set, _, training_set_metadata_for_test = preprocess_for_training(
             model_definition,
-            dataset=train_data
+            dataset=test_data
         )
-        test_dataset_to_use = test_set
+
+        test_dataset_to_use = test_set.data_hdf5_fp
 
     # define Ludwig model
     model = LudwigModel(

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -358,19 +358,17 @@ def test_experiment_image_dataset(
 
     # setup training data format to test
     train_data = generate_data(input_features, output_features, train_csv_filename)
+    model_definition['input_features'][0]['preprocessing']['in_memory'] \
+        = train_in_memory
     training_set_metadata = None
     if train_format == 'csv':
-        model_definition['input_features'][0]['preprocessing'][
-            'in_memory'] = train_in_memory
         train_dataset_to_use = train_data
+
     elif train_format == 'df':
-        model_definition['input_features'][0]['preprocessing'][
-            'in_memory'] = train_in_memory
         train_dataset_to_use = pd.read_csv(train_data)
+
     else:
         # hdf5 format
-        model_definition['input_features'][0]['preprocessing'][
-            'in_memory'] = train_in_memory
         train_set, _, _, training_set_metadata = preprocess_for_training(
             model_definition,
             dataset=train_data
@@ -390,16 +388,14 @@ def test_experiment_image_dataset(
     # setup test data format to test
     test_data = generate_data(input_features, output_features, test_csv_filename)
     if test_format == 'csv':
-        model_definition['input_features'][0]['preprocessing'][
-            'in_memory'] = test_in_memory
         test_dataset_to_use = test_data
+
     elif test_format == 'df':
-        model_definition['input_features'][0]['preprocessing'][
-            'in_memory'] = test_in_memory
         test_dataset_to_use = pd.read_csv(test_data)
+
     else:
         # hdf5 format
-        # for in_memory True for creating hdf5 data with correct representation
+        # temporary override for creating hdf5 data with correct representation
         # this need due to the way the hdf5 data set is created for testing
         model_definition['input_features'][0]['preprocessing'][
             'in_memory'] = True
@@ -408,10 +404,10 @@ def test_experiment_image_dataset(
             model_definition,
             dataset=test_data
         )
-        # set back to requested in_memory specification
-        model_definition['input_features'][0]['preprocessing'][
-            'in_memory'] = test_in_memory
         test_dataset_to_use = test_set.data_hdf5_fp
+
+    model_definition['input_features'][0]['preprocessing']['in_memory'] \
+        = test_in_memory
 
     # run functions with the specified data format
     model.evaluate(dataset=test_dataset_to_use)

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -310,8 +310,8 @@ def test_experiment_image_inputs(image_parms: ImageParms, csv_filename: str):
 
 @pytest.mark.parametrize('test_in_memory', [True, False])
 @pytest.mark.parametrize('test_format', ['csv', 'df', 'hdf5'])
-@pytest.mark.parametrize('train_in_memory', [False]) #True, False])
-@pytest.mark.parametrize('train_format', ['df']) #'csv', 'df', 'hdf5'])
+@pytest.mark.parametrize('train_in_memory', [True, False])
+@pytest.mark.parametrize('train_format', ['csv', 'df', 'hdf5'])
 def test_experiment_image_dataset(
         train_format, train_in_memory,
         test_format, test_in_memory

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -399,14 +399,18 @@ def test_experiment_image_dataset(
         test_dataset_to_use = pd.read_csv(test_data)
     else:
         # hdf5 format
+        # for in_memory True for creating hdf5 data with correct representation
+        # this need due to the way the hdf5 data set is created for testing
         model_definition['input_features'][0]['preprocessing'][
-            'in_memory'] = test_in_memory
+            'in_memory'] = True
         # create hdf5 data set
         _, test_set, _, training_set_metadata_for_test = preprocess_for_training(
             model_definition,
             dataset=test_data
         )
-
+        # set back to requested in_memory specification
+        model_definition['input_features'][0]['preprocessing'][
+            'in_memory'] = test_in_memory
         test_dataset_to_use = test_set.data_hdf5_fp
 
     # run functions with the specified data format


### PR DESCRIPTION
# Code Pull Requests

Accounting for these tests:
* csv is the path to the file containing paths to images (I believe this is accounted for by the current `test_experiment_image_inputs`)
* pandas is an in memory DF containing paths to images.  Added with this PR `test_experiment_image_df`
* hdf5 is a path to an hdf5 file on disk created before, it contains the numpy ndarrays of images.  Added with this PR `test_experiment_image_hdf5`.  Still work-in-progress.


