### PR TITLE
[WIP] Added schema validation to config files

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -66,6 +66,7 @@ from ludwig.utils.misc_utils import (get_experiment_description,
                                      get_file_names, get_from_registry,
                                      get_output_directory)
 from ludwig.utils.print_utils import print_boxed
+from ludwig.utils.schema import validate_config
 from ludwig.utils.tf_utils import initialize_tensorflow
 
 logger = logging.getLogger(__name__)
@@ -184,6 +185,7 @@ class LudwigModel:
 
         # merge config with defaults
         self.config = merge_with_defaults(config_dict)
+        validate_config(self.config)
 
         # setup horovod
         self._horovod = configure_horovod(use_horovod)

--- a/ludwig/constants.py
+++ b/ludwig/constants.py
@@ -32,9 +32,7 @@ H3 = 'h3'
 VECTOR = 'vector'
 HEIGHT = 'height'
 WIDTH = 'width'
-CROP_OR_PAD = 'crop_or_pad'
 NUM_CHANNELS = 'num_channels'
-INTERPOLATE = 'interpolate'
 LOSS = 'loss'
 EVAL_LOSS = 'eval_loss'
 TRAIN_MEAN_LOSS = 'train_mean_loss'
@@ -71,7 +69,18 @@ FILL_WITH_CONST = 'fill_with_const'
 FILL_WITH_MODE = 'fill_with_mode'
 FILL_WITH_MEAN = 'fill_with_mean'
 BACKFILL = 'backfill'
+BFILL = 'bfill'
+PAD = 'pad'
+FFILL = 'ffill'
 DROP_ROW = 'drop_row'
+MISSING_VALUE_STRATEGY_OPTIONS = [
+    FILL_WITH_CONST, FILL_WITH_MODE, FILL_WITH_MEAN,
+    BACKFILL, BFILL, PAD, FFILL, DROP_ROW
+]
+
+CROP_OR_PAD = 'crop_or_pad'
+INTERPOLATE = 'interpolate'
+RESIZE_METHODS = [CROP_OR_PAD, INTERPOLATE]
 
 METRIC = 'metric'
 PREDICTION = 'prediction'

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -1079,7 +1079,7 @@ def handle_missing_values(dataset_df, feature, preprocessing_parameters):
         dataset_df[feature[COLUMN]] = dataset_df[feature[COLUMN]].fillna(
             computed_fill_value,
         )
-    elif missing_value_strategy in ['backfill', 'bfill', 'pad', 'ffill']:
+    elif missing_value_strategy in [BACKFILL, BFILL, PAD, FFILL]:
         dataset_df[feature[COLUMN]] = dataset_df[feature[COLUMN]].fillna(
             method=missing_value_strategy,
         )

--- a/ludwig/features/audio_feature.py
+++ b/ludwig/features/audio_feature.py
@@ -21,8 +21,7 @@ import sys
 import numpy as np
 import tensorflow as tf
 
-from ludwig.constants import AUDIO, BACKFILL, TIED, TYPE, COLUMN, PROC_COLUMN, \
-    PREPROCESSING, NAME
+from ludwig.constants import *
 from ludwig.encoders.sequence_encoders import StackedCNN, ParallelCNN, \
     StackedParallelCNN, StackedRNN, SequencePassthroughEncoder, StackedCNNRNN
 from ludwig.features.sequence_feature import SequenceInputFeature
@@ -53,6 +52,25 @@ class AudioFeatureMixin(object):
         'norm': None,
         'audio_feature': {
             TYPE: 'raw',
+        }
+    }
+
+    preprocessing_schema = {
+        'audio_file_length_limit_in_s': {'type': 'number', 'minimum': 0},
+        'missing_value_strategy': {'enum': MISSING_VALUE_STRATEGY_OPTIONS},
+        'in_memory': {'type': 'boolean'},
+        'padding_value': {'type': 'number', 'minimum': 0},
+        'norm': {'enum': [None, 'per_file', 'global']},
+        'audio_feature': {
+            'type': 'object',
+            'properties': {
+                'type': {'enum': ['raw', 'stft', 'stft_phase', 'group_delay', 'fbank']},
+                'window_length_in_s': {'type': 'number', 'minimum': 0},
+                'window_shift_in_s': {'type': 'number', 'minimum': 0},
+                'num_fft_points': {'type': 'number', 'minimum': 0},
+                'window_type': {'type': 'string'},
+                'num_filter_bands': {'type': 'number', 'minimum': 0},
+            }
         }
     }
 

--- a/ludwig/features/audio_feature.py
+++ b/ludwig/features/audio_feature.py
@@ -57,14 +57,14 @@ class AudioFeatureMixin(object):
 
     preprocessing_schema = {
         'audio_file_length_limit_in_s': {'type': 'number', 'minimum': 0},
-        'missing_value_strategy': {'enum': MISSING_VALUE_STRATEGY_OPTIONS},
+        'missing_value_strategy': {'type': 'string', 'enum': MISSING_VALUE_STRATEGY_OPTIONS},
         'in_memory': {'type': 'boolean'},
         'padding_value': {'type': 'number', 'minimum': 0},
-        'norm': {'enum': [None, 'per_file', 'global']},
+        'norm': {'type': 'string', 'enum': [None, 'per_file', 'global']},
         'audio_feature': {
             'type': 'object',
             'properties': {
-                'type': {'enum': ['raw', 'stft', 'stft_phase', 'group_delay', 'fbank']},
+                'type': {'type': 'string', 'enum': ['raw', 'stft', 'stft_phase', 'group_delay', 'fbank']},
                 'window_length_in_s': {'type': 'number', 'minimum': 0},
                 'window_shift_in_s': {'type': 'number', 'minimum': 0},
                 'num_fft_points': {'type': 'number', 'minimum': 0},

--- a/ludwig/features/bag_feature.py
+++ b/ludwig/features/bag_feature.py
@@ -25,7 +25,7 @@ from ludwig.encoders.bag_encoders import BagEmbedWeightedEncoder
 from ludwig.features.base_feature import InputFeature
 from ludwig.features.feature_utils import set_str_to_idx
 from ludwig.utils.misc_utils import set_default_value
-from ludwig.utils.strings_utils import create_vocabulary, UNKNOWN_SYMBOL
+from ludwig.utils.strings_utils import create_vocabulary, tokenizer_registry, UNKNOWN_SYMBOL
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +39,14 @@ class BagFeatureMixin(object):
         'lowercase': False,
         'missing_value_strategy': FILL_WITH_CONST,
         'fill_value': UNKNOWN_SYMBOL
+    }
+
+    preprocessing_schema = {
+        'tokenizer': {'type': 'string', 'enum': sorted(list(tokenizer_registry.keys()))},
+        'most_common': {'type': 'integer', 'minimum': 0},
+        'lowercase': {'type': 'boolean'},
+        'missing_value_strategy': {'type': 'string', 'enum': MISSING_VALUE_STRATEGY_OPTIONS},
+        'fill_value': {'type': 'string'},
     }
 
     @staticmethod

--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -49,6 +49,11 @@ class BinaryFeatureMixin(object):
         'fill_value': 0
     }
 
+    preprocessing_schema = {
+        'missing_value_strategy': {'type': 'string', 'enum': MISSING_VALUE_STRATEGY_OPTIONS},
+        'fill_value': {'type': 'integer'},
+    }
+
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters):
         return {}

--- a/ludwig/features/category_feature.py
+++ b/ludwig/features/category_feature.py
@@ -53,6 +53,13 @@ class CategoryFeatureMixin(object):
         'fill_value': UNKNOWN_SYMBOL
     }
 
+    preprocessing_schema = {
+        'most_common': {'type': 'integer', 'minimum': 0},
+        'lowercase': {'type': 'boolean'},
+        'missing_value_strategy': {'type': 'string', 'enum': MISSING_VALUE_STRATEGY_OPTIONS},
+        'fill_value': {'type': 'string'},
+    }
+
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters):
         idx2str, str2idx, str2freq, _, _, _, _ = create_vocabulary(

--- a/ludwig/features/date_feature.py
+++ b/ludwig/features/date_feature.py
@@ -40,6 +40,12 @@ class DateFeatureMixin(object):
         'datetime_format': None
     }
 
+    preprocessing_schema = {
+        'missing_value_strategy': {'type': 'string', 'enum': MISSING_VALUE_STRATEGY_OPTIONS},
+        'fill_value': {'type': 'string'},
+        'datetime_format': {'type': 'string'},
+    }
+
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters):
         return {

--- a/ludwig/features/h3_feature.py
+++ b/ludwig/features/h3_feature.py
@@ -40,6 +40,11 @@ class H3FeatureMixin(object):
         # mode 1 edge 0 resolution 0 base_cell 0
     }
 
+    preprocessing_schema = {
+        'missing_value_strategy': {'type': 'string', 'enum': MISSING_VALUE_STRATEGY_OPTIONS},
+        'fill_value': {'type': 'integer'},
+    }
+
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters):
         return {}

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -58,7 +58,10 @@ class ImageFeatureMixin(object):
         'in_memory': {'type': 'boolean'},
         'resize_method': {'enum': RESIZE_METHODS},
         'scaling': {'enum': list(image_scaling_registry.keys())},
-        'num_processes': {'type': 'integer', 'minimum': 0}
+        'num_processes': {'type': 'integer', 'minimum': 0},
+        'height': {'type': 'integer', 'minimum': 0},
+        'width': {'type': 'integer', 'minimum': 0},
+        'num_channels': {'type': 'integer', 'minimum': 0},
     }
 
     @staticmethod

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -54,10 +54,10 @@ class ImageFeatureMixin(object):
     }
 
     preprocessing_schema = {
-        'missing_value_strategy': {'enum': MISSING_VALUE_STRATEGY_OPTIONS},
+        'missing_value_strategy': {'type': 'string', 'enum': MISSING_VALUE_STRATEGY_OPTIONS},
         'in_memory': {'type': 'boolean'},
-        'resize_method': {'enum': RESIZE_METHODS},
-        'scaling': {'enum': list(image_scaling_registry.keys())},
+        'resize_method': {'type': 'string', 'enum': RESIZE_METHODS},
+        'scaling': {'type': 'string', 'enum': list(image_scaling_registry.keys())},
         'num_processes': {'type': 'integer', 'minimum': 0},
         'height': {'type': 'integer', 'minimum': 0},
         'width': {'type': 'integer', 'minimum': 0},

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -36,6 +36,13 @@ from ludwig.utils.misc_utils import set_default_value
 logger = logging.getLogger(__name__)
 
 
+image_scaling_registry = {
+    'pixel_normalization': lambda x: x * 1.0 / 255,
+    'pixel_standardization': lambda x: tf.map_fn(
+        lambda f: tf.image.per_image_standardization(f), x)
+}
+
+
 class ImageFeatureMixin(object):
     type = IMAGE
     preprocessing_defaults = {
@@ -44,6 +51,14 @@ class ImageFeatureMixin(object):
         'resize_method': 'interpolate',
         'scaling': 'pixel_normalization',
         'num_processes': 1
+    }
+
+    preprocessing_schema = {
+        'missing_value_strategy': {'enum': MISSING_VALUE_STRATEGY_OPTIONS},
+        'in_memory': {'type': 'boolean'},
+        'resize_method': {'enum': RESIZE_METHODS},
+        'scaling': {'enum': list(image_scaling_registry.keys())},
+        'num_processes': {'type': 'integer', 'minimum': 0}
     }
 
     @staticmethod
@@ -389,10 +404,3 @@ class ImageInputFeature(ImageFeatureMixin, InputFeature):
         'resnet': ResNetEncoder,
         None: Stacked2DCNN
     }
-
-
-image_scaling_registry = {
-    'pixel_normalization': lambda x: x * 1.0 / 255,
-    'pixel_standardization': lambda x: tf.map_fn(
-        lambda f: tf.image.per_image_standardization(f), x)
-}

--- a/ludwig/features/numerical_feature.py
+++ b/ludwig/features/numerical_feature.py
@@ -47,6 +47,12 @@ class NumericalFeatureMixin(object):
         'normalization': None
     }
 
+    preprocessing_schema = {
+        'missing_value_strategy': {'type': 'string', 'enum': MISSING_VALUE_STRATEGY_OPTIONS},
+        'fill_value': {'type': 'string'},
+        'normalization': {'type': 'string', 'enum': [None, 'zscore', 'minmax']},
+    }
+
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters):
         if preprocessing_parameters['normalization'] is not None:

--- a/ludwig/features/sequence_feature.py
+++ b/ludwig/features/sequence_feature.py
@@ -47,6 +47,7 @@ from ludwig.utils.strings_utils import PADDING_SYMBOL
 from ludwig.utils.strings_utils import UNKNOWN_SYMBOL
 from ludwig.utils.strings_utils import build_sequence_matrix
 from ludwig.utils.strings_utils import create_vocabulary
+from ludwig.utils.strings_utils import tokenizer_registry
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +66,18 @@ class SequenceFeatureMixin(object):
         'vocab_file': None,
         'missing_value_strategy': FILL_WITH_CONST,
         'fill_value': UNKNOWN_SYMBOL
+    }
+
+    preprocessing_schema = {
+        'sequence_length_limit': {'type': 'integer', 'minimum': 0},
+        'most_common': {'type': 'integer', 'minimum': 0},
+        'padding_symbol': {'type': 'string'},
+        'unknown_symbol': {'type': 'string'},
+        'padding': {'type': 'string', 'enum': ['right', 'left']},
+        'tokenizer': {'type': 'string', 'enum': sorted(list(tokenizer_registry.keys()))},
+        'lowercase': {'type': 'boolean'},
+        'missing_value_strategy': {'type': 'string', 'enum': MISSING_VALUE_STRATEGY_OPTIONS},
+        'fill_value': {'type': 'string'},
     }
 
     @staticmethod

--- a/ludwig/features/set_feature.py
+++ b/ludwig/features/set_feature.py
@@ -31,7 +31,7 @@ from ludwig.modules.metric_modules import JaccardMetric
 from ludwig.modules.metric_modules import SigmoidCrossEntropyMetric
 from ludwig.utils.horovod_utils import is_on_master
 from ludwig.utils.misc_utils import set_default_value
-from ludwig.utils.strings_utils import create_vocabulary, UNKNOWN_SYMBOL
+from ludwig.utils.strings_utils import create_vocabulary, tokenizer_registry, UNKNOWN_SYMBOL
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +44,14 @@ class SetFeatureMixin(object):
         'lowercase': False,
         'missing_value_strategy': FILL_WITH_CONST,
         'fill_value': UNKNOWN_SYMBOL
+    }
+
+    preprocessing_schema = {
+        'tokenizer': {'type': 'string', 'enum': sorted(list(tokenizer_registry.keys()))},
+        'most_common': {'type': 'integer', 'minimum': 0},
+        'lowercase': {'type': 'boolean'},
+        'missing_value_strategy': {'type': 'string', 'enum': MISSING_VALUE_STRATEGY_OPTIONS},
+        'fill_value': {'type': 'string'},
     }
 
     @staticmethod

--- a/ludwig/features/text_feature.py
+++ b/ludwig/features/text_feature.py
@@ -32,6 +32,8 @@ from ludwig.utils.strings_utils import PADDING_SYMBOL
 from ludwig.utils.strings_utils import UNKNOWN_SYMBOL
 from ludwig.utils.strings_utils import build_sequence_matrix
 from ludwig.utils.strings_utils import create_vocabulary
+from ludwig.utils.strings_utils import tokenizer_registry
+
 
 logger = logging.getLogger(__name__)
 
@@ -55,6 +57,24 @@ class TextFeatureMixin(object):
         'lowercase': True,
         'missing_value_strategy': FILL_WITH_CONST,
         'fill_value': UNKNOWN_SYMBOL
+    }
+
+    preprocessing_schema = {
+        'char_tokenizer': {'type': 'string', 'enum': sorted(list(tokenizer_registry.keys()))},
+        'char_vocab_file': {'type': 'string'},
+        'char_sequence_length_limit': {'type': 'integer', 'minimum': 0},
+        'char_most_common': {'type': 'integer', 'minimum': 0},
+        'word_tokenizer': {'type': 'string', 'enum': sorted(list(tokenizer_registry.keys()))},
+        'pretrained_model_name_or_path': {'type': 'string'},
+        'word_vocab_file': {'type': 'string'},
+        'word_sequence_length_limit': {'type': 'integer', 'minimum': 0},
+        'word_most_common': {'type': 'integer', 'minimum': 0},
+        'padding_symbol': {'type': 'string'},
+        'unknown_symbol': {'type': 'string'},
+        'padding': {'type': 'string', 'enum': ['right', 'left']},
+        'lowercase': {'type': 'boolean'},
+        'missing_value_strategy': {'type': 'string', 'enum': MISSING_VALUE_STRATEGY_OPTIONS},
+        'fill_value': {'type': 'string'},
     }
 
     @staticmethod

--- a/ludwig/features/timeseries_feature.py
+++ b/ludwig/features/timeseries_feature.py
@@ -42,6 +42,15 @@ class TimeseriesFeatureMixin(object):
         'fill_value': ''
     }
 
+    preprocessing_schema = {
+        'timeseries_length_limit': {'type': 'integer', 'minimum': 0},
+        'padding_value': {'type': 'number'},
+        'padding': {'type': 'string', 'enum': ['right', 'left']},
+        'tokenizer': {'type': 'string', 'enum': sorted(list(tokenizer_registry.keys()))},
+        'missing_value_strategy': {'type': 'string', 'enum': MISSING_VALUE_STRATEGY_OPTIONS},
+        'fill_value': {'type': 'string'},
+    }
+
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters):
         tokenizer = get_from_registry(

--- a/ludwig/features/vector_feature.py
+++ b/ludwig/features/vector_feature.py
@@ -47,6 +47,12 @@ class VectorFeatureMixin(object):
         'fill_value': ""
     }
 
+    preprocessing_schema = {
+        'vector_size': {'type': 'integer', 'minimum': 0},
+        'missing_value_strategy': {'type': 'string', 'enum': MISSING_VALUE_STRATEGY_OPTIONS},
+        'fill_value': {'type': 'number'},
+    }
+
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters):
         return {

--- a/ludwig/utils/schema.py
+++ b/ludwig/utils/schema.py
@@ -1,0 +1,94 @@
+#! /usr/bin/env python
+# coding=utf-8
+# Copyright (c) 2020 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import inspect
+
+from jsonschema import validate
+
+from ludwig.features.feature_registries import input_type_registry, output_type_registry
+
+INPUT_FEATURE_TYPES = sorted(list(input_type_registry.keys()))
+OUTPUT_FEATURE_TYPES = sorted(list(output_type_registry.keys()))
+
+
+def get_schema():
+    schema = {
+        'type': 'object',
+        'properties': {
+            'input_features': {
+                'type': 'array',
+                'items': {
+                    'type': 'object',
+                    'properties': {
+                        'name': {'type': 'string'},
+                        'type': {'type': 'string', 'enum': INPUT_FEATURE_TYPES},
+                        'preprocessing': {},
+                        'encoder': {'type': 'string'}
+                    },
+                    'allOf': get_input_encoder_conds(),
+                    'required': ['name', 'type']
+                }
+            },
+            'combiner': {},
+            'output_features': {},
+            'training': {},
+            'preprocessing': {},
+        },
+        'required': ['input_features', 'output_features']
+    }
+    return schema
+
+
+def get_input_encoder_conds():
+    conds = []
+    for feature_type in INPUT_FEATURE_TYPES:
+        feature_cls = input_type_registry[feature_type]
+        encoder_names = sorted(list(feature_cls.encoder_registry.keys()))
+        encoder_cond = create_cond(
+            {'type': feature_type},
+            {'encoder': {'enum': encoder_names}},
+        )
+        conds.append(encoder_cond)
+
+        for encoder_name in encoder_names:
+            encoder_cls = feature_cls.encoder_registry[encoder_name]
+            signature = inspect.signature(encoder_cls.__init__)
+            config_args = [
+                k for k, v in signature.parameters.items()
+                if v.default is not inspect.Parameter.empty
+            ]
+            encoder_arg_cond = create_cond(
+                {'type': feature_type, 'encoder': encoder_cls},
+                {arg: {} for arg in config_args}
+            )
+            conds.append(encoder_arg_cond)
+    return conds
+
+
+def create_cond(if_pred, then_pred):
+    return {
+        'if': {
+            'properties': {k: {'const': v} for k, v in if_pred.items()}
+        },
+        'then': {
+            'properties': {k: v for k, v in then_pred.items()}
+        }
+    }
+
+
+def validate_config(config):
+    validate(instance=config, schema=get_schema())

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ tfa-nightly==0.12.0.dev20200820045606
 PyYAML>=3.12
 absl-py
 requests
+jsonschema
 
 
 # new data format support

--- a/tests/ludwig/utils/test_schema.py
+++ b/tests/ludwig/utils/test_schema.py
@@ -22,13 +22,17 @@ from ludwig.utils.schema import validate_config
 
 from tests.integration_tests.utils import ENCODERS
 from tests.integration_tests.utils import category_feature
+from tests.integration_tests.utils import image_feature
 from tests.integration_tests.utils import sequence_feature
 
 
 def test_config_basic():
     for encoder in ENCODERS:
         config = {
-            'input_features': [sequence_feature(reduce_output='sum', encoder=encoder)],
+            'input_features': [
+                sequence_feature(reduce_output='sum', encoder=encoder),
+                image_feature('/tmp/destination_folder'),
+            ],
             'output_features': [category_feature(vocab_size=2, reduce_input='sum')],
             'combiner': {'type': 'concat', 'fc_size': 14},
         }
@@ -49,6 +53,29 @@ def test_config_bad_feature_type():
 def test_config_bad_encoder_name():
     config = {
         'input_features': [sequence_feature(reduce_output='sum', encoder='fake')],
+        'output_features': [category_feature(vocab_size=2, reduce_input='sum')],
+        'combiner': {'type': 'concat', 'fc_size': 14},
+    }
+
+    with pytest.raises(ValidationError, match=r"^'fake' is not one of .*"):
+        validate_config(config)
+
+
+def test_config_bad_preprocessing_param():
+    config = {
+        'input_features': [
+            sequence_feature(reduce_output='sum', encoder='fake'),
+            image_feature(
+                '/tmp/destination_folder',
+                preprocessing={
+                     'in_memory': True,
+                     'height': 12,
+                     'width': 12,
+                     'num_channels': 3,
+                     'tokenizer': 'space',
+                },
+            ),
+        ],
         'output_features': [category_feature(vocab_size=2, reduce_input='sum')],
         'combiner': {'type': 'concat', 'fc_size': 14},
     }

--- a/tests/ludwig/utils/test_schema.py
+++ b/tests/ludwig/utils/test_schema.py
@@ -1,0 +1,57 @@
+#! /usr/bin/env python
+# coding=utf-8
+# Copyright (c) 2020 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import pytest
+from jsonschema.exceptions import ValidationError
+
+from ludwig.utils.schema import validate_config
+
+from tests.integration_tests.utils import ENCODERS
+from tests.integration_tests.utils import category_feature
+from tests.integration_tests.utils import sequence_feature
+
+
+def test_config_basic():
+    for encoder in ENCODERS:
+        config = {
+            'input_features': [sequence_feature(reduce_output='sum', encoder=encoder)],
+            'output_features': [category_feature(vocab_size=2, reduce_input='sum')],
+            'combiner': {'type': 'concat', 'fc_size': 14},
+        }
+        validate_config(config)
+
+
+def test_config_bad_feature_type():
+    config = {
+        'input_features': [{'name': 'foo', 'type': 'fake'}],
+        'output_features': [category_feature(vocab_size=2, reduce_input='sum')],
+        'combiner': {'type': 'concat', 'fc_size': 14},
+    }
+
+    with pytest.raises(ValidationError, match=r"^'fake' is not one of .*"):
+        validate_config(config)
+
+
+def test_config_bad_encoder_name():
+    config = {
+        'input_features': [sequence_feature(reduce_output='sum', encoder='fake')],
+        'output_features': [category_feature(vocab_size=2, reduce_input='sum')],
+        'combiner': {'type': 'concat', 'fc_size': 14},
+    }
+
+    with pytest.raises(ValidationError, match=r"^'fake' is not one of .*"):
+        validate_config(config)


### PR DESCRIPTION
The purpose of this PR is to catch typos or other misconfigurations in the Ludwig `config.yaml` before training.

One common occurrence is that users will set a parameter in the config expecting it to do something, but because Ludwig does not validate the schema and will assume reasonable defaults, this can result in errors that go undetected.

This PR introduces schema validation based on `jsonschema` that is called at `LudwigModel` creation time.  It enforces that certain fields are set, and that certain fields (like `preprocessing`) do not have any unrecognized subfields.

Note that we do not apply strict subfield checking to every field in the config, in order to make it easier for users to switch between different encoders that take different parameters, for example.  We do, however, check that feature types, encoders, tokenizers, and other common parameters all have valid values and that preprocessing in particular does not have unrecognized fields.