### PR TITLE
Added label-wise probability to binary feature predictions

### DIFF
--- a/ludwig/data/postprocessing.py
+++ b/ludwig/data/postprocessing.py
@@ -16,6 +16,7 @@
 # ==============================================================================
 import pandas as pd
 
+from ludwig.constants import BINARY
 from ludwig.features.feature_utils import SEQUENCE_TYPES
 from ludwig.utils.data_utils import DICT_FORMATS, DATAFRAME_FORMATS, \
     normalize_numpy
@@ -83,6 +84,8 @@ def convert_to_df(
                                 'idx2str' in training_set_metadata[of_name]):
                             class_name = training_set_metadata[of_name][
                                 'idx2str'][i]
+                        elif output_feature.type == BINARY:
+                            class_name = 'True' if i == 1 else 'False'
                         else:
                             class_name = str(i)
                         data_for_df[

--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -300,10 +300,13 @@ class BinaryOutputFeature(BinaryFeatureMixin, OutputFeature):
 
         if PROBABILITIES in result and len(result[PROBABILITIES]) > 0:
             postprocessed[PROBABILITIES] = result[PROBABILITIES].numpy()
-            postprocessed[PROBABILITIES] = np.concatenate(
+            postprocessed[PROBABILITIES] = np.stack(
                 [1 - postprocessed[PROBABILITIES],
                 postprocessed[PROBABILITIES]],
                 axis=1
+            )
+            postprocessed[PROBABILITY] = np.amax(
+                postprocessed[PROBABILITIES], axis=1
             )
             if not skip_save_unprocessed_output:
                 np.save(
@@ -311,11 +314,6 @@ class BinaryOutputFeature(BinaryFeatureMixin, OutputFeature):
                     postprocessed[PROBABILITIES]
                 )
             del result[PROBABILITIES]
-
-        if PROBABILITIES in postprocessed:
-            postprocessed[PROBABILITY] = np.amax(
-                postprocessed[PROBABILITIES], axis=1
-            )
 
         return postprocessed
 

--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -307,6 +307,11 @@ class BinaryOutputFeature(BinaryFeatureMixin, OutputFeature):
                 )
             del result[PROBABILITIES]
 
+        if PREDICTIONS in postprocessed and PROBABILITIES in postprocessed:
+            preds = postprocessed[PREDICTIONS]
+            probs = postprocessed[PROBABILITIES]
+            postprocessed[PROBABILITY] = abs((1 - preds) - probs)
+
         return postprocessed
 
     @staticmethod

--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -300,6 +300,11 @@ class BinaryOutputFeature(BinaryFeatureMixin, OutputFeature):
 
         if PROBABILITIES in result and len(result[PROBABILITIES]) > 0:
             postprocessed[PROBABILITIES] = result[PROBABILITIES].numpy()
+            postprocessed[PROBABILITIES] = np.concatenate(
+                [1 - postprocessed[PROBABILITIES],
+                postprocessed[PROBABILITIES]],
+                axis=1
+            )
             if not skip_save_unprocessed_output:
                 np.save(
                     npy_filename.format(name, PROBABILITIES),
@@ -307,10 +312,10 @@ class BinaryOutputFeature(BinaryFeatureMixin, OutputFeature):
                 )
             del result[PROBABILITIES]
 
-        if PREDICTIONS in postprocessed and PROBABILITIES in postprocessed:
-            preds = postprocessed[PREDICTIONS]
-            probs = postprocessed[PROBABILITIES]
-            postprocessed[PROBABILITY] = abs((1 - preds) - probs)
+        if PROBABILITIES in postprocessed:
+            postprocessed[PROBABILITY] = np.amax(
+                postprocessed[PROBABILITIES], axis=1
+            )
 
         return postprocessed
 

--- a/ludwig/utils/neuropod_utils.py
+++ b/ludwig/utils/neuropod_utils.py
@@ -48,10 +48,12 @@ def postprocess_for_neuropod(predicted, config):
             postprocessed[feature_name + "_predictions"] = \
                 np.expand_dims(
                     predicted[feature_name][PREDICTIONS].astype('str'), 1)
-            postprocessed[feature_name + "_probabilities"] = \
+            postprocessed[feature_name + "_probability"] = \
                 np.expand_dims(
-                    predicted[feature_name][PROBABILITIES].astype('float64'),
+                    predicted[feature_name][PROBABILITY].astype('float64'),
                     1)
+            postprocessed[feature_name + "_probabilities"] = \
+                predicted[feature_name][PROBABILITIES].astype('float64')
         elif feature_type == NUMERICAL:
             postprocessed[feature_name + "_predictions"] = \
                 np.expand_dims(
@@ -188,9 +190,14 @@ def export_neuropod(
                 "shape": (None, 1)
             })
             output_spec.append({
-                "name": feature_name + '_probabilities',
+                "name": feature_name + '_probability',
                 "dtype": "float64",
                 "shape": (None, 1)
+            })
+            output_spec.append({
+                "name": feature_name + '_probabilities',
+                "dtype": "float64",
+                "shape": (None, 2)
             })
         elif feature_type == NUMERICAL:
             output_spec.append({

--- a/tests/integration_tests/test_postprocessing.py
+++ b/tests/integration_tests/test_postprocessing.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+
+import os
+
+import mock
+import numpy as np
+import pandas as pd
+import tensorflow as tf
+
+from ludwig.api import LudwigModel
+from ludwig.constants import NAME
+
+from tests.integration_tests.utils import binary_feature, category_feature
+from tests.integration_tests.utils import generate_data
+
+
+def test_binary_predictions(tmpdir):
+    input_features = [
+        category_feature(vocab_size=3),
+    ]
+
+    feature = binary_feature()
+    output_features = [
+        feature,
+    ]
+
+    data_csv_path = generate_data(
+        input_features,
+        output_features,
+        os.path.join(tmpdir, 'dataset.csv'),
+    )
+    data_df = pd.read_csv(data_csv_path)
+
+    config = {
+        'input_features': input_features,
+        'output_features': output_features,
+        'training': {'epochs': 1}
+    }
+    ludwig_model = LudwigModel(config)
+    ludwig_model.train(
+        dataset=data_df,
+        output_directory=os.path.join(tmpdir, 'output'),
+    )
+
+    # Produce an even mix of True and False predictions, as the model may be biased towards
+    # one direction without training
+    def random_logits(*args, **kwargs):
+        return tf.convert_to_tensor(
+            np.random.uniform(low=-1.0, high=1.0, size=(len(data_df),))
+        )
+
+    with mock.patch('ludwig.features.binary_feature.BinaryOutputFeature.logits', random_logits):
+        preds_df, _ = ludwig_model.predict(
+            dataset=data_csv_path
+        )
+
+    cols = set(preds_df.columns)
+    assert f'{feature[NAME]}_predictions' in cols
+    assert f'{feature[NAME]}_probabilities_0' in cols
+    assert f'{feature[NAME]}_probabilities_1' in cols
+    assert f'{feature[NAME]}_probability' in cols
+
+    for pred, prob_0, prob_1, prob in zip(
+        preds_df[f'{feature[NAME]}_predictions'],
+        preds_df[f'{feature[NAME]}_probabilities_0'],
+        preds_df[f'{feature[NAME]}_probabilities_1'],
+        preds_df[f'{feature[NAME]}_probability'],
+    ):
+        assert pred is True or pred is False
+        if pred:
+            assert prob_1 == prob
+        else:
+            assert prob_0 == prob
+        assert prob_0 == 1 - prob_1

--- a/tests/integration_tests/test_postprocessing.py
+++ b/tests/integration_tests/test_postprocessing.py
@@ -71,14 +71,14 @@ def test_binary_predictions(tmpdir):
 
     cols = set(preds_df.columns)
     assert f'{feature[NAME]}_predictions' in cols
-    assert f'{feature[NAME]}_probabilities_0' in cols
-    assert f'{feature[NAME]}_probabilities_1' in cols
+    assert f'{feature[NAME]}_probabilities_False' in cols
+    assert f'{feature[NAME]}_probabilities_True' in cols
     assert f'{feature[NAME]}_probability' in cols
 
     for pred, prob_0, prob_1, prob in zip(
         preds_df[f'{feature[NAME]}_predictions'],
-        preds_df[f'{feature[NAME]}_probabilities_0'],
-        preds_df[f'{feature[NAME]}_probabilities_1'],
+        preds_df[f'{feature[NAME]}_probabilities_False'],
+        preds_df[f'{feature[NAME]}_probabilities_True'],
         preds_df[f'{feature[NAME]}_probability'],
     ):
         assert pred is True or pred is False


### PR DESCRIPTION
Prior to this PR, prediction outputs for binary features contain the column `feature_probabilities` which is the raw output of the model used to determine the label `{True, False}`.  In order to know the model's confidence in a prediction, the user needs to check the label, then mentally subtract this value from 1 if the label is False to get the model's confidence.  This PR simplifies things by adding a new `feature_probability` column that does just this.