### PR TITLE
Convert materialized tensors to numpy arrays up front to avoid repeated conversion

### DIFF
--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -290,7 +290,7 @@ class BinaryOutputFeature(BinaryFeatureMixin, OutputFeature):
             if not skip_save_unprocessed_output:
                 np.save(
                     npy_filename.format(name, PREDICTIONS),
-                    result[PREDICTIONS]
+                    postprocessed[PREDICTIONS]
                 )
             del result[PREDICTIONS]
 
@@ -299,7 +299,7 @@ class BinaryOutputFeature(BinaryFeatureMixin, OutputFeature):
             if not skip_save_unprocessed_output:
                 np.save(
                     npy_filename.format(name, PROBABILITIES),
-                    result[PROBABILITIES]
+                    postprocessed[PROBABILITIES]
                 )
             del result[PROBABILITIES]
 

--- a/ludwig/features/sequence_feature.py
+++ b/ludwig/features/sequence_feature.py
@@ -406,7 +406,7 @@ class SequenceOutputFeature(SequenceFeatureMixin, OutputFeature):
             skip_save_unprocessed_output = True
 
         if PREDICTIONS in result and len(result[PREDICTIONS]) > 0:
-            preds = result[PREDICTIONS]
+            preds = result[PREDICTIONS].numpy()
             lengths = result[LENGTHS]
             if 'idx2str' in metadata:
                 postprocessed[PREDICTIONS] = [
@@ -425,7 +425,7 @@ class SequenceOutputFeature(SequenceFeatureMixin, OutputFeature):
             del result[PREDICTIONS]
 
         if LAST_PREDICTIONS in result and len(result[LAST_PREDICTIONS]) > 0:
-            last_preds = result[LAST_PREDICTIONS]
+            last_preds = result[LAST_PREDICTIONS].numpy()
             if 'idx2str' in metadata:
                 postprocessed[LAST_PREDICTIONS] = [
                     metadata['idx2str'][last_pred]

--- a/ludwig/features/set_feature.py
+++ b/ludwig/features/set_feature.py
@@ -252,7 +252,7 @@ class SetOutputFeature(SetFeatureMixin, OutputFeature):
             skip_save_unprocessed_output = True
 
         if PREDICTIONS in result and len(result[PREDICTIONS]) > 0:
-            preds = result[PREDICTIONS]
+            preds = result[PREDICTIONS].numpy()
             if 'idx2str' in metadata:
                 postprocessed[PREDICTIONS] = [
                     [metadata['idx2str'][i] for i, pred in enumerate(pred_set)

--- a/ludwig/features/text_feature.py
+++ b/ludwig/features/text_feature.py
@@ -433,7 +433,7 @@ class TextOutputFeature(TextFeatureMixin, SequenceOutputFeature):
             skip_save_unprocessed_output = True
 
         if PREDICTIONS in result and len(result[PREDICTIONS]) > 0:
-            preds = result[PREDICTIONS]
+            preds = result[PREDICTIONS].numpy()
             if level_idx2str in metadata:
                 postprocessed[PREDICTIONS] = [
                     [metadata[level_idx2str][token]
@@ -451,7 +451,7 @@ class TextOutputFeature(TextFeatureMixin, SequenceOutputFeature):
             del result[PREDICTIONS]
 
         if LAST_PREDICTIONS in result and len(result[LAST_PREDICTIONS]) > 0:
-            last_preds = result[LAST_PREDICTIONS]
+            last_preds = result[LAST_PREDICTIONS].numpy()
             if level_idx2str in metadata:
                 postprocessed[LAST_PREDICTIONS] = [
                     metadata[level_idx2str][last_pred]

--- a/ludwig/features/vector_feature.py
+++ b/ludwig/features/vector_feature.py
@@ -260,7 +260,7 @@ class VectorOutputFeature(VectorFeatureMixin, OutputFeature):
             if not skip_save_unprocessed_output:
                 np.save(
                     npy_filename.format(name, PREDICTIONS),
-                    result[PREDICTIONS]
+                    postprocessed[PREDICTIONS]
                 )
             del result[PREDICTIONS]
 


### PR DESCRIPTION
Fixes #963.