### PR TITLE
Reduce run-time for Sequence Encoder/Generator unit test

### DIFF
--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -627,54 +627,54 @@ def test_experiment_tied_weights(csv_filename):
         run_experiment(input_features, output_features, dataset=rel_path)
 
 
-@pytest.mark.parametrize('dec_beam_width', [1, 3])
-@pytest.mark.parametrize('dec_attention', ['bahdanau', 'luong', None])
-@pytest.mark.parametrize('dec_cell_type', ['lstm', 'rnn', 'gru'])
-@pytest.mark.parametrize('enc_cell_type', ['lstm', 'rnn', 'gru'])
-@pytest.mark.parametrize('enc_encoder', ENCODERS)
-def test_sequence_generator(
-        enc_encoder,
-        enc_cell_type,
-        dec_cell_type,
-        dec_attention,
-        dec_beam_width,
-        csv_filename
-):
-    # Define input and output features
-    input_features = [
-        sequence_feature(
-            min_len=5,
-            max_len=10,
-            encoder='rnn',
-            cell_type='lstm',
-            reduce_output=None
-        )
-    ]
-    output_features = [
-        sequence_feature(
-            min_len=5,
-            max_len=10,
-            decoder='generator',
-            cell_type='lstm',
-            attention='bahdanau',
-            reduce_input=None
-        )
-    ]
-
-    # Generate test data
-    rel_path = generate_data(input_features, output_features, csv_filename)
-
-    # setup encoder specification
-    input_features[0]['encoder'] = enc_encoder
-    input_features[0]['cell_type'] = enc_cell_type
-
-    # setup decoder specification
-    output_features[0]['cell_type'] = dec_cell_type
-    output_features[0]['attention'] = dec_attention
-    output_features[0]['beam_width'] = dec_beam_width
-
-    # run the experiment
-    run_experiment(input_features, output_features, dataset=rel_path)
+# @pytest.mark.parametrize('dec_beam_width', [1, 3])
+# @pytest.mark.parametrize('dec_attention', ['bahdanau', 'luong', None])
+# @pytest.mark.parametrize('dec_cell_type', ['lstm', 'rnn', 'gru'])
+# @pytest.mark.parametrize('enc_cell_type', ['lstm', 'rnn', 'gru'])
+# @pytest.mark.parametrize('enc_encoder', ENCODERS)
+# def test_sequence_generator(
+#         enc_encoder,
+#         enc_cell_type,
+#         dec_cell_type,
+#         dec_attention,
+#         dec_beam_width,
+#         csv_filename
+# ):
+#     # Define input and output features
+#     input_features = [
+#         sequence_feature(
+#             min_len=5,
+#             max_len=10,
+#             encoder='rnn',
+#             cell_type='lstm',
+#             reduce_output=None
+#         )
+#     ]
+#     output_features = [
+#         sequence_feature(
+#             min_len=5,
+#             max_len=10,
+#             decoder='generator',
+#             cell_type='lstm',
+#             attention='bahdanau',
+#             reduce_input=None
+#         )
+#     ]
+#
+#     # Generate test data
+#     rel_path = generate_data(input_features, output_features, csv_filename)
+#
+#     # setup encoder specification
+#     input_features[0]['encoder'] = enc_encoder
+#     input_features[0]['cell_type'] = enc_cell_type
+#
+#     # setup decoder specification
+#     output_features[0]['cell_type'] = dec_cell_type
+#     output_features[0]['attention'] = dec_attention
+#     output_features[0]['beam_width'] = dec_beam_width
+#
+#     # run the experiment
+#     run_experiment(input_features, output_features, dataset=rel_path)
 
 
 @pytest.mark.parametrize('enc_cell_type', ['lstm', 'rnn', 'gru'])

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -627,56 +627,6 @@ def test_experiment_tied_weights(csv_filename):
         run_experiment(input_features, output_features, dataset=rel_path)
 
 
-@pytest.mark.parametrize('dec_beam_width', [1, 3])
-@pytest.mark.parametrize('dec_attention', ['bahdanau', 'luong', None])
-@pytest.mark.parametrize('dec_cell_type', ['lstm', 'rnn', 'gru'])
-@pytest.mark.parametrize('enc_cell_type', ['lstm', 'rnn', 'gru'])
-@pytest.mark.parametrize('enc_encoder', ENCODERS)
-def test_sequence_generator(
-        enc_encoder,
-        enc_cell_type,
-        dec_cell_type,
-        dec_attention,
-        dec_beam_width,
-        csv_filename
-):
-    # Define input and output features
-    input_features = [
-        sequence_feature(
-            min_len=5,
-            max_len=10,
-            encoder='rnn',
-            cell_type='lstm',
-            reduce_output=None
-        )
-    ]
-    output_features = [
-        sequence_feature(
-            min_len=5,
-            max_len=10,
-            decoder='generator',
-            cell_type='lstm',
-            attention='bahdanau',
-            reduce_input=None
-        )
-    ]
-
-    # Generate test data
-    rel_path = generate_data(input_features, output_features, csv_filename)
-
-    # setup encoder specification
-    input_features[0]['encoder'] = enc_encoder
-    input_features[0]['cell_type'] = enc_cell_type
-
-    # setup decoder specification
-    output_features[0]['cell_type'] = dec_cell_type
-    output_features[0]['attention'] = dec_attention
-    output_features[0]['beam_width'] = dec_beam_width
-
-    # run the experiment
-    run_experiment(input_features, output_features, dataset=rel_path)
-
-
 @pytest.mark.parametrize('enc_cell_type', ['lstm', 'rnn', 'gru'])
 @pytest.mark.parametrize('attention', [False, True])
 def test_sequence_tagger(

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -627,54 +627,54 @@ def test_experiment_tied_weights(csv_filename):
         run_experiment(input_features, output_features, dataset=rel_path)
 
 
-# @pytest.mark.parametrize('dec_beam_width', [1, 3])
-# @pytest.mark.parametrize('dec_attention', ['bahdanau', 'luong', None])
-# @pytest.mark.parametrize('dec_cell_type', ['lstm', 'rnn', 'gru'])
-# @pytest.mark.parametrize('enc_cell_type', ['lstm', 'rnn', 'gru'])
-# @pytest.mark.parametrize('enc_encoder', ENCODERS)
-# def test_sequence_generator(
-#         enc_encoder,
-#         enc_cell_type,
-#         dec_cell_type,
-#         dec_attention,
-#         dec_beam_width,
-#         csv_filename
-# ):
-#     # Define input and output features
-#     input_features = [
-#         sequence_feature(
-#             min_len=5,
-#             max_len=10,
-#             encoder='rnn',
-#             cell_type='lstm',
-#             reduce_output=None
-#         )
-#     ]
-#     output_features = [
-#         sequence_feature(
-#             min_len=5,
-#             max_len=10,
-#             decoder='generator',
-#             cell_type='lstm',
-#             attention='bahdanau',
-#             reduce_input=None
-#         )
-#     ]
-#
-#     # Generate test data
-#     rel_path = generate_data(input_features, output_features, csv_filename)
-#
-#     # setup encoder specification
-#     input_features[0]['encoder'] = enc_encoder
-#     input_features[0]['cell_type'] = enc_cell_type
-#
-#     # setup decoder specification
-#     output_features[0]['cell_type'] = dec_cell_type
-#     output_features[0]['attention'] = dec_attention
-#     output_features[0]['beam_width'] = dec_beam_width
-#
-#     # run the experiment
-#     run_experiment(input_features, output_features, dataset=rel_path)
+@pytest.mark.parametrize('dec_beam_width', [1, 3])
+@pytest.mark.parametrize('dec_attention', ['bahdanau', 'luong', None])
+@pytest.mark.parametrize('dec_cell_type', ['lstm', 'rnn', 'gru'])
+@pytest.mark.parametrize('enc_cell_type', ['lstm', 'rnn', 'gru'])
+@pytest.mark.parametrize('enc_encoder', ENCODERS)
+def test_sequence_generator(
+        enc_encoder,
+        enc_cell_type,
+        dec_cell_type,
+        dec_attention,
+        dec_beam_width,
+        csv_filename
+):
+    # Define input and output features
+    input_features = [
+        sequence_feature(
+            min_len=5,
+            max_len=10,
+            encoder='rnn',
+            cell_type='lstm',
+            reduce_output=None
+        )
+    ]
+    output_features = [
+        sequence_feature(
+            min_len=5,
+            max_len=10,
+            decoder='generator',
+            cell_type='lstm',
+            attention='bahdanau',
+            reduce_input=None
+        )
+    ]
+
+    # Generate test data
+    rel_path = generate_data(input_features, output_features, csv_filename)
+
+    # setup encoder specification
+    input_features[0]['encoder'] = enc_encoder
+    input_features[0]['cell_type'] = enc_cell_type
+
+    # setup decoder specification
+    output_features[0]['cell_type'] = dec_cell_type
+    output_features[0]['attention'] = dec_attention
+    output_features[0]['beam_width'] = dec_beam_width
+
+    # run the experiment
+    run_experiment(input_features, output_features, dataset=rel_path)
 
 
 @pytest.mark.parametrize('enc_cell_type', ['lstm', 'rnn', 'gru'])

--- a/tests/integration_tests/test_graph_execution.py
+++ b/tests/integration_tests/test_graph_execution.py
@@ -99,6 +99,13 @@ def test_sequence_generator(
         dec_beam_width,
         csv_filename
 ):
+    # check if gpu is present
+    gpu_devices = tf.config.list_physical_devices(device_type='GPU')
+    if not gpu_devices:
+        # gpu not present, ensure TFA Python Ops is loaded
+        import tensorflow_addons as tfa
+        tfa.options.TF_ADDONS_PY_OPS = True
+
     with graph_mode():
         # Define input and output features
         input_features = [

--- a/tests/integration_tests/test_graph_execution.py
+++ b/tests/integration_tests/test_graph_execution.py
@@ -17,6 +17,7 @@ import contextlib
 
 import pytest
 import tensorflow as tf
+import tensorflow_addons as tfa
 
 from tests.integration_tests.utils import category_feature
 from tests.integration_tests.utils import generate_data
@@ -99,12 +100,7 @@ def test_sequence_generator(
         dec_beam_width,
         csv_filename
 ):
-    # check if gpu is present
-    gpu_devices = tf.config.list_physical_devices(device_type='GPU')
-    if not gpu_devices:
-        # gpu not present, ensure TFA Python Ops is loaded
-        import tensorflow_addons as tfa
-        tfa.options.TF_ADDONS_PY_OPS = True
+    tfa.options.TF_ADDONS_PY_OPS = True
 
     with graph_mode():
         # Define input and output features

--- a/tests/integration_tests/test_graph_execution.py
+++ b/tests/integration_tests/test_graph_execution.py
@@ -72,6 +72,13 @@ def graph_mode():
     ]
 )
 def test_experiment_multiple_seq_seq(csv_filename, output_features):
+    # check if gpu is present
+    gpu_devices = tf.config.list_physical_devices(device_type='GPU')
+    if not gpu_devices:
+        # gpu not present, ensure TFA Python Ops is loaded
+        import tensorflow_addons as tfa
+        tfa.options.TF_ADDONS_PY_OPS = True
+
     with graph_mode():
         input_features = [
             text_feature(vocab_size=100, min_len=1, encoder='stacked_cnn'),

--- a/tests/integration_tests/test_graph_execution.py
+++ b/tests/integration_tests/test_graph_execution.py
@@ -72,13 +72,6 @@ def graph_mode():
     ]
 )
 def test_experiment_multiple_seq_seq(csv_filename, output_features):
-    # check if gpu is present
-    gpu_devices = tf.config.list_physical_devices(device_type='GPU')
-    if not gpu_devices:
-        # gpu not present, ensure TFA Python Ops is loaded
-        import tensorflow_addons as tfa
-        tfa.options.TF_ADDONS_PY_OPS = True
-
     with graph_mode():
         input_features = [
             text_feature(vocab_size=100, min_len=1, encoder='stacked_cnn'),

--- a/tests/integration_tests/test_sequence_features.py
+++ b/tests/integration_tests/test_sequence_features.py
@@ -13,6 +13,9 @@ from ludwig.utils.batcher import initialize_batcher
 from ludwig.data.dataset_synthesizer import build_synthetic_dataset
 from tests.integration_tests.utils import sequence_feature
 from tests.integration_tests.utils import ENCODERS
+from tests.integration_tests.utils import generate_data
+from tests.integration_tests.utils import run_experiment
+
 
 DEFAULT_HIDDEN_SIZE = 8
 
@@ -176,3 +179,53 @@ def test_sequence_encoders(
         else:
             raise ValueError('{} is an invalid encoder specification'\
                              .format(enc_encoder))
+
+
+@pytest.mark.parametrize('dec_beam_width', [1, 3])
+@pytest.mark.parametrize('dec_attention', ['bahdanau', 'luong', None])
+@pytest.mark.parametrize('dec_cell_type', ['lstm', 'rnn', 'gru'])
+@pytest.mark.parametrize('enc_cell_type', ['lstm', 'rnn', 'gru'])
+@pytest.mark.parametrize('enc_encoder', ['embed', 'rnn'])
+def test_sequence_generator(
+        enc_encoder,
+        enc_cell_type,
+        dec_cell_type,
+        dec_attention,
+        dec_beam_width,
+        csv_filename
+):
+    # Define input and output features
+    input_features = [
+        sequence_feature(
+            min_len=5,
+            max_len=10,
+            encoder='rnn',
+            cell_type='lstm',
+            reduce_output=None
+        )
+    ]
+    output_features = [
+        sequence_feature(
+            min_len=5,
+            max_len=10,
+            decoder='generator',
+            cell_type='lstm',
+            attention='bahdanau',
+            reduce_input=None
+        )
+    ]
+
+    # Generate test data
+    rel_path = generate_data(input_features, output_features, csv_filename)
+
+    # setup encoder specification
+    input_features[0]['encoder'] = enc_encoder
+    input_features[0]['cell_type'] = enc_cell_type
+
+    # setup decoder specification
+    output_features[0]['cell_type'] = dec_cell_type
+    output_features[0]['attention'] = dec_attention
+    output_features[0]['beam_width'] = dec_beam_width
+
+    # run the experiment
+    run_experiment(input_features, output_features, dataset=rel_path)

--- a/tests/integration_tests/test_sequence_features.py
+++ b/tests/integration_tests/test_sequence_features.py
@@ -58,23 +58,13 @@ def generate_sequence_training_data():
 
     return df, input_features, output_features
 
-@pytest.mark.parametrize('enc_cell_type', ['lstm', 'rnn', 'gru'])
-@pytest.mark.parametrize('enc_encoder', ENCODERS)
-def test_sequence_encoders(
-    enc_encoder,
-    enc_cell_type,
-    generate_sequence_training_data
+def setup_model_scaffolding(
+    raw_df,
+    input_features,
+    output_features
 ):
-    # retrieve pre-computed dataset and features
-    raw_df = generate_sequence_training_data[0]
-    input_features = generate_sequence_training_data[1]
-    output_features = generate_sequence_training_data[2]
-
-    input_feature_name = input_features[0]['name']
 
     # setup input feature for testing
-    input_features[0]['encoder'] = enc_encoder
-    input_features[0]['cell_type'] = enc_cell_type
     config = {'input_features': input_features,
               'output_features': output_features}
 
@@ -96,6 +86,32 @@ def test_sequence_encoders(
     batcher = initialize_batcher(
         training_set
     )
+
+    return model, batcher
+
+
+@pytest.mark.parametrize('enc_cell_type', ['lstm', 'rnn', 'gru'])
+@pytest.mark.parametrize('enc_encoder', ENCODERS)
+def test_sequence_encoders(
+    enc_encoder,
+    enc_cell_type,
+    generate_sequence_training_data
+):
+    # retrieve pre-computed dataset and features
+    raw_df = generate_sequence_training_data[0]
+    input_features = generate_sequence_training_data[1]
+    output_features = generate_sequence_training_data[2]
+    input_feature_name = input_features[0]['name']
+    input_features[0]['encoder'] = enc_encoder
+    input_features[0]['cell_type'] = enc_cell_type
+
+
+    model, batcher = setup_model_scaffolding(
+        raw_df,
+        input_features,
+        output_features
+    )
+
     while not batcher.last_batch():
         batch = batcher.next_batch()
         inputs = {

--- a/tests/integration_tests/test_sequence_features.py
+++ b/tests/integration_tests/test_sequence_features.py
@@ -1,0 +1,178 @@
+import copy
+from io import StringIO
+
+import pandas as pd
+import pytest
+
+import tensorflow as tf
+
+from ludwig.api import LudwigModel
+from ludwig.data.preprocessing import preprocess_for_training
+from ludwig.features.feature_registries import update_config_with_metadata
+from ludwig.utils.batcher import initialize_batcher
+from ludwig.data.dataset_synthesizer import build_synthetic_dataset
+from tests.integration_tests.utils import sequence_feature
+from tests.integration_tests.utils import ENCODERS
+
+DEFAULT_HIDDEN_SIZE = 8
+
+
+@pytest.fixture(scope='module')
+def generate_sequence_training_data():
+    input_features = [
+        sequence_feature(
+            min_len=5,
+            max_len=10,
+            encoder='rnn',
+            cell_type='lstm',
+            reduce_output=None
+        )
+        # {'name': 'in_sequence', 'type': 'sequence', 'min_len': 2,
+        #  'max_len': 10},
+    ]
+
+    output_features = [
+        sequence_feature(
+            min_len=5,
+            max_len=10,
+            decoder='generator',
+            cell_type='lstm',
+            attention='bahdanau',
+            reduce_input=None
+        )
+
+        # {'name': 'out_sequence', 'type': 'sequence', 'min_len': 3,
+        #  'max_len': 10}
+    ]
+
+    dataset = build_synthetic_dataset(
+        150,
+        copy.deepcopy(input_features) + copy.deepcopy(output_features)
+    )
+
+    raw_data = '\n'.join([r[0] + ',' + r[1] for r in dataset])
+    df = pd.read_csv(StringIO(raw_data))
+
+    return df, input_features, output_features
+
+@pytest.mark.parametrize('enc_cell_type', ['lstm', 'rnn', 'gru'])
+@pytest.mark.parametrize('enc_encoder', ENCODERS)
+def test_sequence_encoders(
+    enc_encoder,
+    enc_cell_type,
+    generate_sequence_training_data
+):
+    # retrieve pre-computed dataset and features
+    raw_df = generate_sequence_training_data[0]
+    input_features = generate_sequence_training_data[1]
+    output_features = generate_sequence_training_data[2]
+
+    input_feature_name = input_features[0]['name']
+
+    # setup input feature for testing
+    input_features[0]['encoder'] = enc_encoder
+    input_features[0]['cell_type'] = enc_cell_type
+    config = {'input_features': input_features,
+              'output_features': output_features}
+
+    # setup model scaffolding to test feature
+    model = LudwigModel(config)
+    training_set, _, _, training_set_metadata = preprocess_for_training(
+        config,
+        training_set=raw_df,
+        skip_save_processed_input=True
+    )
+    model.training_set_metadata = training_set_metadata
+    update_config_with_metadata(
+        model.config,
+        training_set_metadata
+    )
+    model.model = model.create_model(model.config)
+
+    # setup batcher to go through synthetic data
+    batcher = initialize_batcher(
+        training_set
+    )
+    while not batcher.last_batch():
+        batch = batcher.next_batch()
+        inputs = {
+            i_feat.feature_name: batch[i_feat.feature_name]
+            for i_feat in model.model.input_features.values()
+        }
+        # targets = {
+        #     o_feat.feature_name: batch[o_feat.feature_name]
+        #     for o_feat in model.model.output_features.values()
+        # }
+        # retrieve encoder to test
+        encoder = model.model.input_features[input_feature_name].encoder_obj
+        encoder_out = encoder(tf.cast(inputs[input_feature_name], dtype=tf.int32))
+
+        # check encoder output for proper content, type and shape
+        batch_size = batch[input_feature_name].shape[0]
+        seq_size = input_features[0]['max_len']
+
+        assert 'encoder_output' in encoder_out
+        assert isinstance(encoder_out['encoder_output'], tf.Tensor)
+
+        if enc_encoder == 'parallel_cnn':
+            number_parallel_cnn_layers = \
+                len(model.model.input_features[input_feature_name].encoder_obj.conv_layers)
+            hidden_size = input_features[0]['state_size'] * number_parallel_cnn_layers
+            assert encoder_out['encoder_output'].shape.as_list() == \
+                   [batch_size, seq_size, hidden_size]
+
+        elif enc_encoder == 'stacked_parallel_cnn':
+            number_parallel_cnn_layers = \
+                len(model.model.input_features[input_feature_name]\
+                    .encoder_obj.parallel_conv1d_stack\
+                    .stacked_parallel_layers[0])
+            hidden_size = input_features[0]['state_size'] * number_parallel_cnn_layers
+            assert encoder_out['encoder_output'].shape.as_list() == \
+                   [batch_size, seq_size, hidden_size]
+
+        elif enc_encoder == 'rnn':
+            assert encoder_out['encoder_output'].shape.as_list() == \
+                   [batch_size, seq_size, DEFAULT_HIDDEN_SIZE]
+
+            assert 'encoder_output_state' in encoder_out
+            if enc_cell_type == 'lstm':
+                assert isinstance(encoder_out['encoder_output_state'], list)
+                assert encoder_out['encoder_output_state'][0].shape.as_list() == \
+                       [batch_size, DEFAULT_HIDDEN_SIZE]
+                assert encoder_out['encoder_output_state'][1].shape.as_list() == \
+                       [batch_size, DEFAULT_HIDDEN_SIZE]
+            else:
+                assert isinstance(encoder_out['encoder_output_state'], tf.Tensor)
+                assert encoder_out['encoder_output_state'].shape.as_list() == \
+                       [batch_size, DEFAULT_HIDDEN_SIZE]
+
+        elif enc_encoder == 'cnnrnn':
+            assert encoder_out['encoder_output'].shape.as_list() == \
+                   [batch_size, 1, DEFAULT_HIDDEN_SIZE]
+            assert 'encoder_output_state' in encoder_out
+            if enc_cell_type == 'lstm':
+                assert isinstance(encoder_out['encoder_output_state'], list)
+                assert encoder_out['encoder_output_state'][0].shape.as_list() == \
+                       [batch_size, DEFAULT_HIDDEN_SIZE]
+                assert encoder_out['encoder_output_state'][1].shape.as_list() == \
+                       [batch_size, DEFAULT_HIDDEN_SIZE]
+            else:
+                assert isinstance(encoder_out['encoder_output_state'], tf.Tensor)
+                assert encoder_out['encoder_output_state'].shape.as_list() == \
+                       [batch_size, DEFAULT_HIDDEN_SIZE]
+
+        elif enc_encoder == 'stacked_cnn':
+            assert encoder_out['encoder_output'].shape.as_list() == \
+                   [batch_size, 1, DEFAULT_HIDDEN_SIZE]
+
+        elif enc_encoder == 'transformer':
+            assert encoder_out['encoder_output'].shape.as_list() == \
+                   [batch_size, seq_size, 256]
+
+        elif enc_encoder == 'embed':
+            assert encoder_out['encoder_output'].shape.as_list() == \
+                   [batch_size, seq_size, DEFAULT_HIDDEN_SIZE]
+
+        else:
+            raise ValueError('{} is an invalid encoder specification'\
+                             .format(enc_encoder))

--- a/tests/integration_tests/test_sequence_features.py
+++ b/tests/integration_tests/test_sequence_features.py
@@ -16,10 +16,16 @@ from tests.integration_tests.utils import ENCODERS
 from tests.integration_tests.utils import generate_data
 from tests.integration_tests.utils import run_experiment
 
+#
+# this test is focused on testing input sequence features with all encoders
+# and output sequence feature with Generator decoder.  Except for specified
+# configuration parameters all other parameters assume default values.
+#
 
-DEFAULT_HIDDEN_SIZE = 8
+TEST_HIDDEN_SIZE = 8
 
 # generates dataset that can be used for rest of test
+# Note: sequence_feature function specifies hidden size to be 8
 @pytest.fixture(scope='module')
 def generate_sequence_training_data():
     input_features = [
@@ -149,39 +155,39 @@ def test_sequence_encoders(
 
         elif enc_encoder == 'rnn':
             assert encoder_out['encoder_output'].shape.as_list() == \
-                   [batch_size, seq_size, DEFAULT_HIDDEN_SIZE]
+                   [batch_size, seq_size, TEST_HIDDEN_SIZE]
 
             assert 'encoder_output_state' in encoder_out
             if enc_cell_type == 'lstm':
                 assert isinstance(encoder_out['encoder_output_state'], list)
                 assert encoder_out['encoder_output_state'][0].shape.as_list() == \
-                       [batch_size, DEFAULT_HIDDEN_SIZE]
+                       [batch_size, TEST_HIDDEN_SIZE]
                 assert encoder_out['encoder_output_state'][1].shape.as_list() == \
-                       [batch_size, DEFAULT_HIDDEN_SIZE]
+                       [batch_size, TEST_HIDDEN_SIZE]
             else:
                 assert isinstance(encoder_out['encoder_output_state'], tf.Tensor)
                 assert encoder_out['encoder_output_state'].shape.as_list() == \
-                       [batch_size, DEFAULT_HIDDEN_SIZE]
+                       [batch_size, TEST_HIDDEN_SIZE]
 
         elif enc_encoder == 'cnnrnn':
             assert encoder_out['encoder_output'].shape.as_list() == \
-                   [batch_size, 1, DEFAULT_HIDDEN_SIZE]
+                   [batch_size, 1, TEST_HIDDEN_SIZE]
             assert 'encoder_output_state' in encoder_out
 
             if enc_cell_type == 'lstm':
                 assert isinstance(encoder_out['encoder_output_state'], list)
                 assert encoder_out['encoder_output_state'][0].shape.as_list() \
-                       == [batch_size, DEFAULT_HIDDEN_SIZE]
+                       == [batch_size, TEST_HIDDEN_SIZE]
                 assert encoder_out['encoder_output_state'][1].shape.as_list() \
-                       == [batch_size, DEFAULT_HIDDEN_SIZE]
+                       == [batch_size, TEST_HIDDEN_SIZE]
             else:
                 assert isinstance(encoder_out['encoder_output_state'], tf.Tensor)
                 assert encoder_out['encoder_output_state'].shape.as_list() \
-                       == [batch_size, DEFAULT_HIDDEN_SIZE]
+                       == [batch_size, TEST_HIDDEN_SIZE]
 
         elif enc_encoder == 'stacked_cnn':
             assert encoder_out['encoder_output'].shape.as_list() \
-                   == [batch_size, 1, DEFAULT_HIDDEN_SIZE]
+                   == [batch_size, 1, TEST_HIDDEN_SIZE]
 
         elif enc_encoder == 'transformer':
             assert encoder_out['encoder_output'].shape.as_list() \
@@ -189,7 +195,7 @@ def test_sequence_encoders(
 
         elif enc_encoder == 'embed':
             assert encoder_out['encoder_output'].shape.as_list() \
-                   == [batch_size, seq_size, DEFAULT_HIDDEN_SIZE]
+                   == [batch_size, seq_size, TEST_HIDDEN_SIZE]
 
         else:
             raise ValueError('{} is an invalid encoder specification'\

--- a/tests/integration_tests/test_sequence_features.py
+++ b/tests/integration_tests/test_sequence_features.py
@@ -191,7 +191,7 @@ def test_sequence_encoders(
 
         elif enc_encoder == 'transformer':
             assert encoder_out['encoder_output'].shape.as_list() \
-                   == [batch_size, seq_size, 256]
+                   == [batch_size, seq_size, TEST_HIDDEN_SIZE]
 
         elif enc_encoder == 'embed':
             assert encoder_out['encoder_output'].shape.as_list() \

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -305,7 +305,12 @@ def vector_feature(**kwargs):
     return feature
 
 
-def run_experiment(input_features, output_features, **kwargs):
+def run_experiment(
+    input_features,
+    output_features,
+    skip_save_processed_input=True,
+    **kwargs
+):
     """
     Helper method to avoid code repetition in running an experiment. Deletes
     the data saved to disk after running the experiment
@@ -333,7 +338,7 @@ def run_experiment(input_features, output_features, **kwargs):
         'config': config,
         'skip_save_training_description': True,
         'skip_save_training_statistics': True,
-        'skip_save_processed_input': True,
+        'skip_save_processed_input': skip_save_processed_input,
         'skip_save_progress': True,
         'skip_save_unprocessed_output': True,
         'skip_save_model': True,

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -178,7 +178,8 @@ def sequence_feature(**kwargs):
         'embedding_size': 8,
         'fc_size': 8,
         'state_size': 8,
-        'num_filters': 8
+        'num_filters': 8,
+        'hidden_size': 8
     }
     seq_feature.update(kwargs)
     return seq_feature


### PR DESCRIPTION
# Code Pull Requests

Summary of changes:
* Add Sequence encoder test that confirm correctness of generated output
* Add Generator decoder test that confirm correctness of generated output
* Reduce parameter combinations when generating test cases for Sequence Encoder/Sequence Generator decoder that execute `experiment_cli()`

Before and after results on testing this PR locally:

|Metrics For Entire Test Suite|Before PR|After PR|
|-----------|:-----------:|:------------:|
|Generated Tests|895|718|
|Elapsed Time (mm:ss)|33:15|27:38|
|Overall Test Coverage|81%|81%|

Note:

* Horvord test (`test_horovod.py`) fails because there is no local Horovod setup
* After the change one of the graph execution test fails (`test_graph_exection.py::test_sequence_generator`). The error occurs in the TFA `dynamic_decode` function.  The stack trace indicates the issue is around use of TFA custom ops.  Still investigating this failure.

Here is consolidate log file from testing the PR.
[_pytest_entire_tests_after_test_sequence_generator_change.txt](https://github.com/uber/ludwig/files/5398324/_pytest_entire_tests_after_test_sequence_generator_change.txt)

