### PR TITLE
Changed missing_value_strategy to apply values computed during training time at prediction

### DIFF
--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -225,7 +225,7 @@ class CSVPreprocessor(DataFormatPreprocessor):
             dataset_df,
             features,
             preprocessing_params,
-            training_set_metadata=training_set_metadata
+            metadata=training_set_metadata
         )
         return dataset, training_set_metadata, None
 
@@ -269,7 +269,7 @@ class TSVPreprocessor(DataFormatPreprocessor):
             dataset_df,
             features,
             preprocessing_params,
-            training_set_metadata=training_set_metadata
+            metadata=training_set_metadata
         )
         return dataset, training_set_metadata, None
 
@@ -313,7 +313,7 @@ class JSONPreprocessor(DataFormatPreprocessor):
             dataset_df,
             features,
             preprocessing_params,
-            training_set_metadata=training_set_metadata
+            metadata=training_set_metadata
         )
         return dataset, training_set_metadata, None
 
@@ -357,7 +357,7 @@ class JSONLPreprocessor(DataFormatPreprocessor):
             dataset_df,
             features,
             preprocessing_params,
-            training_set_metadata=training_set_metadata
+            metadata=training_set_metadata
         )
         return dataset, training_set_metadata, None
 
@@ -401,7 +401,7 @@ class ExcelPreprocessor(DataFormatPreprocessor):
             dataset_df,
             features,
             preprocessing_params,
-            training_set_metadata=training_set_metadata
+            metadata=training_set_metadata
         )
         return dataset, training_set_metadata, None
 
@@ -445,7 +445,7 @@ class ParquetPreprocessor(DataFormatPreprocessor):
             dataset_df,
             features,
             preprocessing_params,
-            training_set_metadata=training_set_metadata
+            metadata=training_set_metadata
         )
         return dataset, training_set_metadata, None
 
@@ -489,7 +489,7 @@ class PicklePreprocessor(DataFormatPreprocessor):
             dataset_df,
             features,
             preprocessing_params,
-            training_set_metadata=training_set_metadata
+            metadata=training_set_metadata
         )
         return dataset, training_set_metadata, None
 
@@ -533,7 +533,7 @@ class FatherPreprocessor(DataFormatPreprocessor):
             dataset_df,
             features,
             preprocessing_params,
-            training_set_metadata=training_set_metadata
+            metadata=training_set_metadata
         )
         return dataset, training_set_metadata, None
 
@@ -577,7 +577,7 @@ class FWFPreprocessor(DataFormatPreprocessor):
             dataset_df,
             features,
             preprocessing_params,
-            training_set_metadata=training_set_metadata
+            metadata=training_set_metadata
         )
         return dataset, training_set_metadata, None
 
@@ -621,7 +621,7 @@ class HTMLPreprocessor(DataFormatPreprocessor):
             dataset_df,
             features,
             preprocessing_params,
-            training_set_metadata=training_set_metadata
+            metadata=training_set_metadata
         )
         return dataset, training_set_metadata, None
 
@@ -665,7 +665,7 @@ class ORCPreprocessor(DataFormatPreprocessor):
             dataset_df,
             features,
             preprocessing_params,
-            training_set_metadata=training_set_metadata
+            metadata=training_set_metadata
         )
         return dataset, training_set_metadata, None
 
@@ -709,7 +709,7 @@ class SASPreprocessor(DataFormatPreprocessor):
             dataset_df,
             features,
             preprocessing_params,
-            training_set_metadata=training_set_metadata
+            metadata=training_set_metadata
         )
         return dataset, training_set_metadata, None
 
@@ -753,7 +753,7 @@ class SPSSPreprocessor(DataFormatPreprocessor):
             dataset_df,
             features,
             preprocessing_params,
-            training_set_metadata=training_set_metadata
+            metadata=training_set_metadata
         )
         return dataset, training_set_metadata, None
 
@@ -797,7 +797,7 @@ class StataPreprocessor(DataFormatPreprocessor):
             dataset_df,
             features,
             preprocessing_params,
-            training_set_metadata=training_set_metadata
+            metadata=training_set_metadata
         )
         return dataset, training_set_metadata, None
 
@@ -907,7 +907,6 @@ def build_dataset(
         global_preprocessing_parameters,
         metadata=None,
         random_seed=default_random_seed,
-        **kwargs
 ):
     global_preprocessing_parameters = merge_dict(
         default_preprocessing_parameters,
@@ -1293,7 +1292,7 @@ def _preprocess_file_for_training(
             dataset_df,
             features,
             preprocessing_params,
-            training_set_metadata=training_set_metadata,
+            metadata=training_set_metadata,
             random_seed=random_seed
         )
 
@@ -1510,6 +1509,7 @@ def preprocess_for_prediction(
         data_format,
         data_format_preprocessor_registry
     )
+
     processed = data_format_processor.preprocess_for_prediction(dataset,
                                                                 features,
                                                                 preprocessing_params,
@@ -1653,12 +1653,13 @@ if __name__ == '__main__':
 
     dataset_df = read_csv(args.dataset_csv)
     dataset_df.src = args.dataset_csv
+    training_set_metadata = load_metadata(args.training_set_metadata_json)
     dataset, training_set_metadata = build_dataset(
-        dataset_df,
-        args.training_set_metadata_json,
-        args.features,
-        args.preprocessing_parameters,
-        args.random_seed
+        dataset_df=dataset_df,
+        features=args.features,
+        global_preprocessing_parameters=args.preprocessing_parameters,
+        metadata=training_set_metadata,
+        random_seed=args.random_seed
     )
 
     # write train set metadata, dataset

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -971,6 +971,7 @@ def build_metadata(dataset_df, features, global_preprocessing_parameters):
             feature[TYPE],
             base_type_registry
         ).get_feature_meta
+
         metadata[feature[NAME]] = get_feature_meta(
             dataset_df[feature[NAME]].astype(str),
             preprocessing_parameters

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -1039,11 +1039,6 @@ def handle_missing_values(dataset_df, feature, preprocessing_parameters):
 
     # Check for the precomputed fill value in the metadata
     computed_fill_value = preprocessing_parameters.get('computed_fill_value')
-    if computed_fill_value is None:
-        # For legacy models, we need to recompute the fill value, as it will not
-        # have been stored
-        computed_fill_value = precompute_fill_value(
-            dataset_df, feature, preprocessing_parameters)
 
     if computed_fill_value is not None:
         dataset_df[feature[NAME]] = dataset_df[feature[NAME]].fillna(

--- a/tests/integration_tests/test_missing_value_strategy.py
+++ b/tests/integration_tests/test_missing_value_strategy.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import tempfile
+
+import pandas as pd
+
+from ludwig.api import LudwigModel
+from tests.integration_tests.utils import binary_feature
+from tests.integration_tests.utils import category_feature
+from tests.integration_tests.utils import generate_data
+
+
+def test_missing_value_prediction(csv_filename):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        input_features = [category_feature(vocab_size=2, reduce_input='sum',
+                                           preprocessing=dict(missing_value_strategy='fill_with_mode'))]
+        output_features = [binary_feature()]
+
+        dataset = pd.read_csv(generate_data(input_features, output_features, csv_filename))
+
+        model_definition = {
+            'input_features': input_features,
+            'output_features': output_features,
+            'combiner': {'type': 'concat', 'fc_size': 14},
+        }
+        model = LudwigModel(model_definition)
+        model.train(dataset=dataset, output_directory=tmpdir)
+
+        # Set the input column to None, we should be able to replace the missing value with the mode
+        # from the training set
+        dataset[input_features[0]['name']] = None
+        model.predict(dataset=dataset)

--- a/tests/integration_tests/test_missing_value_strategy.py
+++ b/tests/integration_tests/test_missing_value_strategy.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+import os
 import tempfile
 
 import pandas as pd
@@ -37,9 +38,12 @@ def test_missing_value_prediction(csv_filename):
             'combiner': {'type': 'concat', 'fc_size': 14},
         }
         model = LudwigModel(model_definition)
-        model.train(dataset=dataset, output_directory=tmpdir)
+        _, _, output_dir = model.train(dataset=dataset, output_directory=tmpdir)
 
         # Set the input column to None, we should be able to replace the missing value with the mode
         # from the training set
         dataset[input_features[0]['name']] = None
+        model.predict(dataset=dataset)
+
+        model = LudwigModel.load(os.path.join(output_dir, 'model'))
         model.predict(dataset=dataset)

--- a/tests/integration_tests/test_neuropod.py
+++ b/tests/integration_tests/test_neuropod.py
@@ -83,12 +83,13 @@ def test_neuropod(csv_filename):
         dataset=data_csv_path,
         skip_save_training_description=True,
         skip_save_training_statistics=True,
-        skip_save_model=True,
         skip_save_progress=True,
         skip_save_log=True,
         skip_save_processed_input=True,
     )
-    original_predictions_df, _ = ludwig_model.predict(dataset=data_csv_path)
+
+    data_df = pd.read_csv(data_csv_path)
+    original_predictions_df, _ = ludwig_model.predict(dataset=data_df)
 
     ###################
     # save Ludwig model
@@ -107,7 +108,6 @@ def test_neuropod(csv_filename):
     ########################
     # predict using neuropod
     ########################
-    data_df = pd.read_csv(data_csv_path)
     if_dict = {
         input_feature['name']: np.expand_dims(np.array(
             [str(x) for x in data_df[input_feature['name']].tolist()],
@@ -176,7 +176,7 @@ def test_neuropod(csv_filename):
                     itertools.zip_longest(*original_prob, fillvalue=0)
                 )).T
 
-            assert np.isclose(neuropod_prob, original_prob).all()
+            assert np.allclose(neuropod_prob, original_prob)
 
         if (output_feature_name + "_probabilities" in preds and
                 output_feature_name + "_probabilities" in original_predictions_df):
@@ -186,4 +186,4 @@ def test_neuropod(csv_filename):
             original_prob = original_predictions_df[
                 output_feature_name + "_probabilities"].tolist()
 
-            assert np.isclose(neuropod_prob, original_prob).all()
+            assert np.allclose(neuropod_prob, original_prob)


### PR DESCRIPTION
This PR fixes `missing_value_stragegy` in cases where the user is doing one-off or small batch prediction.  

In such cases, certain fields may be entirely null, and the predefined missing value strategy (mean or mode) cannot be determined.  However, what we want. is to apply the mean or mode not from the prediction set, but from the training set, as it more accurately reflects the true distribution of values.

To address this, a new preprocessing parameters `computed_fill_value` has been added to the `training_set_metadata` which, if present, will override the missing value strategy.  This only applies for mean and mode at this time, as there is no easy equivalent for backfill or dropping rows.

An additional benefit for this PR is that it reduces computation by only calling `handle_missing_values` once during training, as opposed to twice.