### PR TITLE
fix(progress_tracker): update current learning_rate

### DIFF
--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -583,6 +583,8 @@ class Trainer:
                         self.optimizer.variables(), root_rank=0)
 
                 progress_tracker.steps += 1
+                progress_tracker.learning_rate = current_learning_rate
+
                 if is_on_master():
                     progress_bar.update(1)
                 first_batch = False


### PR DESCRIPTION
There is no update for `current_learning_rate` in `progress_tracker`