### PR TITLE
TF2: correct inconsistent naming in categorical encoder/decoder

### DIFF
--- a/ludwig/decoders/generic_decoders.py
+++ b/ludwig/decoders/generic_decoders.py
@@ -119,9 +119,9 @@ class Classifier(Layer):
             self,
             num_classes,
             use_bias=True,
-            kernel_initializer='glorot_uniform',
+            weights_initializer='glorot_uniform',
             bias_initializer='zeros',
-            kernel_regularizer=None,
+            weights_regularizer=None,
             bias_regularizer=None,
             activity_regularizer=None,
             **kwargs
@@ -133,9 +133,9 @@ class Classifier(Layer):
         self.dense = Dense(
             num_classes,
             use_bias=use_bias,
-            kernel_initializer=kernel_initializer,
+            kernel_initializer=weights_initializer,
             bias_initializer=bias_initializer,
-            kernel_regularizer=kernel_regularizer,
+            kernel_regularizer=weights_regularizer,
             bias_regularizer=bias_regularizer,
             activity_regularizer=activity_regularizer
         )

--- a/ludwig/encoders/category_encoders.py
+++ b/ludwig/encoders/category_encoders.py
@@ -76,8 +76,8 @@ class CategoricalSparseEncoder(Layer):
             pretrained_embeddings=None,
             embeddings_on_cpu=False,
             dropout=0.0,
-            initializer=None,
-            regularizer=None,
+            embedding_initializer=None,
+            embedding_regularizer=None,
             **kwargs
     ):
         super(CategoricalSparseEncoder, self).__init__()
@@ -92,8 +92,8 @@ class CategoricalSparseEncoder(Layer):
             pretrained_embeddings=pretrained_embeddings,
             embeddings_on_cpu=embeddings_on_cpu,
             dropout=dropout,
-            initializer=initializer,
-            regularizer=regularizer
+            embedding_initializer=embedding_initializer,
+            embedding_regularizer=embedding_regularizer
         )
 
     def call(self, inputs, training=None, mask=None):


### PR DESCRIPTION
# Code Pull Requests

Correct parameter name inconsistency.