### PR TITLE
Set output_feature_name to default None for learning_curves and compare_performance visualization

### DIFF
--- a/ludwig/visualize.py
+++ b/ludwig/visualize.py
@@ -1245,7 +1245,7 @@ def frequency_vs_f1_cli(
 
 def learning_curves(
         train_stats_per_model: List[dict],
-        output_feature_name: Union[str, None],
+        output_feature_name: Union[str, None] = None,
         model_names: Union[str, List[str]] = None,
         output_directory: str = None,
         file_format: str = 'pdf',
@@ -1322,7 +1322,7 @@ def learning_curves(
 
 def compare_performance(
         test_stats_per_model: List[dict],
-        output_feature_name: Union[str, None],
+        output_feature_name: Union[str, None] = None,
         model_names: Union[str, List[str]] = None,
         output_directory: str = None,
         file_format: str = 'pdf',

--- a/ludwig/visualize.py
+++ b/ludwig/visualize.py
@@ -1261,7 +1261,7 @@ def learning_curves(
 
     :param train_stats_per_model: (List[dict]) list containing dictionary of
         training statistics per model.
-    :param output_feature_name: (Union[str, `None`]) name of the output feature
+    :param output_feature_name: (Union[str, `None`], default: `None`) name of the output feature
         to use for the visualization.  If `None`, use all output features.
     :param model_names: (Union[str, List[str]], default: `None`) model name or
         list of the model names to use as labels.
@@ -1338,7 +1338,7 @@ def compare_performance(
 
     :param test_stats_per_model: (List[dict]) dictionary containing evaluation
         performance statistics.
-    :param output_feature_name: (Union[str, `None`]) name of the output feature
+    :param output_feature_name: (Union[str, `None`], default: `None`) name of the output feature
         to use for the visualization.  If `None`, use all output features.
     :param model_names: (Union[str, List[str]], default: `None`) model name or
         list of the model names to use as labels.


### PR DESCRIPTION
Previously, to call `learning_curves()` or `compare_performance()` you had to specifically provide an `output_feature_name` to tell ludwig which output_feature to use for the visualization. 

However, if you input `None` or a random string, the `_validate_output_feature_name_from_train_stats()` function will tell `learning_curves()` to just use **all** the output features. 

I feel like it'd be better to just set `output_feature_name: Union[str, None] = None` so by default it does this automatically without needing the user to input `None` specifically

Previous: `output_feature_name: Union[str, None]`
```
from ludwig.visualize import learning_curves
learning_curves(
    train_stats_per_model = train_stats, 
    output_feature_name = None,               # seems kind of redundant and it's unclear that all output_features are used unless someone looks through the codebase
    output_directory='./visualizations',
    file_format='png')
```

New: `output_feature_name: Union[str, None] = None` 

```
from ludwig.visualize import learning_curves
learning_curves(
    train_stats_per_model = train_stats, 
    output_directory='./visualizations',
    file_format='png')
```


