### PR TITLE
Limit numpy\h5py max versions due to tensorflow 2.3.1 max supported versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 Cython>=0.25
 h5py>=2.6,<2.11.0
-numpy>=1.15,<1.19.0
+numpy>=1.15 ; sys_platform != "Windows"
+numpy>=1.15,<1.19.0 ; sys_platform == "Windows"
 pandas>=0.19
 scipy>=0.18
 tabulate>=0.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Cython>=0.25
-h5py>=2.6,<2.11.0
+h5py>=2.6 ; sys_platform != "Windows"
+h5py>=2.6,<2.11.0 ; sys_platform == "Windows"
 numpy>=1.15 ; sys_platform != "Windows"
 numpy>=1.15,<1.19.0 ; sys_platform == "Windows"
 pandas>=0.19

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Cython>=0.25
-h5py>=2.6
-numpy>=1.15,<=1.19.3
+h5py>=2.6,<2.11.0
+numpy>=1.15,<1.19.0
 pandas>=0.19
 scipy>=0.18
 tabulate>=0.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Cython>=0.25
 h5py>=2.6
-numpy>=1.15
+numpy>=1.15,<=1.19.3
 pandas>=0.19
 scipy>=0.18
 tabulate>=0.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
 Cython>=0.25
-h5py>=2.6 ; sys_platform != "Windows"
-h5py>=2.6,<2.11.0 ; sys_platform == "Windows"
-numpy>=1.15 ; sys_platform != "Windows"
-numpy>=1.15,<1.19.0 ; sys_platform == "Windows"
+h5py>=2.6,<2.11.0
+numpy>=1.15,<1.19.0
 pandas>=0.19
 scipy>=0.18
 tabulate>=0.7

--- a/requirements_serve.txt
+++ b/requirements_serve.txt
@@ -2,4 +2,4 @@ uvicorn
 fastapi
 pydantic
 python-multipart
-neuropod
+neuropod ; sys_platform != "Windows"

--- a/requirements_serve.txt
+++ b/requirements_serve.txt
@@ -2,4 +2,4 @@ uvicorn
 fastapi
 pydantic
 python-multipart
-neuropod ; sys_platform != "Windows"
+neuropod ; platform_system != "Windows"


### PR DESCRIPTION
Numpy 1.19.4 has an issue on windows which prevents it from running correctly (numpy package refers to this URL https://tinyurl.com/y3dm3h86).
I just tested with 1.19.3 and the issue is not present yet