### PR TITLE
Using isort Module to Optimize the Imports

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -26,7 +26,7 @@ import logging
 import os
 import tempfile
 from pprint import pformat
-from typing import List, Union, Dict, Tuple, Optional
+from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -35,35 +35,40 @@ import ludwig.contrib
 
 ludwig.contrib.contrib_import()
 
-from ludwig.constants import PREPROCESSING, TRAINING, VALIDATION, TEST, FULL
-from ludwig.contrib import contrib_command
-from ludwig.data.postprocessing import convert_predictions, postprocess
-from ludwig.data.preprocessing import preprocess_for_training, \
-    preprocess_for_prediction, load_metadata
-from ludwig.features.feature_registries import \
-    update_model_definition_with_metadata
-from ludwig.globals import TRAIN_SET_METADATA_FILE_NAME, \
-    MODEL_HYPERPARAMETERS_FILE_NAME, \
-    MODEL_WEIGHTS_FILE_NAME, set_disable_progressbar
-from ludwig.models.ecd import ECD
-from ludwig.models.predictor import Predictor, save_prediction_outputs, \
-    calculate_overall_stats, print_evaluation_stats, save_evaluation_stats
-from ludwig.models.trainer import Trainer
-from ludwig.modules.metric_modules import get_best_function
-from ludwig.utils.data_utils import save_json, load_json, \
-    generate_kfold_splits, figure_data_format, DATAFRAME_FORMATS, \
-    DICT_FORMATS, CACHEABLE_FORMATS, external_data_reader_registry
-from ludwig.utils.horovod_utils import broadcast_return, configure_horovod, \
-    set_on_master, \
-    is_on_master
-from ludwig.utils.misc_utils import get_output_directory, get_file_names, \
-    get_experiment_description, get_from_registry
-from ludwig.utils.tf_utils import initialize_tensorflow
-
 import yaml
 
+from ludwig.constants import FULL, PREPROCESSING, TEST, TRAINING, VALIDATION
+from ludwig.contrib import contrib_command
+from ludwig.data.postprocessing import convert_predictions, postprocess
+from ludwig.data.preprocessing import (load_metadata,
+                                       preprocess_for_prediction,
+                                       preprocess_for_training)
+from ludwig.features.feature_registries import \
+    update_model_definition_with_metadata
+from ludwig.globals import (MODEL_HYPERPARAMETERS_FILE_NAME,
+                            MODEL_WEIGHTS_FILE_NAME,
+                            TRAIN_SET_METADATA_FILE_NAME,
+                            set_disable_progressbar)
+from ludwig.models.ecd import ECD
+from ludwig.models.predictor import (Predictor, calculate_overall_stats,
+                                     print_evaluation_stats,
+                                     save_evaluation_stats,
+                                     save_prediction_outputs)
+from ludwig.models.trainer import Trainer
+from ludwig.modules.metric_modules import get_best_function
+from ludwig.utils.data_utils import (CACHEABLE_FORMATS, DATAFRAME_FORMATS,
+                                     DICT_FORMATS,
+                                     external_data_reader_registry,
+                                     figure_data_format, generate_kfold_splits,
+                                     load_json, save_json)
 from ludwig.utils.defaults import default_random_seed, merge_with_defaults
+from ludwig.utils.horovod_utils import (broadcast_return, configure_horovod,
+                                        is_on_master, set_on_master)
+from ludwig.utils.misc_utils import (get_experiment_description,
+                                     get_file_names, get_from_registry,
+                                     get_output_directory)
 from ludwig.utils.print_utils import print_boxed
+from ludwig.utils.tf_utils import initialize_tensorflow
 
 logger = logging.getLogger(__name__)
 

--- a/ludwig/collect.py
+++ b/ludwig/collect.py
@@ -23,12 +23,11 @@ from typing import List
 import numpy as np
 
 from ludwig.api import LudwigModel
-from ludwig.constants import FULL, TRAINING, VALIDATION, TEST
+from ludwig.constants import FULL, TEST, TRAINING, VALIDATION
 from ludwig.contrib import contrib_command
 from ludwig.globals import LUDWIG_VERSION
-from ludwig.utils.print_utils import logging_level_registry
-from ludwig.utils.print_utils import print_boxed
-from ludwig.utils.print_utils import print_ludwig
+from ludwig.utils.print_utils import (logging_level_registry, print_boxed,
+                                      print_ludwig)
 from ludwig.utils.strings_utils import make_safe_filename
 
 logger = logging.getLogger(__name__)

--- a/ludwig/evaluate.py
+++ b/ludwig/evaluate.py
@@ -17,15 +17,15 @@
 import argparse
 import logging
 import sys
-from typing import Union, List
+from typing import List, Union
 
 import pandas as pd
 
 from ludwig.api import LudwigModel
-from ludwig.constants import FULL, TRAINING, VALIDATION, TEST
+from ludwig.constants import FULL, TEST, TRAINING, VALIDATION
 from ludwig.contrib import contrib_command, contrib_import
 from ludwig.globals import LUDWIG_VERSION
-from ludwig.utils.horovod_utils import set_on_master, is_on_master
+from ludwig.utils.horovod_utils import is_on_master, set_on_master
 from ludwig.utils.print_utils import logging_level_registry, print_ludwig
 
 logger = logging.getLogger(__name__)

--- a/ludwig/experiment.py
+++ b/ludwig/experiment.py
@@ -18,22 +18,20 @@ import argparse
 import logging
 import os
 import sys
-from typing import Union, List
-
-import yaml
+from typing import List, Union
 
 import pandas as pd
+import yaml
 
 from ludwig.api import LudwigModel, kfold_cross_validate
-from ludwig.constants import TEST, TRAINING, VALIDATION, FULL
+from ludwig.constants import FULL, TEST, TRAINING, VALIDATION
 from ludwig.contrib import contrib_command, contrib_import
 from ludwig.globals import LUDWIG_VERSION
 from ludwig.utils.data_utils import save_json
 from ludwig.utils.defaults import default_random_seed
-from ludwig.utils.horovod_utils import set_on_master, is_on_master
+from ludwig.utils.horovod_utils import is_on_master, set_on_master
 from ludwig.utils.misc_utils import check_which_model_definition
-from ludwig.utils.print_utils import logging_level_registry
-from ludwig.utils.print_utils import print_ludwig
+from ludwig.utils.print_utils import logging_level_registry, print_ludwig
 
 logger = logging.getLogger(__name__)
 

--- a/ludwig/export.py
+++ b/ludwig/export.py
@@ -24,8 +24,7 @@ from ludwig.contrib import contrib_command
 from ludwig.globals import LUDWIG_VERSION
 from ludwig.utils.neuropod_utils import \
     export_neuropod as utils_export_neuropod
-from ludwig.utils.print_utils import logging_level_registry
-from ludwig.utils.print_utils import print_ludwig
+from ludwig.utils.print_utils import logging_level_registry, print_ludwig
 
 logger = logging.getLogger(__name__)
 

--- a/ludwig/hyperopt_cli.py
+++ b/ludwig/hyperopt_cli.py
@@ -17,7 +17,7 @@
 import argparse
 import logging
 import sys
-from typing import Union, List
+from typing import List, Union
 
 import yaml
 
@@ -25,7 +25,7 @@ from ludwig.contrib import contrib_command, contrib_import
 from ludwig.globals import LUDWIG_VERSION
 from ludwig.hyperopt.run import hyperopt
 from ludwig.utils.defaults import default_random_seed
-from ludwig.utils.horovod_utils import set_on_master, is_on_master
+from ludwig.utils.horovod_utils import is_on_master, set_on_master
 from ludwig.utils.misc_utils import check_which_model_definition
 from ludwig.utils.print_utils import logging_level_registry, print_ludwig
 

--- a/ludwig/modules/attention_modules.py
+++ b/ludwig/modules/attention_modules.py
@@ -17,8 +17,7 @@ import logging
 
 import tensorflow as tf
 from tensorflow.keras import Sequential
-from tensorflow.keras.layers import Layer, Dense, Dropout, \
-    LayerNormalization
+from tensorflow.keras.layers import Dense, Dropout, Layer, LayerNormalization
 
 logger = logging.getLogger(__name__)
 

--- a/ludwig/modules/convolutional_modules.py
+++ b/ludwig/modules/convolutional_modules.py
@@ -16,21 +16,13 @@
 import logging
 
 import tensorflow as tf
-from tensorflow import math
-from tensorflow import squeeze
+from tensorflow import math, squeeze
 from tensorflow.keras.initializers import VarianceScaling
-from tensorflow.keras.layers import Activation
-from tensorflow.keras.layers import AveragePooling1D
-from tensorflow.keras.layers import AveragePooling2D
-from tensorflow.keras.layers import BatchNormalization
-from tensorflow.keras.layers import Conv1D
-from tensorflow.keras.layers import Conv2D
-from tensorflow.keras.layers import Dropout
-from tensorflow.keras.layers import Layer
-from tensorflow.keras.layers import LayerNormalization
-from tensorflow.keras.layers import MaxPool1D
-from tensorflow.keras.layers import MaxPool2D
-from tensorflow.keras.layers import ZeroPadding2D
+from tensorflow.keras.layers import (Activation, AveragePooling1D,
+                                     AveragePooling2D, BatchNormalization,
+                                     Conv1D, Conv2D, Dropout, Layer,
+                                     LayerNormalization, MaxPool1D, MaxPool2D,
+                                     ZeroPadding2D)
 
 logger = logging.getLogger(__name__)
 

--- a/ludwig/modules/fully_connected_modules.py
+++ b/ludwig/modules/fully_connected_modules.py
@@ -15,12 +15,8 @@
 # ==============================================================================
 import logging
 
-from tensorflow.keras.layers import Activation
-from tensorflow.keras.layers import BatchNormalization
-from tensorflow.keras.layers import Dense
-from tensorflow.keras.layers import Dropout
-from tensorflow.keras.layers import Layer
-from tensorflow.keras.layers import LayerNormalization
+from tensorflow.keras.layers import (Activation, BatchNormalization, Dense,
+                                     Dropout, Layer, LayerNormalization)
 
 logger = logging.getLogger(__name__)
 

--- a/ludwig/modules/loss_modules.py
+++ b/ludwig/modules/loss_modules.py
@@ -16,7 +16,7 @@
 import numpy as np
 import tensorflow as tf
 import tensorflow_addons as tfa
-from tensorflow.python.keras.losses import MeanSquaredError, MeanAbsoluteError
+from tensorflow.python.keras.losses import MeanAbsoluteError, MeanSquaredError
 
 from ludwig.constants import *
 from ludwig.constants import LOGITS

--- a/ludwig/modules/metric_modules.py
+++ b/ludwig/modules/metric_modules.py
@@ -16,17 +16,16 @@
 import numpy as np
 import tensorflow as tf
 from tensorflow.python.keras.metrics import \
-    MeanAbsoluteError as MeanAbsoluteErrorMetric, \
+    MeanAbsoluteError as MeanAbsoluteErrorMetric
+from tensorflow.python.keras.metrics import \
     MeanSquaredError as MeanSquaredErrorMetric
 
 from ludwig.constants import *
 from ludwig.constants import PREDICTIONS
-from ludwig.modules.loss_modules import BWCEWLoss, \
-    SigmoidCrossEntropyLoss
-from ludwig.modules.loss_modules import SequenceLoss
-from ludwig.modules.loss_modules import SoftmaxCrossEntropyLoss
-from ludwig.utils.tf_utils import sequence_length_2D
-from ludwig.utils.tf_utils import to_sparse
+from ludwig.modules.loss_modules import (BWCEWLoss, SequenceLoss,
+                                         SigmoidCrossEntropyLoss,
+                                         SoftmaxCrossEntropyLoss)
+from ludwig.utils.tf_utils import sequence_length_2D, to_sparse
 
 metrics = {ACCURACY, TOKEN_ACCURACY, HITS_AT_K, R2, JACCARD, EDIT_DISTANCE,
            MEAN_SQUARED_ERROR, MEAN_ABSOLUTE_ERROR,

--- a/ludwig/modules/recurrent_modules.py
+++ b/ludwig/modules/recurrent_modules.py
@@ -16,7 +16,7 @@
 import inspect
 import logging
 
-from tensorflow.keras.layers import SimpleRNN, GRU, LSTM, Bidirectional, Layer
+from tensorflow.keras.layers import GRU, LSTM, Bidirectional, Layer, SimpleRNN
 
 from ludwig.utils.misc_utils import get_from_registry
 

--- a/ludwig/modules/reduction_modules.py
+++ b/ludwig/modules/reduction_modules.py
@@ -18,8 +18,7 @@ import logging
 import tensorflow as tf
 from tensorflow.keras.layers import Layer
 
-from ludwig.modules.attention_modules import \
-    FeedForwardAttentionReducer
+from ludwig.modules.attention_modules import FeedForwardAttentionReducer
 from ludwig.utils.misc_utils import get_from_registry
 from ludwig.utils.tf_utils import sequence_length_3D
 

--- a/ludwig/predict.py
+++ b/ludwig/predict.py
@@ -17,17 +17,16 @@
 import argparse
 import logging
 import sys
-from typing import Union, List
+from typing import List, Union
 
 import pandas as pd
 
 from ludwig.api import LudwigModel
-from ludwig.constants import FULL, TRAINING, VALIDATION, TEST
+from ludwig.constants import FULL, TEST, TRAINING, VALIDATION
 from ludwig.contrib import contrib_command, contrib_import
 from ludwig.globals import LUDWIG_VERSION
-from ludwig.utils.horovod_utils import set_on_master, is_on_master
-from ludwig.utils.print_utils import logging_level_registry
-from ludwig.utils.print_utils import print_ludwig
+from ludwig.utils.horovod_utils import is_on_master, set_on_master
+from ludwig.utils.print_utils import logging_level_registry, print_ludwig
 
 logger = logging.getLogger(__name__)
 

--- a/ludwig/train.py
+++ b/ludwig/train.py
@@ -17,19 +17,18 @@
 import argparse
 import logging
 import sys
-from typing import Union, List
+from typing import List, Union
 
-import yaml
 import pandas as pd
+import yaml
 
 from ludwig.api import LudwigModel
 from ludwig.contrib import contrib_command, contrib_import
 from ludwig.globals import LUDWIG_VERSION
 from ludwig.utils.defaults import default_random_seed
-from ludwig.utils.horovod_utils import set_on_master, is_on_master
+from ludwig.utils.horovod_utils import is_on_master, set_on_master
 from ludwig.utils.misc_utils import check_which_model_definition
-from ludwig.utils.print_utils import logging_level_registry
-from ludwig.utils.print_utils import print_ludwig
+from ludwig.utils.print_utils import logging_level_registry, print_ludwig
 
 logger = logging.getLogger(__name__)
 

--- a/ludwig/utils/batcher.py
+++ b/ludwig/utils/batcher.py
@@ -17,7 +17,6 @@
 import math
 
 import numpy as np
-
 from ludwig.data.sampler import DistributedSampler
 
 

--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -27,12 +27,12 @@ import re
 import h5py
 import numpy as np
 import pandas as pd
+from ludwig.constants import NAME, PREPROCESSING, SPLIT
+from ludwig.globals import (MODEL_HYPERPARAMETERS_FILE_NAME,
+                            MODEL_WEIGHTS_FILE_NAME,
+                            TRAIN_SET_METADATA_FILE_NAME)
 from pandas.errors import ParserError
 from sklearn.model_selection import KFold
-
-from ludwig.constants import SPLIT, PREPROCESSING, NAME
-from ludwig.globals import MODEL_HYPERPARAMETERS_FILE_NAME, \
-    TRAIN_SET_METADATA_FILE_NAME, MODEL_WEIGHTS_FILE_NAME
 
 logger = logging.getLogger(__name__)
 

--- a/ludwig/utils/defaults.py
+++ b/ludwig/utils/defaults.py
@@ -17,12 +17,11 @@
 import logging
 
 from ludwig.constants import *
-from ludwig.features.feature_registries import base_type_registry
-from ludwig.features.feature_registries import input_type_registry
-from ludwig.features.feature_registries import output_type_registry
-from ludwig.utils.misc_utils import get_from_registry
-from ludwig.utils.misc_utils import merge_dict
-from ludwig.utils.misc_utils import set_default_value
+from ludwig.features.feature_registries import (base_type_registry,
+                                                input_type_registry,
+                                                output_type_registry)
+from ludwig.utils.misc_utils import (get_from_registry, merge_dict,
+                                     set_default_value)
 
 logger = logging.getLogger(__name__)
 

--- a/ludwig/utils/image_utils.py
+++ b/ludwig/utils/image_utils.py
@@ -16,10 +16,9 @@
 # ==============================================================================
 import logging
 import sys
-from math import floor, ceil
+from math import ceil, floor
 
 import numpy as np
-
 from ludwig.constants import CROP_OR_PAD, INTERPOLATE
 
 logger = logging.getLogger(__name__)

--- a/ludwig/utils/misc_utils.py
+++ b/ludwig/utils/misc_utils.py
@@ -23,9 +23,8 @@ import sys
 from collections import OrderedDict
 from collections.abc import Mapping
 
-import numpy
-
 import ludwig.globals
+import numpy
 from ludwig.utils.data_utils import figure_data_format
 
 

--- a/ludwig/utils/neuropod_utils.py
+++ b/ludwig/utils/neuropod_utils.py
@@ -1,16 +1,16 @@
 import logging
-import logging
 import os
 import shutil
 
 import numpy as np
-
 from ludwig import __file__ as ludwig_path
 from ludwig.api import LudwigModel
-from ludwig.constants import CATEGORY, NUMERICAL, BINARY, SEQUENCE, TEXT, SET, \
-    VECTOR, PREDICTIONS, PROBABILITIES, PROBABILITY, NAME, TYPE
-from ludwig.globals import MODEL_HYPERPARAMETERS_FILE_NAME, \
-    TRAIN_SET_METADATA_FILE_NAME, MODEL_WEIGHTS_FILE_NAME
+from ludwig.constants import (BINARY, CATEGORY, NAME, NUMERICAL, PREDICTIONS,
+                              PROBABILITIES, PROBABILITY, SEQUENCE, SET, TEXT,
+                              TYPE, VECTOR)
+from ludwig.globals import (MODEL_HYPERPARAMETERS_FILE_NAME,
+                            MODEL_WEIGHTS_FILE_NAME,
+                            TRAIN_SET_METADATA_FILE_NAME)
 from ludwig.utils.data_utils import load_json
 
 logger = logging.getLogger(__name__)

--- a/ludwig/utils/strings_utils.py
+++ b/ludwig/utils/strings_utils.py
@@ -21,7 +21,6 @@ from abc import abstractmethod
 from collections import Counter
 
 import numpy as np
-
 from ludwig.utils.math_utils import int_type
 from ludwig.utils.misc_utils import get_from_registry
 from ludwig.utils.nlp_utils import load_nlp_pipeline, process_text

--- a/ludwig/utils/visualization_utils.py
+++ b/ludwig/utils/visualization_utils.py
@@ -20,11 +20,10 @@ import sys
 from collections import Counter
 from sys import platform
 
+import ludwig.contrib
 import numpy as np
 import pandas as pd
-
-import ludwig.contrib
-from ludwig.constants import TRAINING, VALIDATION, TYPE
+from ludwig.constants import TRAINING, TYPE, VALIDATION
 
 logger = logging.getLogger(__name__)
 

--- a/ludwig/visualize.py
+++ b/ludwig/visualize.py
@@ -31,7 +31,7 @@ from sklearn.metrics import brier_score_loss
 from ludwig.constants import *
 from ludwig.contrib import contrib_command, contrib_import
 from ludwig.utils import visualization_utils
-from ludwig.utils.data_utils import load_json, load_from_file
+from ludwig.utils.data_utils import load_from_file, load_json
 from ludwig.utils.print_utils import logging_level_registry
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
`isort` module is one of the most efficient ways to optimize importing libs, modules, files, and etc. It eventually sorts all those lines at the top of any script. I've chopped each directory in the several commits. In spite, there is no big change in the main algorithm, now, everything looks more pretty and clean.

[isort module official Github page](https://github.com/PyCQA/isort)