### PR TITLE
Reimplement Jaccard Metric for the Set Feature

### DIFF
--- a/ludwig/features/set_feature.py
+++ b/ludwig/features/set_feature.py
@@ -29,6 +29,7 @@ from ludwig.features.base_feature import OutputFeature
 from ludwig.features.feature_utils import set_str_to_idx
 from ludwig.modules.loss_modules import SigmoidCrossEntropyLoss
 from ludwig.modules.metric_modules import SigmoidCrossEntropyMetric
+from ludwig.modules.metric_modules import JaccardMetric
 from ludwig.utils.horovod_utils import is_on_master
 from ludwig.utils.misc_utils import set_default_value
 from ludwig.utils.strings_utils import create_vocabulary, UNKNOWN_SYMBOL
@@ -208,7 +209,7 @@ class SetOutputFeature(SetFeatureMixin, OutputFeature):
     def _setup_metrics(self):
         self.metric_functions = {}  # needed to shadow class variable
         self.metric_functions[LOSS] = self.eval_loss_function
-        self.metric_functions[JACCARD] = MeanIoU(num_classes=self.num_classes)
+        self.metric_functions[JACCARD] = JaccardMetric()
 
     def get_output_dtype(self):
         return tf.bool

--- a/ludwig/modules/metric_modules.py
+++ b/ludwig/modules/metric_modules.py
@@ -334,6 +334,46 @@ class MSEMetric(MeanSquaredErrorMetric):
         )
 
 
+class JaccardMetric(tf.keras.metrics.Metric):
+    def __init__(self, name=None):
+        super(JaccardMetric, self).__init__(name=name)
+        self.jaccard_total = self.add_weight(
+            'jaccard_numerator', initializer='zeros', dtype=tf.float32
+        )
+        self.N = self.add_weight(
+            'jaccard_denomerator', initializer='zeros', dtype=tf.float32
+        )
+
+    def update_state(self, y_true, y_pred):
+        # notation: b is batch size and nc is number of unique elements
+        #           in the set
+        # y_true: shape [b, nc] bit-mapped set representation
+        # y_pred: shape [b, nc] bit-mapped set representation
+
+        batch_size = tf.cast(tf.shape(y_true)[0], tf.float32)
+
+        y_true_bool = tf.cast(y_true, tf.bool)
+        y_pred_bool = tf.cast(y_pred, tf.bool)
+
+        intersection = tf.reduce_sum(
+            tf.cast(tf.logical_and(y_true_bool, y_pred_bool), tf.float32),
+            axis=1
+        )
+        union = tf.reduce_sum(
+            tf.cast(tf.logical_or(y_true_bool, y_pred_bool), tf.float32),
+            axis=1
+        )
+
+        jaccard_index = intersection / union  #shape [b]
+
+        # update metric state tensors
+        self.jaccard_total.assign_add(tf.reduce_sum(jaccard_index))
+        self.N.assign_add(batch_size)
+
+    def result(self):
+        return self.jaccard_total / self.N
+
+
 def get_improved_fun(metric):
     if metric in min_metrics:
         return lambda x, y: x < y


### PR DESCRIPTION
# Code Pull Requests

Fix Issue #973 

This PR adds
* custom metric `JaccardMetric` class and converted set output feature to use this custom metric
* add unit test for the new custom metric class

```
root@d011aea229e1:/opt/project/sandbox/pytest_area# pytest -v /opt/project/tests/integration_tests/test_custom_metrics.py
=========================================================== test session starts ============================================================
platform linux -- Python 3.6.9, pytest-6.1.1, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /opt/project
plugins: forked-1.3.0, cov-2.10.1, pycharm-0.7.0, xdist-2.1.0, typeguard-2.9.1
collected 3 items

../../tests/integration_tests/test_custom_metrics.py::test_R2Score PASSED                                                            [ 33%]
../../tests/integration_tests/test_custom_metrics.py::test_ErrorScore PASSED                                                         [ 66%]
../../tests/integration_tests/test_custom_metrics.py::test_JaccardMetric PASSED                                                      [100%]

============================================================= warnings summary =============================================================
../../../../usr/local/lib/python3.6/dist-packages/tensorflow/python/pywrap_tensorflow_internal.py:15
  /usr/local/lib/python3.6/dist-packages/tensorflow/python/pywrap_tensorflow_internal.py:15: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    import imp

-- Docs: https://docs.pytest.org/en/stable/warnings.html
======================================================= 3 passed, 1 warning in 0.13s =======================================================
```

