### PR TITLE
TF2: add exponential decay learning rate function

### DIFF
--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -552,7 +552,7 @@ class Trainer:
 
                 if self._decay:
                     current_learning_rate = exponential_decay(
-                        self._learning_rate,
+                        current_learning_rate,
                         self._decay_rate,
                         self._decay_steps,
                         batcher.step

--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -70,6 +70,9 @@ class Trainer:
             epochs=100,
             regularization_lambda=0.0,
             learning_rate=0.001,
+            decay=False,
+            decay_rate=0.96,
+            decay_steps=10000,
             batch_size=128,
             eval_batch_size=0,
             bucketing_field=None,
@@ -187,6 +190,9 @@ class Trainer:
         self._epochs = epochs
         self._regularization_lambda = regularization_lambda
         self._learning_rate = learning_rate
+        self._decay = decay
+        self._decay_rate = decay_rate
+        self._decay_steps = decay_steps
         self._batch_size = batch_size
         self._eval_batch_size = batch_size if eval_batch_size < 1 else eval_batch_size
         self._bucketing_field = bucketing_field
@@ -560,7 +566,11 @@ class Trainer:
                         progress_tracker.epoch,
                         self._learning_rate_warmup_epochs,
                         batcher.step,
-                        batcher.steps_per_epoch
+                        batcher.steps_per_epoch,
+                        self._learning_rate,
+                        self._decay,
+                        self._decay_rate,
+                        self._decay_steps
                     )
                 self._optimizer.set_learning_rate(current_learning_rate)
 

--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -558,7 +558,11 @@ class Trainer:
                         self._learning_rate_warmup_epochs,
                         self._horovod.size(),
                         batcher.step,
-                        batcher.steps_per_epoch
+                        batcher.steps_per_epoch,
+                        self._learning_rate,
+                        self._decay,
+                        self._decay_rate,
+                        self._decay_steps
                     ) * self._horovod.size()
                 else:
                     current_learning_rate = learning_rate_warmup(

--- a/ludwig/utils/math_utils.py
+++ b/ludwig/utils/math_utils.py
@@ -87,13 +87,23 @@ def learning_rate_warmup(
         epoch,
         warmup_epochs,
         curr_step,
-        steps_per_epoch
+        steps_per_epoch,
+        initial_learning_rate,
+        decay,
+        decay_rate,
+        decay_steps
 ):
     global_curr_step = 1 + curr_step + epoch * steps_per_epoch
     warmup_steps = warmup_epochs * steps_per_epoch
 
+    if decay:
+        learning_rate_to_use = \
+            initial_learning_rate * decay_rate ** (float(global_curr_step) / decay_steps)
+    else:
+        learning_rate_to_use = learning_rate
+
     warmup_percent_done = global_curr_step / warmup_steps
-    warmup_learning_rate = learning_rate * warmup_percent_done
+    warmup_learning_rate = learning_rate_to_use * warmup_percent_done
 
     is_warmup = int(global_curr_step < warmup_steps)
     interpolated_learning_rate = (

--- a/ludwig/utils/math_utils.py
+++ b/ludwig/utils/math_utils.py
@@ -107,7 +107,7 @@ def learning_rate_warmup(
 
     is_warmup = int(global_curr_step < warmup_steps)
     interpolated_learning_rate = (
-            (1.0 - is_warmup) * learning_rate +
+            (1.0 - is_warmup) * learning_rate_to_use +
             is_warmup * warmup_learning_rate
     )
 


### PR DESCRIPTION
# Code Pull Requests

Adds decay learning rate function.  Right now the modification only applies to the function `learning_rate_warmup`.  I still have to work decay into the `learning_rate_warmup_distributed()`


Sample learning rates before the modification:
![b4_decay_modification](https://user-images.githubusercontent.com/1425269/93656120-09359900-f9f6-11ea-8c31-4b0718106af9.png)

Sample learning rate after adding decay functions:
![after_decay_modification](https://user-images.githubusercontent.com/1425269/93656134-1e122c80-f9f6-11ea-970f-91aafc6c91a1.png)
