### PR TITLE
Fix errors with DataFrame truthy checks

### DIFF
--- a/ludwig/hyperopt/run.py
+++ b/ludwig/hyperopt/run.py
@@ -176,7 +176,7 @@ def hyperopt(
     # check validity of output_feature / metric/ split combination
     ######################
     if split == TRAINING:
-        if not training_set and (
+        if training_set is None and (
                 config['preprocessing']['split_probabilities'][0]
                 <= 0):
             raise ValueError(
@@ -186,7 +186,7 @@ def hyperopt(
                 'of the config is not greater than 0'.format(split)
             )
     elif split == VALIDATION:
-        if not validation_set and (
+        if validation_set is None and (
                 config['preprocessing']['split_probabilities'][1]
                 <= 0):
             raise ValueError(
@@ -196,7 +196,7 @@ def hyperopt(
                 'of the config is not greater than 0'.format(split)
             )
     elif split == TEST:
-        if not test_set and (
+        if test_set is None and (
                 config['preprocessing']['split_probabilities'][2]
                 <= 0):
             raise ValueError(


### PR DESCRIPTION
Tried to use hyperopt programmatic API with dataframes for each split
```
hyperopt(
    config=config,
    training_set=train_data,
    validation_set=validation_data,
    test_set=test_data,
    output_directory="hyperopt_results",
)
```
This gave an error `ValueError: The truth value of a DataFrame is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all()` when `not training_set` is evaluated.

Fix is to change the following in the hyperopt.run module:
- `not training_set` to `training_set is None`
- `not validation_set` to `validation_set is None`
- `not test_set` to `test_set is None`

