### PR TITLE
feat: Add `pretrained_tokenizer_fast` configuration for HFTokenizer

### DIFF
--- a/ludwig/features/text_feature.py
+++ b/ludwig/features/text_feature.py
@@ -46,6 +46,7 @@ class TextFeatureMixin(object):
         'char_most_common': 70,
         'word_tokenizer': 'space_punct',
         'pretrained_model_name_or_path': None,
+        'pretrained_tokenizer_fast': False,
         'word_vocab_file': None,
         'word_sequence_length_limit': 256,
         'word_most_common': 20000,
@@ -94,7 +95,9 @@ class TextFeatureMixin(object):
             unknown_symbol=preprocessing_parameters['unknown_symbol'],
             padding_symbol=preprocessing_parameters['padding_symbol'],
             pretrained_model_name_or_path=preprocessing_parameters[
-                'pretrained_model_name_or_path']
+                'pretrained_model_name_or_path'],
+            pretrained_tokenizer_fast=preprocessing_parameters[
+                'pretrained_tokenizer_fast']
         )
         return (
             char_idx2str,

--- a/ludwig/utils/strings_utils.py
+++ b/ludwig/utils/strings_utils.py
@@ -96,7 +96,8 @@ def create_vocabulary(
         vocab_file=None,
         unknown_symbol=UNKNOWN_SYMBOL,
         padding_symbol=PADDING_SYMBOL,
-        pretrained_model_name_or_path=None
+        pretrained_model_name_or_path=None,
+        pretrained_tokenizer_fast=False,
 ):
     vocab = None
     max_line_length = 0
@@ -108,6 +109,7 @@ def create_vocabulary(
     )(
         vocab_file=vocab_file,
         pretrained_model_name_or_path=pretrained_model_name_or_path,
+        pretrained_tokenizer_fast=pretrained_tokenizer_fast,
     )
 
     if tokenizer_type == 'hf_tokenizer':
@@ -1157,6 +1159,7 @@ class MultiLemmatizeRemoveStopwordsTokenizer(BaseTokenizer):
 class HFTokenizer(BaseTokenizer):
     def __init__(self,
                  pretrained_model_name_or_path,
+                 pretrained_tokenizer_fast=False,
                  **kwargs
                  ):
         super().__init__()
@@ -1164,6 +1167,7 @@ class HFTokenizer(BaseTokenizer):
 
         self.tokenizer = AutoTokenizer.from_pretrained(
             pretrained_model_name_or_path,
+            use_fast=pretrained_tokenizer_fast
         )
 
     def __call__(self, text):

--- a/requirements_text.txt
+++ b/requirements_text.txt
@@ -1,2 +1,3 @@
 spacy>=2.3
 transformers
+tokenizers


### PR DESCRIPTION
##  Description

Please provide the following:
- As per [discussion](https://github.com/uber/ludwig/issues/648#issuecomment-729239220) suggested adding support for the `use_fast` argument passed to the Hugging Face [AutoTokenizer](https://huggingface.co/transformers/model_doc/auto.html#transformers.AutoTokenizer)

```python
   self.tokenizer = AutoTokenizer.from_pretrained(
        pretrained_model_name_or_path, use_fast=True
    )
```

Validated that I was able to pass the following argument to `create_vocabulary`

```python
>>> from ludwig.utils.strings_utils import create_vocabulary
>>> create_vocabulary('abc',tokenizer_type='hf_tokenizer',
pretrained_model_name_or_path='/opt/ml/code/transformer',
pretrained_tokenizer_fast=True)
```
I tested with pulling my fork to pip install ludwig, and train a model with the following config.yml

```yaml
input_features:
    -   name: review_body
        type: text
        level: word
        encoder: bert
        preprocessing:
            pretrained_tokenizer_fast: true
        pretrained_model_name_or_path: /opt/ml/code/transformer
output_features:
    -   name: star_rating
        type: category
```

## Docs

I am not clear on how to update the `docs`.  The update would be to the following page:
https://ludwig-ai.github.io/ludwig-docs/user_guide/#text-features-preprocessing

  * pretrained_tokenizer_fast (default false): if the string has to be lowercased before being handled by the tokenizer.
