### PR TITLE
Fix error in ludwig.predict while using skip_save_predictions=False

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -689,12 +689,12 @@ class LudwigModel:
 
         logger.debug('Postprocessing')
         postproc_predictions = postprocess(
-                predictions,
-                self.model.output_features,
-                self.training_set_metadata,
-                output_directory=output_directory,
-                skip_save_unprocessed_output=skip_save_unprocessed_output
-                                             or not is_on_master(),
+            predictions,
+            self.model.output_features,
+            self.training_set_metadata,
+            output_directory=output_directory,
+            skip_save_unprocessed_output=skip_save_unprocessed_output
+                                        or not is_on_master(),
             )
 
         if is_on_master():
@@ -703,6 +703,13 @@ class LudwigModel:
                                         output_directory)
 
                 logger.info('Saved to: {0}'.format(output_directory))
+
+        postproc_predictions = convert_predictions(
+            postproc_predictions,
+            self.model.output_features,
+            self.training_set_metadata,
+            return_type=return_type
+        )
 
         return postproc_predictions, output_directory
 

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -688,19 +688,14 @@ class LudwigModel:
                 os.makedirs(output_directory, exist_ok=True)
 
         logger.debug('Postprocessing')
-        postproc_predictions = convert_predictions(
-            postprocess(
+        postproc_predictions = postprocess(
                 predictions,
                 self.model.output_features,
                 self.training_set_metadata,
                 output_directory=output_directory,
                 skip_save_unprocessed_output=skip_save_unprocessed_output
                                              or not is_on_master(),
-            ),
-            self.model.output_features,
-            self.training_set_metadata,
-            return_type=return_type
-        )
+            )
 
         if is_on_master():
             if not skip_save_predictions:

--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -319,7 +319,7 @@ class Trainer:
 
         if not valid_validation_field:
             raise ValueError(
-                'The specificed validation_field {} is not valid.'
+                'The specified validation_field {} is not valid. '
                 'Available ones are: {}'.format(
                     self.validation_field,
                     list(output_features.keys()) + ['combined']
@@ -332,7 +332,7 @@ class Trainer:
         ]
         if not valid_validation_metric:
             raise ValueError(
-                'The specificed metric {} is not valid. '
+                'The specified metric {} is not valid. '
                 'Available metrics for {} output feature are: {}'.format(
                     self.validation_metric,
                     self.validation_field,

--- a/tests/integration_tests/test_api.py
+++ b/tests/integration_tests/test_api.py
@@ -78,7 +78,7 @@ def run_api_experiment(input_features, output_features, data_csv):
             skip_save_progress=True,
             skip_save_unprocessed_output=True
         )
-        model.predict(dataset=data_df)
+        model.predict(dataset=data_df, skip_save_predictions=False)
     finally:
         shutil.rmtree(output_dir, ignore_errors=True)
 


### PR DESCRIPTION
While trying to use the predict method with the parameter as `skip_save_predictions=False`,
```
predictions_parallel_cnn, _ = parallel_cnn.predict(dataset=test_data,
                                                   skip_save_predictions=False,
                                                   output_directory = 'test_results/parallel_cnn')
```
This throws an error `TypeError: 'float' object is not iterable`  which I suspect is due to the conversion of predictions before saving as a csv file,
https://github.com/uber/ludwig/blob/ab9bb7cac6287578e73b46579c18d518e2ddb5a6/ludwig/api.py#L691-L692

So, as a fix to this, I have removed `convert_predictions`. I have also added the parameter `skip_save_predictions=False` at one of the places in `test_api.py`.