### PR TITLE
[WIP\proposal] use hparam plugin in tensorboard

### DIFF
--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -50,6 +50,8 @@ from ludwig.utils.math_utils import learning_rate_warmup, \
     learning_rate_warmup_distributed, exponential_decay
 from ludwig.utils.misc_utils import set_random_seed
 
+from tensorboard.plugins.hparams import api as hp
+
 logger = logging.getLogger(__name__)
 
 
@@ -224,6 +226,54 @@ class Trainer:
             horovod=horovod,
             **optimizer
         )
+
+    @classmethod
+    def write_hparam_summary(
+            cls,
+            train_summary_writer,
+            epochs,
+            learning_rate,
+            batch_size,
+            early_stop,
+            warmup_epochs,
+    ):
+        if not train_summary_writer:
+            return
+
+        HP_EPOCHS = hp.HParam('epochs')
+        HP_LEARNING_RATE = hp.HParam('learning_rate')
+        HP_BATCH_SIZE = hp.HParam('batch_size')
+        HP_EARLY_STOP = hp.HParam('early_stop')
+        HP_WARMUP_EPOCHS = hp.HParam('warmup_epochs')
+
+        # We can track the validation metric by setting this to the nametag of
+        # the metric already logged to the summary writer. I know I'm lazy :)
+        # TODO: set this using the actual values and do not use a fixed one
+        METRIC_LOSS = 'combined/epoch_loss'
+
+        with train_summary_writer.as_default():
+            hp.hparams_config(
+                hparams=[
+                    HP_EPOCHS,
+                    HP_LEARNING_RATE,
+                    HP_BATCH_SIZE,
+                    HP_EARLY_STOP,
+                    HP_WARMUP_EPOCHS
+                ],
+                metrics=[
+                    hp.Metric(METRIC_LOSS, display_name='loss')
+                ],
+            )
+            hparams = {
+                HP_EPOCHS: epochs,
+                HP_LEARNING_RATE: learning_rate,
+                HP_BATCH_SIZE: batch_size,
+                HP_EARLY_STOP: early_stop,
+                HP_WARMUP_EPOCHS: warmup_epochs,
+            }
+            hp.hparams(hparams)
+
+        train_summary_writer.flush()
 
     @classmethod
     def write_epoch_summary(
@@ -453,6 +503,15 @@ class Trainer:
                 last_learning_rate_reduction=0,
                 last_increase_batch_size=0,
             )
+
+        self.write_hparam_summary(
+            train_summary_writer=train_summary_writer,
+            epochs=self.epochs,
+            learning_rate=self.learning_rate,
+            batch_size=self.batch_size,
+            early_stop=self.early_stop,
+            warmup_epochs=self.learning_rate_warmup_epochs
+        )
 
         set_random_seed(self.random_seed)
         batcher = initialize_batcher(


### PR DESCRIPTION
I tried logging some of the hyperparameters used when training a model, along with the "usual" summaries that get written.
This enables a nice and cool feature in TensorBoard (yep, I'm always up for data analysis), that allows to have a quick comparison between models trained on the same dataset (hopefully) but with different hyperparameters.

This is only a proof-of-concept, and might not be so useful (well... it's not completely unuseful either, and it should only be polished prior to merging it), but it still has some potential. I'm currently using this to compare "big" changes in the overall parameters, but would like a lot to extend it to map also common parameters I tweak, such as resnet size, dropout value, fc_layer_sizes and so on.
I am currently fixed on the only measure of combined/epoch_loss, and I know that's suboptimal (there's a TODO exactly for that), and when present a combined/epoch_accuracy would be great too (but it hasn't been reimplemented yet).
Also, multiple measures can be added, cycling through all the various output features and tracking each epoch_loss as an output measure (along with epoch_accuracy when present, or mean_absolute_error, and so on... you get the reasoning).

This is the current result sample:
![image](https://user-images.githubusercontent.com/4464640/94615064-69a2c100-02a7-11eb-9512-0a573f87387a.png)
A detail shown when drilling down into the actual measures that resulted from that training
![image](https://user-images.githubusercontent.com/4464640/94615912-d074aa00-02a8-11eb-9334-83ed3c3b3c31.png)
A graphical representation "cause-effect" like
![image](https://user-images.githubusercontent.com/4464640/94615820-ab803700-02a8-11eb-81b5-091ecd2b9a41.png)

Logging everything would clutter the interface (the menu on the left shows all the hyperparameters you have logged), and by design works by specifying the hyperparameter range (which is a think I don't want to do, that would force us in defining the hyperparameter range prior to training, as opposed to just logging and plotting the results).
I tought of everything I could in terms of having a way to automatically choose the best yaml parameters to track, but something that is *very* important to me might be absolutely of no use for someone else.

The only thing that could resolve this in my opinion is to have a yaml "flag" for each actual parameter that toggles hparam logging on\off, like below.
Do you have any ideas about this? Not being able to log\map\track the dropout of an input\output feature (for example) is a huge dealbreaker for me, since the parameters I "play" with the most during optimization are exactly those linked to the input features, and I also might want to just track some and not all of them.
Of course this would mean that you should track always the same parameter values, to be consistent in the output\analysis that would follow.

yaml sample:

input_features:
    -
        name: in
        type: numerical
        dropout: 0.2
                hparam_logging: true

output_features:
    -
        name: out
        type: numerical
        
preprocessing:
        force_split: true
        split_probabilities: [0.8, 0.2, 0.0]
        
training:
        batch_size: 5
                hparam_logging: true
        learning_rate: 0.01
                hparam_logging: true
        epochs: 1000
        early_stop: 1000
        reduce_learning_rate_on_plateau: 100
        reduce_learning_rate_on_plateau_patience: 5
                hparam_logging: true
        reduce_learning_rate_on_plateau_rate: 0.5
                hparam_logging: true
        learning_rate_warmup_epochs: 10
