### PR TITLE
Execute transformer tests in subprocesses to avoid OOM

### DIFF
--- a/ludwig/encoders/text_encoders.py
+++ b/ludwig/encoders/text_encoders.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 
 class BERTEncoder(Layer):
     fixed_preprocessing_parameters = {
+        'word_tokenizer': 'hf_tokenizer',
         'pretrained_model_name_or_path': 'feature.pretrained_model_name_or_path',
     }
 
@@ -82,6 +83,7 @@ class BERTEncoder(Layer):
 
 class GPTEncoder(Layer):
     fixed_preprocessing_parameters = {
+        'word_tokenizer': 'hf_tokenizer',
         'pretrained_model_name_or_path': 'feature.pretrained_model_name_or_path',
     }
 
@@ -132,6 +134,7 @@ class GPTEncoder(Layer):
 
 class GPT2Encoder(Layer):
     fixed_preprocessing_parameters = {
+        'word_tokenizer': 'hf_tokenizer',
         'pretrained_model_name_or_path': 'feature.pretrained_model_name_or_path',
     }
 
@@ -182,6 +185,7 @@ class GPT2Encoder(Layer):
 
 class TransformerXLEncoder(Layer):
     fixed_preprocessing_parameters = {
+        'word_tokenizer': 'hf_tokenizer',
         'pretrained_model_name_or_path': 'feature.pretrained_model_name_or_path',
     }
 
@@ -227,6 +231,7 @@ class TransformerXLEncoder(Layer):
 
 class XLNetEncoder(Layer):
     fixed_preprocessing_parameters = {
+        'word_tokenizer': 'hf_tokenizer',
         'pretrained_model_name_or_path': 'feature.pretrained_model_name_or_path',
     }
 
@@ -277,6 +282,7 @@ class XLNetEncoder(Layer):
 
 class XLMEncoder(Layer):
     fixed_preprocessing_parameters = {
+        'word_tokenizer': 'hf_tokenizer',
         'pretrained_model_name_or_path': 'feature.pretrained_model_name_or_path',
     }
 
@@ -327,6 +333,7 @@ class XLMEncoder(Layer):
 
 class RoBERTaEncoder(Layer):
     fixed_preprocessing_parameters = {
+        'word_tokenizer': 'hf_tokenizer',
         'pretrained_model_name_or_path': 'feature.pretrained_model_name_or_path',
     }
 
@@ -381,6 +388,7 @@ class RoBERTaEncoder(Layer):
 
 class DistilBERTEncoder(Layer):
     fixed_preprocessing_parameters = {
+        'word_tokenizer': 'hf_tokenizer',
         'pretrained_model_name_or_path': 'feature.pretrained_model_name_or_path',
     }
 
@@ -430,6 +438,7 @@ class DistilBERTEncoder(Layer):
 
 class CTRLEncoder(Layer):
     fixed_preprocessing_parameters = {
+        'word_tokenizer': 'hf_tokenizer',
         'pretrained_model_name_or_path': 'feature.pretrained_model_name_or_path',
     }
 
@@ -480,6 +489,7 @@ class CTRLEncoder(Layer):
 
 class CamemBERTEncoder(Layer):
     fixed_preprocessing_parameters = {
+        'word_tokenizer': 'hf_tokenizer',
         'pretrained_model_name_or_path': 'feature.pretrained_model_name_or_path',
     }
 
@@ -534,6 +544,7 @@ class CamemBERTEncoder(Layer):
 
 class ALBERTEncoder(Layer):
     fixed_preprocessing_parameters = {
+        'word_tokenizer': 'hf_tokenizer',
         'pretrained_model_name_or_path': 'feature.pretrained_model_name_or_path',
     }
 
@@ -588,6 +599,7 @@ class ALBERTEncoder(Layer):
 
 class T5Encoder(Layer):
     fixed_preprocessing_parameters = {
+        'word_tokenizer': 'hf_tokenizer',
         'pretrained_model_name_or_path': 'feature.pretrained_model_name_or_path',
     }
 
@@ -639,6 +651,7 @@ class T5Encoder(Layer):
 
 class XLMRoBERTaEncoder(Layer):
     fixed_preprocessing_parameters = {
+        'word_tokenizer': 'hf_tokenizer',
         'pretrained_model_name_or_path': 'feature.pretrained_model_name_or_path',
     }
 
@@ -693,6 +706,7 @@ class XLMRoBERTaEncoder(Layer):
 
 class FlauBERTEncoder(Layer):
     fixed_preprocessing_parameters = {
+        'word_tokenizer': 'hf_tokenizer',
         'pretrained_model_name_or_path': 'feature.pretrained_model_name_or_path',
     }
 
@@ -743,6 +757,7 @@ class FlauBERTEncoder(Layer):
 
 class ELECTRAEncoder(Layer):
     fixed_preprocessing_parameters = {
+        'word_tokenizer': 'hf_tokenizer',
         'pretrained_model_name_or_path': 'feature.pretrained_model_name_or_path',
     }
 
@@ -793,6 +808,7 @@ class ELECTRAEncoder(Layer):
 
 class LongformerEncoder(Layer):
     fixed_preprocessing_parameters = {
+        'word_tokenizer': 'hf_tokenizer',
         'pretrained_model_name_or_path': 'feature.pretrained_model_name_or_path',
     }
 
@@ -847,6 +863,7 @@ class LongformerEncoder(Layer):
 
 class AutoTransformerEncoder(Layer):
     fixed_preprocessing_parameters = {
+        'word_tokenizer': 'hf_tokenizer',
         'pretrained_model_name_or_path': 'feature.pretrained_model_name_or_path',
     }
 

--- a/ludwig/features/text_feature.py
+++ b/ludwig/features/text_feature.py
@@ -76,7 +76,6 @@ class TextFeatureMixin(object):
             padding_symbol=preprocessing_parameters['padding_symbol'],
             pretrained_model_name_or_path=preprocessing_parameters[
                 'pretrained_model_name_or_path']
-
         )
         (
             word_idx2str,

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -82,7 +82,6 @@ def run_experiment_hf_tokenizer(encoder, csv_filename):
             vocab_size=30,
             min_len=1,
             encoder=encoder,
-            preprocessing={'word_tokenizer': 'hf_tokenizer'}
         )
     ]
     output_features = [category_feature(vocab_size=2)]

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -57,6 +57,22 @@ logger.setLevel(logging.INFO)
 logging.getLogger("ludwig").setLevel(logging.INFO)
 
 
+@pytest.mark.parametrize('encoder', ENCODERS)
+def test_experiment_text_feature_non_HF(encoder, csv_filename):
+    input_features = [
+        text_feature(
+            vocab_size=30,
+            min_len=1,
+            encoder=encoder,
+            preprocessing={'word_tokenizer': 'space'}
+        )
+    ]
+    output_features = [category_feature(vocab_size=2)]
+    # Generate test data
+    rel_path = generate_data(input_features, output_features, csv_filename)
+    run_experiment(input_features, output_features, dataset=rel_path)
+
+
 @spawn
 def run_experiment_hf_tokenizer(encoder, csv_filename):
     # Run in a subprocess to clear TF and prevent OOM
@@ -67,22 +83,6 @@ def run_experiment_hf_tokenizer(encoder, csv_filename):
             min_len=1,
             encoder=encoder,
             preprocessing={'word_tokenizer': 'hf_tokenizer'}
-        )
-    ]
-    output_features = [category_feature(vocab_size=2)]
-    # Generate test data
-    rel_path = generate_data(input_features, output_features, csv_filename)
-    run_experiment(input_features, output_features, dataset=rel_path)
-
-
-@pytest.mark.parametrize('encoder', ENCODERS)
-def test_experiment_text_feature_non_HF(encoder, csv_filename):
-    input_features = [
-        text_feature(
-            vocab_size=30,
-            min_len=1,
-            encoder=encoder,
-            preprocessing={'word_tokenizer': 'space'}
         )
     ]
     output_features = [category_feature(vocab_size=2)]

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -30,7 +30,6 @@ from ludwig.experiment import experiment_cli
 from ludwig.features.h3_feature import H3InputFeature
 from ludwig.predict import predict_cli
 from ludwig.utils.data_utils import read_csv
-from ludwig.utils.defaults import default_random_seed
 from tests.conftest import delete_temporary_data
 from tests.integration_tests.utils import ENCODERS, HF_ENCODERS, \
     HF_ENCODERS_SHORT, slow
@@ -59,7 +58,7 @@ logging.getLogger("ludwig").setLevel(logging.INFO)
 
 
 @spawn
-def run_experiment_encoder(encoder, csv_filename):
+def run_experiment_hf_tokenizer(encoder, csv_filename):
     # Run in a subprocess to clear TF and prevent OOM
     # This also allows us to use GPU resources
     input_features = [
@@ -94,13 +93,13 @@ def test_experiment_text_feature_non_HF(encoder, csv_filename):
 
 @pytest.mark.parametrize('encoder', HF_ENCODERS_SHORT)
 def test_experiment_text_feature_HF(encoder, csv_filename):
-    run_experiment_encoder(encoder, csv_filename)
+    run_experiment_hf_tokenizer(encoder, csv_filename)
 
 
 @slow
 @pytest.mark.parametrize('encoder', HF_ENCODERS)
 def test_experiment_text_feature_HF_full(encoder, csv_filename):
-    run_experiment_encoder(encoder, csv_filename)
+    run_experiment_hf_tokenizer(encoder, csv_filename)
 
 
 def test_experiment_seq_seq(csv_filename):

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -402,7 +402,7 @@ def spawn(fn):
         p.join()
         results = queue.get()
         if isinstance(results, Exception):
-            raise RuntimeError(f'Spawned subprocess raised {type(results)}, '
+            raise RuntimeError(f'Spawned subprocess raised {type(results).__name__}, '
                                f'check log output above for stack trace.')
         return results
 

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -17,6 +17,8 @@ import multiprocessing
 import os
 import random
 import shutil
+import sys
+import traceback
 import unittest
 import uuid
 from distutils.util import strtobool
@@ -378,7 +380,11 @@ def generate_output_features_with_dependencies(main_feature, dependencies):
 
 def _subproc_wrapper(fn, queue, *args, **kwargs):
     fn = cloudpickle.loads(fn)
-    results = fn(*args, **kwargs)
+    try:
+        results = fn(*args, **kwargs)
+    except Exception as e:
+        traceback.print_exc(file=sys.stderr)
+        results = e
     queue.put(results)
 
 
@@ -395,6 +401,9 @@ def spawn(fn):
         p.start()
         p.join()
         results = queue.get()
+        if isinstance(results, Exception):
+            raise RuntimeError(f'Spawned subprocess raised {type(results)}, '
+                               f'check log output above for stack trace.')
         return results
 
     return wrapped_fn


### PR DESCRIPTION
Running transformers in succession in the same process leaks memory in TensorFlow, leading to OOM errors.