### PR TITLE
Pin tf-nightly==2.4.0.dev20201002

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
     if [ $TENSORFLOW == "nightly" ]; then
       cat requirements.txt | sed '/^tensorflow[>=<]/d' > requirements-temp && mv requirements-temp requirements.txt
       cat requirements_horovod.txt | sed 's/\[tensorflow\]//g' > requirements-temp && mv requirements-temp requirements_horovod.txt
-      pip install tf-nightly
+      pip install tf-nightly==2.4.0.dev20201002
     else
       pip install tensorflow==$TENSORFLOW
     fi


### PR DESCRIPTION
Latest nightly builds are failing due to TensorFlow Eigen update:

```
/home/travis/virtualenv/python3.8.1/lib/python3.8/site-packages/tensorflow/include/unsupported/Eigen/CXX11/src/Tensor/TensorBroadcasting.h:605:61: error: expected primary-expression before ‘>’ token
               if (!internal::index_statically_eq<InputDimensions>(i, 1)) {
```

This will require an update to Horovod, at which point we will need to build Ludwig + tf-nightly against Horovod master until a release is cut.