### PR TITLE
refactor: updated run_experiment to use additional skip parameters and returns

### DIFF
--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -331,15 +331,21 @@ def run_experiment(input_features, output_features, **kwargs):
 
     args = {
         'config': config,
+        'skip_save_training_description': True,
+        'skip_save_training_statistics': True,
         'skip_save_processed_input': True,
         'skip_save_progress': True,
         'skip_save_unprocessed_output': True,
         'skip_save_model': True,
+        'skip_save_predictions': True,
+        'skip_save_eval_stats': True,
+        'skip_collect_predictions': True,
+        'skip_collect_overall_stats': True,
         'skip_save_log': True
     }
     args.update(kwargs)
 
-    exp_dir_name = experiment_cli(**args)
+    _, _, _, _, exp_dir_name = experiment_cli(**args)
     shutil.rmtree(exp_dir_name, ignore_errors=True)
 
 


### PR DESCRIPTION
# Code Pull Requests

Updated test utility `run_experiment()` to use additional skip parameters to avoid storing data and use new return signature so clean up works.  Prior to this change clean up of the `output_directory` was not working.  Clean-up error was failing but was ignored.