### PR TITLE
TF2: add validation metric unit test

### DIFF
--- a/tests/integration_tests/test_validation_metrics.py
+++ b/tests/integration_tests/test_validation_metrics.py
@@ -105,7 +105,6 @@ def test_validation_metrics(test_case, csv_filename):
             [category_feature(), numerical_feature()],
             []
         )
-
     ]
 )
 def test_validation_metrics_mulitiple_output(test_case, csv_filename):

--- a/tests/integration_tests/test_validation_metrics.py
+++ b/tests/integration_tests/test_validation_metrics.py
@@ -1,0 +1,133 @@
+import logging
+from collections import namedtuple
+
+import pytest
+
+from ludwig.api import LudwigModel
+from ludwig.constants import *
+from tests.integration_tests.utils import binary_feature
+from tests.integration_tests.utils import category_feature
+from tests.integration_tests.utils import generate_data
+from tests.integration_tests.utils import numerical_feature
+from tests.integration_tests.utils import text_feature
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+logging.getLogger("ludwig").setLevel(logging.INFO)
+
+
+TestCase = namedtuple('TestCase', 'output_features validation_metrics')
+# output_features: output features to test
+# validation_metrics: relevant metrics for the output feature
+
+
+# test for single output feature
+@pytest.mark.parametrize(
+    'test_case',
+    [
+        TestCase(
+            [numerical_feature()],
+            ['loss', 'mean_squared_error', 'mean_absolute_error', 'r2']
+        ),
+        TestCase(
+            [binary_feature()],
+            ['loss', 'accuracy']
+        ),
+        TestCase(
+            [category_feature()],
+            ['loss', 'accuracy', 'hits_at_k']
+        ),
+        TestCase(
+            [text_feature()],
+            ['loss', 'token_accuracy', 'last_accuracy', 'edit_distance', 'perplexity']
+        )
+    ]
+)
+def test_validation_metrics(test_case, csv_filename):
+    # setup test scenarios
+    if len(test_case.output_features) == 1:
+        # single output feature capture feature specific metrics
+        of_name = test_case.output_features[0][NAME]
+        test_scenarios = [(of_name, measure) for measure in test_case.validation_metrics]
+        # add standard test for combined
+        test_scenarios.append(('combined', 'loss'))
+    else:
+        # multi output features, do one combined loss metric
+        test_scenarios = [('combined', 'loss')]
+
+    # setup features for the test
+    input_features = [numerical_feature(), category_feature(), binary_feature()]
+    output_features = test_case.output_features
+
+    # generate training data
+    training_data = generate_data(
+        input_features,
+        output_features,
+        filename=csv_filename
+    )
+
+    # loop through scenarios
+    for validation_field, validation_metric in test_scenarios:
+        # setup model definition
+        model_definition = {
+            'input_features': input_features,
+            'output_features': output_features,
+            'training': {
+                'epochs': 3,
+                'validation_field': validation_field,
+                'validation_metric': validation_metric
+            }
+        }
+
+        model = LudwigModel(
+            model_definition
+        )
+        train_stats, preprocessed_data, output_directory = model.train(
+            dataset=training_data,
+            skip_save_training_description=True,
+            skip_save_training_statistics=True,
+            skip_save_log=True,
+            skip_save_model=True,
+            skip_save_processed_input=True,
+            skip_save_progress=True
+        )
+
+
+# test for multiple output features
+@pytest.mark.parametrize(
+    'test_case',
+    [
+        TestCase(
+            [numerical_feature(), numerical_feature()],
+            []
+        ),
+        TestCase(
+            [category_feature(), numerical_feature()],
+            []
+        )
+
+    ]
+)
+def test_validation_metrics_mulitiple_output(test_case, csv_filename):
+    test_validation_metrics(test_case, csv_filename)
+
+
+# negative test for invalid metric name
+@pytest.mark.parametrize(
+    'test_case',
+    [
+        TestCase(
+            [numerical_feature()],
+            ['invalid_metric']
+        )
+    ]
+)
+def test_validation_invalid_metric(test_case, csv_filename):
+    # this should generate ValueError Exception
+    try:
+        test_validation_metrics(test_case, csv_filename)
+        raise RuntimeError(
+            'test_validation_metrics() should have raised ValueError but did not.'
+        )
+    except ValueError:
+        pass

--- a/tests/integration_tests/test_validation_metrics.py
+++ b/tests/integration_tests/test_validation_metrics.py
@@ -39,16 +39,18 @@ TestCase = namedtuple('TestCase', 'output_features validation_metrics')
         ),
         TestCase(
             [text_feature()],
-            ['loss', 'token_accuracy', 'last_accuracy', 'edit_distance', 'perplexity']
+            ['loss', 'token_accuracy', 'last_accuracy', 'edit_distance',
+             'perplexity']
         )
     ]
 )
-def test_validation_metrics(test_case, csv_filename):
+def test_validation_metrics(test_case: TestCase, csv_filename: str):
     # setup test scenarios
     if len(test_case.output_features) == 1:
         # single output feature capture feature specific metrics
         of_name = test_case.output_features[0][NAME]
-        test_scenarios = [(of_name, measure) for measure in test_case.validation_metrics]
+        test_scenarios = [(of_name, measure)
+                          for measure in test_case.validation_metrics]
         # add standard test for combined
         test_scenarios.append(('combined', 'loss'))
     else:
@@ -56,7 +58,9 @@ def test_validation_metrics(test_case, csv_filename):
         test_scenarios = [('combined', 'loss')]
 
     # setup features for the test
-    input_features = [numerical_feature(), category_feature(), binary_feature()]
+    input_features = [numerical_feature(),
+                      category_feature(),
+                      binary_feature()]
     output_features = test_case.output_features
 
     # generate training data
@@ -82,7 +86,7 @@ def test_validation_metrics(test_case, csv_filename):
         model = LudwigModel(
             model_definition
         )
-        train_stats, preprocessed_data, output_directory = model.train(
+        model.train(
             dataset=training_data,
             skip_save_training_description=True,
             skip_save_training_statistics=True,
@@ -107,9 +111,9 @@ def test_validation_metrics(test_case, csv_filename):
         )
     ]
 )
-def test_validation_metrics_mulitiple_output(test_case, csv_filename):
+def test_validation_metrics_mulitiple_output(test_case: TestCase,
+                                             csv_filename: str):
     test_validation_metrics(test_case, csv_filename)
-
 
 # negative test for invalid metric name
 @pytest.mark.parametrize(
@@ -121,12 +125,14 @@ def test_validation_metrics_mulitiple_output(test_case, csv_filename):
         )
     ]
 )
-def test_validation_invalid_metric(test_case, csv_filename):
+def test_validation_invalid_metric(test_case: TestCase,
+                                   csv_filename: str):
     # this should generate ValueError Exception
     try:
         test_validation_metrics(test_case, csv_filename)
         raise RuntimeError(
-            'test_validation_metrics() should have raised ValueError but did not.'
+            'test_validation_metrics() should have raised ValueError '
+            'but did not.'
         )
     except ValueError:
         pass


### PR DESCRIPTION
# Code Pull Requests

Add unit test for `validation_field` and `validation_metric` parameters.   Focus of the test was on whether an exception was raised or not.  Three category of tests.

* Single output feature, in addition to 'combined loss` confirmed the following for each feature type
  * Numeric: 'loss', 'mean_squared_error', 'mean_absolute_error', 'r2'
  * Binary: 'loss', 'accuracy'
  * Categorical: 'loss', 'accuracy', 'hits_at_k'
  * Text: 'loss', 'token_accuracy', 'last_accuracy', 'edit_distance', 'perplexity'

* Multiple output features used only 'combined loss'

* Invalid metric name - tested to see that `ValueError` exception was raised.

Local run of unit test
```
=========================================================== test session starts ============================================================
platform linux -- Python 3.6.9, pytest-6.0.2, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /opt/project
plugins: forked-1.3.0, pycharm-0.7.0, xdist-2.1.0, typeguard-2.9.1
collected 7 items

../../tests/integration_tests/test_validation_metrics.py::test_validation_metrics[test_case0] PASSED                                 [ 14%]
../../tests/integration_tests/test_validation_metrics.py::test_validation_metrics[test_case1] PASSED                                 [ 28%]
../../tests/integration_tests/test_validation_metrics.py::test_validation_metrics[test_case2] PASSED                                 [ 42%]
../../tests/integration_tests/test_validation_metrics.py::test_validation_metrics[test_case3] PASSED                                 [ 57%]
../../tests/integration_tests/test_validation_metrics.py::test_validation_metrics_mulitiple_output[test_case0] PASSED                [ 71%]
../../tests/integration_tests/test_validation_metrics.py::test_validation_metrics_mulitiple_output[test_case1] PASSED                [ 85%]
../../tests/integration_tests/test_validation_metrics.py::test_validation_invalid_metric[test_case0] PASSED                          [100%]
```