### PR TITLE
Added cast_columns function to preprocessing and cast_column function to all feature mixin classes

### DIFF
--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -1036,10 +1036,9 @@ def build_dataset(
     return dataset, metadata
 
 
-def cast_columns(input_df, features, global_preprocessing_parameters, backend):
+def cast_columns(dataset_df, features, global_preprocessing_parameters,
+                 backend):
     # todo figure out if global_preprocessing_parameters is needed
-    proc_df = backend.df_engine.empty_df_like(input_df)
-
     for feature in features:
         cast_column = get_from_registry(
             feature[TYPE],
@@ -1047,14 +1046,13 @@ def cast_columns(input_df, features, global_preprocessing_parameters, backend):
         ).cast_column
         # todo figure out if additional parameters are needed
         #  for the cast_column function
-        proc_df = cast_column(
+        dataset_df = cast_column(
             feature,
-            input_df,
-            proc_df,
+            dataset_df,
             backend
         )
 
-    return proc_df
+    return dataset_df
 
 
 def build_metadata(dataset_df, features, global_preprocessing_parameters,

--- a/ludwig/features/audio_feature.py
+++ b/ludwig/features/audio_feature.py
@@ -56,6 +56,11 @@ class AudioFeatureMixin(object):
     }
 
     @staticmethod
+    def cast_column(feature, input_df, proc_df, backend):
+        proc_df[feature[COLUMN]] = input_df[feature[COLUMN]]
+        return proc_df
+
+    @staticmethod
     def get_feature_meta(column, preprocessing_parameters, backend):
         try:
             import soundfile

--- a/ludwig/features/audio_feature.py
+++ b/ludwig/features/audio_feature.py
@@ -56,9 +56,8 @@ class AudioFeatureMixin(object):
     }
 
     @staticmethod
-    def cast_column(feature, input_df, proc_df, backend):
-        proc_df[feature[COLUMN]] = input_df[feature[COLUMN]]
-        return proc_df
+    def cast_column(feature, dataset_df, backend):
+        return dataset_df
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters, backend):

--- a/ludwig/features/bag_feature.py
+++ b/ludwig/features/bag_feature.py
@@ -42,9 +42,8 @@ class BagFeatureMixin(object):
     }
 
     @staticmethod
-    def cast_column(feature, input_df, proc_df, backend):
-        proc_df[feature[COLUMN]] = input_df[feature[COLUMN]]
-        return proc_df
+    def cast_column(feature, dataset_df, backend):
+        return dataset_df
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters, backend):

--- a/ludwig/features/bag_feature.py
+++ b/ludwig/features/bag_feature.py
@@ -42,6 +42,11 @@ class BagFeatureMixin(object):
     }
 
     @staticmethod
+    def cast_column(feature, input_df, proc_df, backend):
+        proc_df[feature[COLUMN]] = input_df[feature[COLUMN]]
+        return proc_df
+
+    @staticmethod
     def get_feature_meta(column, preprocessing_parameters, backend):
         idx2str, str2idx, str2freq, max_size, _, _, _ = create_vocabulary(
             column,

--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -50,6 +50,13 @@ class BinaryFeatureMixin(object):
     }
 
     @staticmethod
+    def cast_column(feature, input_df, proc_df, backend):
+        # todo maybe move code from add_feature_data here
+        #  + figure out what NaN is in a bool column
+        proc_df[feature[COLUMN]] = input_df[feature[COLUMN]]
+        return proc_df
+
+    @staticmethod
     def get_feature_meta(column, preprocessing_parameters, backend):
         return {}
 

--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -50,11 +50,10 @@ class BinaryFeatureMixin(object):
     }
 
     @staticmethod
-    def cast_column(feature, input_df, proc_df, backend):
+    def cast_column(feature, dataset_df, backend):
         # todo maybe move code from add_feature_data here
         #  + figure out what NaN is in a bool column
-        proc_df[feature[COLUMN]] = input_df[feature[COLUMN]]
-        return proc_df
+        return dataset_df
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters, backend):

--- a/ludwig/features/category_feature.py
+++ b/ludwig/features/category_feature.py
@@ -54,6 +54,11 @@ class CategoryFeatureMixin(object):
     }
 
     @staticmethod
+    def cast_column(feature, input_df, proc_df, backend):
+        proc_df[feature[COLUMN]] = input_df[feature[COLUMN]]
+        return proc_df
+
+    @staticmethod
     def get_feature_meta(column, preprocessing_parameters, backend):
         idx2str, str2idx, str2freq, _, _, _, _ = create_vocabulary(
             column, 'stripped',

--- a/ludwig/features/category_feature.py
+++ b/ludwig/features/category_feature.py
@@ -54,9 +54,8 @@ class CategoryFeatureMixin(object):
     }
 
     @staticmethod
-    def cast_column(feature, input_df, proc_df, backend):
-        proc_df[feature[COLUMN]] = input_df[feature[COLUMN]]
-        return proc_df
+    def cast_column(feature, dataset_df, backend):
+        return dataset_df
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters, backend):

--- a/ludwig/features/date_feature.py
+++ b/ludwig/features/date_feature.py
@@ -41,9 +41,8 @@ class DateFeatureMixin(object):
     }
 
     @staticmethod
-    def cast_column(feature, input_df, proc_df, backend):
-        proc_df[feature[COLUMN]] = input_df[feature[COLUMN]]
-        return proc_df
+    def cast_column(feature, dataset_df, backend):
+        return dataset_df
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters, backend):

--- a/ludwig/features/date_feature.py
+++ b/ludwig/features/date_feature.py
@@ -41,6 +41,11 @@ class DateFeatureMixin(object):
     }
 
     @staticmethod
+    def cast_column(feature, input_df, proc_df, backend):
+        proc_df[feature[COLUMN]] = input_df[feature[COLUMN]]
+        return proc_df
+
+    @staticmethod
     def get_feature_meta(column, preprocessing_parameters, backend):
         return {
             'preprocessing': preprocessing_parameters

--- a/ludwig/features/h3_feature.py
+++ b/ludwig/features/h3_feature.py
@@ -41,6 +41,12 @@ class H3FeatureMixin(object):
     }
 
     @staticmethod
+    def cast_column(feature, input_df, proc_df, backend):
+        # todo: add cast to int64
+        proc_df[feature[COLUMN]] = input_df[feature[COLUMN]]
+        return proc_df
+
+    @staticmethod
     def get_feature_meta(column, preprocessing_parameters, backend):
         return {}
 

--- a/ludwig/features/h3_feature.py
+++ b/ludwig/features/h3_feature.py
@@ -41,10 +41,9 @@ class H3FeatureMixin(object):
     }
 
     @staticmethod
-    def cast_column(feature, input_df, proc_df, backend):
+    def cast_column(feature, dataset_df, backend):
         # todo: add cast to int64
-        proc_df[feature[COLUMN]] = input_df[feature[COLUMN]]
-        return proc_df
+        return dataset_df
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters, backend):

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -47,6 +47,11 @@ class ImageFeatureMixin(object):
     }
 
     @staticmethod
+    def cast_column(feature, input_df, proc_df, backend):
+        proc_df[feature[COLUMN]] = input_df[feature[COLUMN]]
+        return proc_df
+
+    @staticmethod
     def get_feature_meta(column, preprocessing_parameters, backend):
         return {
             PREPROCESSING: preprocessing_parameters

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -47,9 +47,8 @@ class ImageFeatureMixin(object):
     }
 
     @staticmethod
-    def cast_column(feature, input_df, proc_df, backend):
-        proc_df[feature[COLUMN]] = input_df[feature[COLUMN]]
-        return proc_df
+    def cast_column(feature, dataset_df, backend):
+        return dataset_df
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters, backend):

--- a/ludwig/features/numerical_feature.py
+++ b/ludwig/features/numerical_feature.py
@@ -48,6 +48,13 @@ class NumericalFeatureMixin(object):
     }
 
     @staticmethod
+    def cast_column(feature, input_df, proc_df, backend):
+        proc_df[feature[COLUMN]] = backend.df_engine.df_lib.to_numeric(
+            input_df[feature[COLUMN]], errors='coerce', downcast='float'
+        )
+        return proc_df
+
+    @staticmethod
     def get_feature_meta(column, preprocessing_parameters, backend):
         compute = backend.df_engine.compute
         if preprocessing_parameters['normalization'] is not None:
@@ -80,15 +87,13 @@ class NumericalFeatureMixin(object):
             preprocessing_parameters,
             backend
     ):
-        proc_df[feature[PROC_COLUMN]] = input_df[feature[COLUMN]].astype(
-            np.float32).values
+        proc_df[feature[PROC_COLUMN]] = input_df[feature[COLUMN]].values
         if preprocessing_parameters['normalization'] is not None:
             if preprocessing_parameters['normalization'] == 'zscore':
                 mean = metadata[feature[NAME]]['mean']
                 std = metadata[feature[NAME]]['std']
-                proc_df[feature[PROC_COLUMN]] = (proc_df[
-                                                     feature[
-                                                         PROC_COLUMN]] - mean) / std
+                proc_df[feature[PROC_COLUMN]] = \
+                    (proc_df[feature[PROC_COLUMN]] - mean) / std
             elif preprocessing_parameters['normalization'] == 'minmax':
                 min_ = metadata[feature[NAME]]['min']
                 max_ = metadata[feature[NAME]]['max']

--- a/ludwig/features/numerical_feature.py
+++ b/ludwig/features/numerical_feature.py
@@ -48,11 +48,11 @@ class NumericalFeatureMixin(object):
     }
 
     @staticmethod
-    def cast_column(feature, input_df, proc_df, backend):
-        proc_df[feature[COLUMN]] = backend.df_engine.df_lib.to_numeric(
-            input_df[feature[COLUMN]], errors='coerce', downcast='float'
+    def cast_column(feature, dataset_df, backend):
+        dataset_df[feature[COLUMN]] = backend.df_engine.df_lib.to_numeric(
+            dataset_df[feature[COLUMN]], errors='coerce', downcast='float'
         )
-        return proc_df
+        return dataset_df
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters, backend):

--- a/ludwig/features/sequence_feature.py
+++ b/ludwig/features/sequence_feature.py
@@ -68,6 +68,11 @@ class SequenceFeatureMixin(object):
     }
 
     @staticmethod
+    def cast_column(feature, input_df, proc_df, backend):
+        proc_df[feature[COLUMN]] = input_df[feature[COLUMN]]
+        return proc_df
+
+    @staticmethod
     def get_feature_meta(column, preprocessing_parameters, backend):
         idx2str, str2idx, str2freq, max_length, _, _, _ = create_vocabulary(
             column, preprocessing_parameters['tokenizer'],

--- a/ludwig/features/sequence_feature.py
+++ b/ludwig/features/sequence_feature.py
@@ -68,9 +68,8 @@ class SequenceFeatureMixin(object):
     }
 
     @staticmethod
-    def cast_column(feature, input_df, proc_df, backend):
-        proc_df[feature[COLUMN]] = input_df[feature[COLUMN]]
-        return proc_df
+    def cast_column(feature, dataset_df, backend):
+        return dataset_df
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters, backend):

--- a/ludwig/features/set_feature.py
+++ b/ludwig/features/set_feature.py
@@ -47,9 +47,8 @@ class SetFeatureMixin(object):
     }
 
     @staticmethod
-    def cast_column(feature, input_df, proc_df, backend):
-        proc_df[feature[COLUMN]] = input_df[feature[COLUMN]]
-        return proc_df
+    def cast_column(feature, dataset_df, backend):
+        return dataset_df
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters, backend):

--- a/ludwig/features/set_feature.py
+++ b/ludwig/features/set_feature.py
@@ -47,6 +47,11 @@ class SetFeatureMixin(object):
     }
 
     @staticmethod
+    def cast_column(feature, input_df, proc_df, backend):
+        proc_df[feature[COLUMN]] = input_df[feature[COLUMN]]
+        return proc_df
+
+    @staticmethod
     def get_feature_meta(column, preprocessing_parameters, backend):
         idx2str, str2idx, str2freq, max_size, _, _, _ = create_vocabulary(
             column,

--- a/ludwig/features/text_feature.py
+++ b/ludwig/features/text_feature.py
@@ -58,6 +58,11 @@ class TextFeatureMixin(object):
     }
 
     @staticmethod
+    def cast_column(feature, input_df, proc_df, backend):
+        proc_df[feature[COLUMN]] = input_df[feature[COLUMN]]
+        return proc_df
+
+    @staticmethod
     def feature_meta(column, preprocessing_parameters, backend):
         (
             char_idx2str,

--- a/ludwig/features/text_feature.py
+++ b/ludwig/features/text_feature.py
@@ -58,9 +58,8 @@ class TextFeatureMixin(object):
     }
 
     @staticmethod
-    def cast_column(feature, input_df, proc_df, backend):
-        proc_df[feature[COLUMN]] = input_df[feature[COLUMN]]
-        return proc_df
+    def cast_column(feature, dataset_df, backend):
+        return dataset_df
 
     @staticmethod
     def feature_meta(column, preprocessing_parameters, backend):

--- a/ludwig/features/timeseries_feature.py
+++ b/ludwig/features/timeseries_feature.py
@@ -43,6 +43,11 @@ class TimeseriesFeatureMixin(object):
     }
 
     @staticmethod
+    def cast_column(feature, input_df, proc_df, backend):
+        proc_df[feature[COLUMN]] = input_df[feature[COLUMN]]
+        return proc_df
+
+    @staticmethod
     def get_feature_meta(column, preprocessing_parameters, backend):
         tokenizer = get_from_registry(
             preprocessing_parameters['tokenizer'],

--- a/ludwig/features/timeseries_feature.py
+++ b/ludwig/features/timeseries_feature.py
@@ -43,9 +43,8 @@ class TimeseriesFeatureMixin(object):
     }
 
     @staticmethod
-    def cast_column(feature, input_df, proc_df, backend):
-        proc_df[feature[COLUMN]] = input_df[feature[COLUMN]]
-        return proc_df
+    def cast_column(feature, dataset_df, backend):
+        return dataset_df
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters, backend):

--- a/ludwig/features/vector_feature.py
+++ b/ludwig/features/vector_feature.py
@@ -48,9 +48,8 @@ class VectorFeatureMixin(object):
     }
 
     @staticmethod
-    def cast_column(feature, input_df, proc_df, backend):
-        proc_df[feature[COLUMN]] = input_df[feature[COLUMN]]
-        return proc_df
+    def cast_column(feature, dataset_df, backend):
+        return dataset_df
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters, backend):

--- a/ludwig/features/vector_feature.py
+++ b/ludwig/features/vector_feature.py
@@ -48,6 +48,11 @@ class VectorFeatureMixin(object):
     }
 
     @staticmethod
+    def cast_column(feature, input_df, proc_df, backend):
+        proc_df[feature[COLUMN]] = input_df[feature[COLUMN]]
+        return proc_df
+
+    @staticmethod
     def get_feature_meta(column, preprocessing_parameters, backend):
         return {
             'preprocessing': preprocessing_parameters

--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -211,8 +211,15 @@ def to_numpy_dataset(df):
 def from_numpy_dataset(dataset):
     col_mapping = {}
     for k, v in dataset.items():
-        *unstacked, = v
-        col_mapping[k] = unstacked
+        if len(v.shape) > 1:
+            # unstacking, needed for ndarrays of dimension 2 and more
+            *vals, = v
+        else:
+            # not unstacking. Needed because otherwise pandas casts types
+            # the way it wants, like converting a list of float32 scalats
+            # to a column of float64
+            vals = v
+        col_mapping[k] = vals
     return pd.DataFrame.from_dict(col_mapping)
 
 


### PR DESCRIPTION
Added cast_columns function to preprocessing and cast_column function to all feature mixin classes

The intent is to cast each df column to the correct type, so that `handle_missing_values` can actually do its job. In particular, for numerical values, if we don't do this, then a empty string value will make it so that the whole column would be read by pandas as `object` and empty string would not be interpreted as a missing value. With this PR empty string becomes NaN for numerical columns, so `handle_missing_values` now works fine.

To test before and after, try creating a dataset with 2 numerical columns and replace some entries with empty string and try to provide it to Ludwig and see the difference in behavior.