### PR TITLE
TF2: Additional cli oriented unit tests

### DIFF
--- a/ludwig/cli.py
+++ b/ludwig/cli.py
@@ -103,6 +103,11 @@ Available sub-commands:
         ludwig.contrib.contrib_command("hyperopt", *sys.argv)
         hyperopt_cli.cli(sys.argv[2:])
 
+    def collect_summary(self):
+        from ludwig import collect
+        ludwig.contrib.contrib_command('collect_summary', *sys.argv)
+        collect.cli_collect_summary(sys.argv[2:])
+
     def collect_weights(self):
         from ludwig import collect
         ludwig.contrib.contrib_command("collect_weights", *sys.argv)

--- a/ludwig/cli.py
+++ b/ludwig/cli.py
@@ -52,6 +52,7 @@ Available sub-commands:
    serve                 Serves a pretrained model
    visualize             Visualizes experimental results
    hyperopt              Perform hyperparameter optimization
+   collect_summary       Prints names of weights and layers activations to use with other collect commands
    collect_weights       Collects tensors containing a pretrained model weights
    collect_activations   Collects tensors for each datapoint using a pretrained model
    export_savedmodel     Exports Ludwig models to SavedModel
@@ -121,12 +122,12 @@ Available sub-commands:
     def export_savedmodel(self):
         from ludwig import export
         ludwig.contrib.contrib_command("export_savedmodel", *sys.argv)
-        export.export_savedmodel_cli(sys.argv[2:])
+        export.cli_export_savedmodel(sys.argv[2:])
 
     def export_neuropod(self):
         from ludwig import export
         ludwig.contrib.contrib_command("export_neuropod", *sys.argv)
-        export.export_neuropod_cli(sys.argv[2:])
+        export.cli_export_neuropod(sys.argv[2:])
 
 
 def main():

--- a/ludwig/collect.py
+++ b/ludwig/collect.py
@@ -384,7 +384,8 @@ def cli_collect_summary(sys_argv):
     """
     parser = argparse.ArgumentParser(
         description='This script loads a pretrained model '
-                    'and uses it collect weight names.',
+                    'and prints names of weights and layers activations '
+                    'to use with other collect commands',
         prog='ludwig collect_summary',
         usage='%(prog)s [options]'
     )

--- a/ludwig/collect.py
+++ b/ludwig/collect.py
@@ -209,12 +209,14 @@ def cli_collect_activations(sys_argv):
         required=True
     )
     parser.add_argument(
-        '-t',
-        '--tensors',
+        '-lyr',
+        '--layers',
         help='tensors to collect',
         nargs='+',
         required=True
     )
+
+
 
     # -------------------------
     # Output results parameters

--- a/ludwig/export.py
+++ b/ludwig/export.py
@@ -77,7 +77,7 @@ def export_neuropod(
     logger.info('Saved to: {0}'.format(output_path))
 
 
-def export_savedmodel_cli(sys_argv):
+def cli_export_savedmodel(sys_argv):
     parser = argparse.ArgumentParser(
         description='This script loads a pretrained model '
                     'and saves it as a SavedModel.',
@@ -131,7 +131,7 @@ def export_savedmodel_cli(sys_argv):
     export_savedmodel(**vars(args))
 
 
-def export_neuropod_cli(sys_argv):
+def cli_export_neuropod(sys_argv):
     parser = argparse.ArgumentParser(
         description='This script loads a pretrained model '
                     'and saves it as a Neuropod.',
@@ -195,10 +195,10 @@ if __name__ == '__main__':
     if len(sys.argv) > 1:
         if sys.argv[1] == 'savedmodel':
             contrib_command("export_savedmodel", *sys.argv)
-            export_savedmodel_cli(sys.argv[2:])
+            cli_export_savedmodel(sys.argv[2:])
         elif sys.argv[1] == 'neuropod':
             contrib_command("export_neuropod", *sys.argv)
-            export_neuropod_cli(sys.argv[2:])
+            cli_export_neuropod(sys.argv[2:])
         else:
             print('Unrecognized command')
     else:

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -59,6 +59,44 @@ def _prepare_data(csv_filename, model_definition_filename):
 
     return dataset_filename
 
+def _prepare_hyperopt_data(csv_filename, model_definition_filename):
+    # Single sequence input, single category output
+    input_features = [sequence_feature(reduce_output='sum')]
+    output_features = [category_feature(vocab_size=2, reduce_input='sum')]
+
+    # Generate test data
+    dataset_filename = generate_data(input_features, output_features,
+                                     csv_filename)
+
+    # generate model definition file
+    model_definition = {
+        'input_features': input_features,
+        'output_features': output_features,
+        'combiner': {'type': 'concat', 'fc_size': 14},
+        'training': {'epochs': 2},
+        'hyperopt': {
+            'parameters': {
+                "training.learning_rate": {
+                    "type": "float",
+                    "low": 0.0001,
+                    "high": 0.01,
+                    "space": "log",
+                    "steps": 3,
+                }
+            },
+            'goal': 'minimize',
+            'output_feature': output_features[0]['name'],
+            'validation_metrics': 'loss',
+            'executor': {'type': 'serial'},
+            'sampler': {'type': 'random', 'num_samples': 5}
+        }
+    }
+
+    with open(model_definition_filename, 'w') as f:
+        yaml.dump(model_definition, f)
+
+    return dataset_filename
+
 
 def test_train_cli_dataset(csv_filename):
     """Test training using `ludwig train --dataset`."""
@@ -92,7 +130,7 @@ def test_train_cli_training_set(csv_filename):
                     output_directory=tmpdir)
 
 def test_export_savedmodel_cli(csv_filename):
-    """Test training using `ludwig train --dataset`."""
+    """Test exporting Ludwig model to Tensorflows savedmodel format."""
     with tempfile.TemporaryDirectory() as tmpdir:
         model_definition_filename = os.path.join(tmpdir,
                                                  'model_definition.yaml')
@@ -108,7 +146,7 @@ def test_export_savedmodel_cli(csv_filename):
                     )
 
 def test_export_neuropod_cli(csv_filename):
-    """Test training using `ludwig train --dataset`."""
+    """Test exporting Ludwig model to neuropod format."""
     with tempfile.TemporaryDirectory() as tmpdir:
         model_definition_filename = os.path.join(tmpdir,
                                                  'model_definition.yaml')
@@ -121,4 +159,83 @@ def test_export_neuropod_cli(csv_filename):
         _run_ludwig('export_neuropod',
                     model_path=os.path.join(tmpdir, 'experiment_run', 'model'),
                     output_path=os.path.join(tmpdir, 'neuropod')
+                    )
+
+def test_experiment_cli(csv_filename):
+    """Test experiment cli."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model_definition_filename = os.path.join(tmpdir,
+                                                 'model_definition.yaml')
+        dataset_filename = _prepare_data(csv_filename,
+                                         model_definition_filename)
+        _run_ludwig('experiment',
+                    dataset=dataset_filename,
+                    model_definition_file=model_definition_filename,
+                    output_directory=tmpdir)
+
+
+def test_predict_cli(csv_filename):
+    """Test predict cli."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model_definition_filename = os.path.join(tmpdir,
+                                                 'model_definition.yaml')
+        dataset_filename = _prepare_data(csv_filename,
+                                         model_definition_filename)
+        _run_ludwig('train',
+                    dataset=dataset_filename,
+                    model_definition_file=model_definition_filename,
+                    output_directory=tmpdir)
+        _run_ludwig('predict',
+                    dataset=dataset_filename,
+                    model_path=os.path.join(tmpdir, 'experiment_run', 'model'),
+                    output_directory=os.path.join(tmpdir, 'predictions'))
+
+
+def test_evaluate_cli(csv_filename):
+    """Test evaluate cli."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model_definition_filename = os.path.join(tmpdir,
+                                                 'model_definition.yaml')
+        dataset_filename = _prepare_data(csv_filename,
+                                         model_definition_filename)
+        _run_ludwig('train',
+                    dataset=dataset_filename,
+                    model_definition_file=model_definition_filename,
+                    output_directory=tmpdir)
+        _run_ludwig('evaluate',
+                    dataset=dataset_filename,
+                    model_path=os.path.join(tmpdir, 'experiment_run', 'model'),
+                    output_directory=os.path.join(tmpdir, 'predictions'))
+
+def test_hyperopt_cli(csv_filename):
+    """Test hyperopt cli."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model_definition_filename = os.path.join(tmpdir,
+                                                 'model_definition.yaml')
+        dataset_filename = _prepare_hyperopt_data(csv_filename,
+                                         model_definition_filename)
+        _run_ludwig('hyperopt',
+                    dataset=dataset_filename,
+                    model_definition_file=model_definition_filename,
+                    output_directory=tmpdir)
+
+
+def test_visualize_cli(csv_filename):
+    """Test Ludwig 'visualize' cli."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model_definition_filename = os.path.join(tmpdir,
+                                                 'model_definition.yaml')
+        dataset_filename = _prepare_data(csv_filename,
+                                         model_definition_filename)
+        _run_ludwig('train',
+                    dataset=dataset_filename,
+                    model_definition_file=model_definition_filename,
+                    output_directory=tmpdir)
+        _run_ludwig('visualize',
+                    visualization='learning_curves',
+                    model_names='run',
+                    training_statistics=os.path.join(
+                        tmpdir, 'experiment_run', 'training_statistics.json'
+                        ),
+                    output_directory=os.path.join(tmpdir, 'visualizations')
                     )

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -78,7 +78,7 @@ def _prepare_hyperopt_data(csv_filename, model_definition_filename):
     model_definition = {
         'input_features': input_features,
         'output_features': output_features,
-        'combiner': {'type': 'concat', 'fc_size': 14},
+        'combiner': {'type': 'concat', 'fc_size': 4},
         'training': {'epochs': 2},
         'hyperopt': {
             'parameters': {
@@ -94,7 +94,7 @@ def _prepare_hyperopt_data(csv_filename, model_definition_filename):
             'output_feature': output_features[0]['name'],
             'validation_metrics': 'loss',
             'executor': {'type': 'serial'},
-            'sampler': {'type': 'random', 'num_samples': 5}
+            'sampler': {'type': 'random', 'num_samples': 2}
         }
     }
 

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -239,3 +239,18 @@ def test_visualize_cli(csv_filename):
                         ),
                     output_directory=os.path.join(tmpdir, 'visualizations')
                     )
+
+
+def test_collect_summary_cli(csv_filename):
+    """Test collect_summary cli."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model_definition_filename = os.path.join(tmpdir,
+                                                 'model_definition.yaml')
+        dataset_filename = _prepare_data(csv_filename,
+                                         model_definition_filename)
+        _run_ludwig('train',
+                    dataset=dataset_filename,
+                    model_definition_file=model_definition_filename,
+                    output_directory=tmpdir)
+        _run_ludwig('collect_summary',
+                    model_path=os.path.join(tmpdir, 'experiment_run', 'model'))


### PR DESCRIPTION
# Code Pull Requests

Here is local run of `test_cli.py`.  Added cli tests for the following:
* experiment
* predict
* evaluate
* hyperopt
* visualize

```
pytest -v /opt/project/tests/integration_tests/test_cli.py
=========================================================== test session starts ============================================================
platform linux -- Python 3.6.9, pytest-6.0.2, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /opt/project
plugins: forked-1.3.0, pycharm-0.7.0, xdist-2.1.0, typeguard-2.9.1
collected 9 items

../../tests/integration_tests/test_cli.py::test_train_cli_dataset PASSED                                                             [ 11%]
../../tests/integration_tests/test_cli.py::test_train_cli_training_set PASSED                                                        [ 22%]
../../tests/integration_tests/test_cli.py::test_export_savedmodel_cli PASSED                                                         [ 33%]
../../tests/integration_tests/test_cli.py::test_export_neuropod_cli PASSED                                                           [ 44%]
../../tests/integration_tests/test_cli.py::test_experiment_cli PASSED                                                                [ 55%]
../../tests/integration_tests/test_cli.py::test_predict_cli PASSED                                                                   [ 66%]
../../tests/integration_tests/test_cli.py::test_evaluate_cli PASSED                                                                  [ 77%]
../../tests/integration_tests/test_cli.py::test_hyperopt_cli PASSED                                                                  [ 88%]
../../tests/integration_tests/test_cli.py::test_visualize_cli PASSED                                                                 [100%]

====================================================== 9 passed in 110.49s (0:01:50) =======================================================
```
