### PR TITLE
Add titles to Hyperopt Report visualization

### DIFF
--- a/ludwig/utils/visualization_utils.py
+++ b/ludwig/utils/visualization_utils.py
@@ -1215,12 +1215,14 @@ def hyperopt_report(
         filename_template,
         float_precision=3
 ):
+    title = "Hyperopt Report: {}"
     for hp_name, hp_params in hyperparameters.items():
         if hp_params[TYPE] == 'int':
             hyperopt_int_plot(
                 hyperopt_results_df,
                 hp_name,
                 metric,
+                title.format(hp_name),
                 filename_template.format(
                     hp_name) if filename_template else None
             )
@@ -1229,6 +1231,7 @@ def hyperopt_report(
                 hyperopt_results_df,
                 hp_name,
                 metric,
+                title.format(hp_name)
                 filename_template.format(
                     hp_name) if filename_template else None,
                 log_scale_x=hp_params[
@@ -1239,6 +1242,7 @@ def hyperopt_report(
                 hyperopt_results_df,
                 hp_name,
                 metric,
+                title.format(hp_name)
                 filename_template.format(
                     hp_name) if filename_template else None
             )
@@ -1264,6 +1268,7 @@ def hyperopt_report(
     hyperopt_pair_plot(
         hyperopt_results_df,
         metric,
+        title.format("pair plot")
         filename_template.format('pair_plot') if filename_template else None
     )
 
@@ -1272,6 +1277,7 @@ def hyperopt_int_plot(
         hyperopt_results_df,
         hp_name,
         metric,
+        title,
         filename,
         log_scale_x=False,
         log_scale_y=True
@@ -1283,6 +1289,7 @@ def hyperopt_int_plot(
         y=metric,
         data=hyperopt_results_df
     )
+    seaborn_figure.set_title(title)
     if log_scale_x:
         seaborn_figure.set(xscale="log")
     if log_scale_y:
@@ -1301,6 +1308,7 @@ def hyperopt_float_plot(
         hyperopt_results_df,
         hp_name,
         metric,
+        title,
         filename,
         log_scale_x=False,
         log_scale_y=True
@@ -1312,6 +1320,7 @@ def hyperopt_float_plot(
         y=metric,
         data=hyperopt_results_df
     )
+    seaborn_figure.set_title(title)
     seaborn_figure.set(ylabel=metric)
     if log_scale_x:
         seaborn_figure.set(xscale="log")
@@ -1328,6 +1337,7 @@ def hyperopt_category_plot(
         hyperopt_results_df,
         hp_name,
         metric,
+        title,
         filename,
         log_scale=True
 ):
@@ -1339,6 +1349,7 @@ def hyperopt_category_plot(
         data=hyperopt_results_df,
         fit_reg=False
     )
+    seaborn_figure.set_title(title)
     seaborn_figure.set(ylabel=metric)
     sns.despine()
     if log_scale:
@@ -1353,6 +1364,7 @@ def hyperopt_category_plot(
 def hyperopt_pair_plot(
         hyperopt_results_df,
         metric,
+        title,
         filename
 ):
     params = sorted(list(hyperopt_results_df.keys()))
@@ -1382,7 +1394,7 @@ def hyperopt_pair_plot(
                 )
 
     plt.tight_layout(pad=5)
-
+    plt.title(title)
     if filename:
         plt.savefig(filename)
     else:

--- a/ludwig/utils/visualization_utils.py
+++ b/ludwig/utils/visualization_utils.py
@@ -1231,7 +1231,7 @@ def hyperopt_report(
                 hyperopt_results_df,
                 hp_name,
                 metric,
-                title.format(hp_name)
+                title.format(hp_name),
                 filename_template.format(
                     hp_name) if filename_template else None,
                 log_scale_x=hp_params[
@@ -1242,7 +1242,7 @@ def hyperopt_report(
                 hyperopt_results_df,
                 hp_name,
                 metric,
-                title.format(hp_name)
+                title.format(hp_name),
                 filename_template.format(
                     hp_name) if filename_template else None
             )
@@ -1268,7 +1268,7 @@ def hyperopt_report(
     hyperopt_pair_plot(
         hyperopt_results_df,
         metric,
-        title.format("pair plot")
+        title.format("pair plot"),
         filename_template.format('pair_plot') if filename_template else None
     )
 

--- a/ludwig/utils/visualization_utils.py
+++ b/ludwig/utils/visualization_utils.py
@@ -1373,7 +1373,7 @@ def hyperopt_pair_plot(
 
     sns.set_style('white')
     fig = plt.figure(figsize=(20, 20))
-    figure.suptitle(title)
+    fig.suptitle(title)
     gs = fig.add_gridspec(num_param, num_param)
 
     for i, param1 in enumerate(params):

--- a/ludwig/utils/visualization_utils.py
+++ b/ludwig/utils/visualization_utils.py
@@ -1373,6 +1373,7 @@ def hyperopt_pair_plot(
 
     sns.set_style('white')
     fig = plt.figure(figsize=(20, 20))
+    figure.suptitle(title)
     gs = fig.add_gridspec(num_param, num_param)
 
     for i, param1 in enumerate(params):
@@ -1394,7 +1395,6 @@ def hyperopt_pair_plot(
                 )
 
     plt.tight_layout(pad=5)
-    plt.title(title)
     if filename:
         plt.savefig(filename)
     else:


### PR DESCRIPTION
Adding titles to the plots created by `hyperopt_report_cli` visualization

Previously there were no titles for these plots.
This pull request just sets each plot's title to be "Hyperopt Report: {hyperparameter_name}" or "Hyperopt Report: pair plot"

