### PR TITLE
Added batch prediction endpoint to FastAPI serving

### DIFF
--- a/ludwig/serve.py
+++ b/ludwig/serve.py
@@ -144,7 +144,7 @@ def convert_batch_input(form):
         if type(v) == UploadFile:
             file_index[v.filename] = _write_file(v, files)
 
-    data = json.loads(form['json'])
+    data = json.loads(form['dataset'])
     for row in data['data']:
         for i in range(len(row)):
             if row[i] in file_index:

--- a/ludwig/serve.py
+++ b/ludwig/serve.py
@@ -15,10 +15,13 @@
 # limitations under the License.
 # ==============================================================================
 import argparse
+import json
 import logging
 import os
 import sys
 import tempfile
+
+import pandas as pd
 
 from ludwig.api import LudwigModel
 from ludwig.constants import NAME
@@ -83,7 +86,41 @@ def server(model):
             for f in files:
                 os.remove(f.name)
 
+    @app.post('/batch_predict')
+    async def batch_predict(request: Request):
+        form = await request.form()
+        files, data = convert_batch_input(form)
+        data_df = pd.DataFrame.from_records(data['data'],
+                                            index=data.get('index'),
+                                            columns=data['columns'])
+
+        try:
+            if (set(data_df.columns) & input_features) != input_features:
+                return JSONResponse(ALL_FEATURES_PRESENT_ERROR,
+                                    status_code=400)
+            try:
+                resp, _ = model.predict(dataset=data_df)
+                return JSONResponse(resp.to_dict('split'))
+            except Exception as e:
+                logger.error("Error: {}".format(str(e)))
+                return JSONResponse(COULD_NOT_RUN_INFERENCE_ERROR,
+                                    status_code=500)
+        finally:
+            for f in files:
+                os.remove(f.name)
+
     return app
+
+
+def _write_file(v, files):
+    # Convert UploadFile to a NamedTemporaryFile to ensure it's on the disk
+    suffix = os.path.splitext(v.filename)[1]
+    named_file = tempfile.NamedTemporaryFile(
+        delete=False, suffix=suffix)
+    files.append(named_file)
+    named_file.write(v.file.read())
+    named_file.close()
+    return named_file.name
 
 
 def convert_input(form):
@@ -92,18 +129,28 @@ def convert_input(form):
     files = []
     for k, v in form.multi_items():
         if type(v) == UploadFile:
-            # Convert UploadFile to a NamedTemporaryFile to ensure it's on the disk
-            suffix = os.path.splitext(v.filename)[1]
-            named_file = tempfile.NamedTemporaryFile(
-                delete=False, suffix=suffix)
-            files.append(named_file)
-            named_file.write(v.file.read())
-            named_file.close()
-            new_input[k] = named_file.name
+            new_input[k] = _write_file(v, files)
         else:
             new_input[k] = v
 
     return files, new_input
+
+
+def convert_batch_input(form):
+    """Returns a new input and a list of files to be cleaned up"""
+    files = []
+    file_index = {}
+    for k, v in form.multi_items():
+        if type(v) == UploadFile:
+            file_index[v.filename] = _write_file(v, files)
+
+    data = json.loads(form['json'])
+    for row in data['data']:
+        for i in range(len(row)):
+            if row[i] in file_index:
+                row[i] = file_index[row[i]]
+
+    return files, data
 
 
 def run_server(model_path, host, port):

--- a/ludwig/serve.py
+++ b/ludwig/serve.py
@@ -101,8 +101,8 @@ def server(model):
             try:
                 resp, _ = model.predict(dataset=data_df)
                 return JSONResponse(resp.to_dict('split'))
-            except Exception as e:
-                logger.error("Error: {}".format(str(e)))
+            except Exception:
+                logger.exception('failed to run batch prediction')
                 return JSONResponse(COULD_NOT_RUN_INFERENCE_ERROR,
                                     status_code=500)
         finally:

--- a/tests/integration_tests/test_server.py
+++ b/tests/integration_tests/test_server.py
@@ -102,7 +102,7 @@ def convert_to_form(entry):
 def convert_to_batch_form(data_df):
     data = data_df.to_dict(orient='split')
     files = {
-        'json': (None, json.dumps(data), 'application/json'),
+        'dataset': (None, json.dumps(data), 'application/json'),
     }
     for row in data['data']:
         for v in row:

--- a/tests/integration_tests/test_server.py
+++ b/tests/integration_tests/test_server.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+import json
 import logging
 import os
 import shutil
@@ -98,6 +99,18 @@ def convert_to_form(entry):
     return data, files
 
 
+def convert_to_batch_form(data_df):
+    data = data_df.to_dict(orient='split')
+    files = {
+        'json': (None, json.dumps(data), 'application/json'),
+    }
+    for row in data['data']:
+        for v in row:
+            if type(v) == str and os.path.exists(v) and v not in files:
+                files[v] = (v, open(v, 'rb'), 'application/octet-stream')
+    return files
+
+
 def test_server_integration(csv_filename):
     # Image Inputs
     image_dest_folder = os.path.join(os.getcwd(), 'generated_images')
@@ -136,6 +149,8 @@ def test_server_integration(csv_filename):
     assert response.json() == ALL_FEATURES_PRESENT_ERROR
 
     data_df = read_csv(rel_path)
+
+    # One-off prediction
     first_entry = data_df.T.to_dict()[0]
     data, files = convert_to_form(first_entry)
     server_response = client.post('/predict', data=data, files=files)
@@ -150,5 +165,20 @@ def test_server_integration(csv_filename):
     model_output = model_output.to_dict('records')[0]
     assert model_output == server_response
 
+    # Batch prediction
+    assert len(data_df) > 1
+    files = convert_to_batch_form(data_df)
+    server_response = client.post('/batch_predict', files=files)
+    server_response = server_response.json()
+
+    server_response_keys = sorted(server_response['columns'])
+    assert server_response_keys == sorted(output_keys_for(output_features))
+    assert len(data_df) == len(server_response['data'])
+
+    model_output, _ = model.predict(dataset=data_df)
+    model_output = model_output.to_dict('split')
+    assert model_output == server_response
+
+    # Cleanup
     shutil.rmtree(output_dir, ignore_errors=True)
-    shutil.rmtree(image_dest_folder)
+    shutil.rmtree(image_dest_folder, ignore_errors=True)


### PR DESCRIPTION
This change allows users to make multiple predictions in a single request when using FastAPI serving.

It introduces a new endpoint: `/batch_predict`.

Using this endpoint, requests are expected to be in a multi-part form.  Form elements are either files keyed by filename or a `dataset` field representing a JSON encoding of the dataset. 

The `dataset` is expected to be in the Pandas "split" format to reduce payload size.  This format divides the dataset into three parts:

```
{
    columns: List[str]
    index: List[Union[str, int]]
    data: List[List[object]]
}
```