### PR TITLE
Fix legend and add tight_layout as param for compare_classifiers_predictions

### DIFF
--- a/ludwig/utils/visualization_utils.py
+++ b/ludwig/utils/visualization_utils.py
@@ -371,9 +371,10 @@ def donut(
         outside_labels,
         outside_groups,
         title=None,
+        tight_layout=None,
         filename=None
 ):
-    fig, ax = plt.subplots()
+    fig, ax = plt.subplots(figsize=(7,5))
 
     if title is not None:
         ax.set_title(title)
@@ -433,11 +434,13 @@ def donut(
             labels.append(outside_labels[so_far])
             so_far += 1
 
-    ax.legend(wedges, labels, frameon=True)
-    plt.tight_layout()
+    if tight_layout:
+        ax.legend(wedges, labels, frameon=True, loc=1, bbox_to_anchor=(1.30, 1.00))
+    else:
+        ax.legend(wedges, labels, frameon=True, loc=1, bbox_to_anchor=(1.50, 1.00))
     ludwig.contrib.contrib_command("visualize_figure", plt.gcf())
     if filename:
-        plt.savefig(filename)
+        plt.savefig(filename, bbox_inches = "tight")
     else:
         plt.show()
 

--- a/ludwig/visualize.py
+++ b/ludwig/visualize.py
@@ -2172,6 +2172,7 @@ def compare_classifiers_predictions(
          'same prediction', 'different prediction'],
         [0, 1, 1, 2, 2],
         title='{} vs {}'.format(name_c1, name_c2),
+        tight_layout=kwargs.pop('tight_layout', True),
         filename=filename
     )
 


### PR DESCRIPTION
Previously, the legend of the donut chart obtained by calling `compare_classifiers_predictions` overlapped the chart, hiding a few values essential for comparing the models. This PR fixes the above issue by adjusting the legend and giving users the option to switch the layout as a boolean param (`tight_layout`) with default value as `True` for legends having max 31 chars and `False` for much more chars. Also, the size of the subplot is increased to enhance the readability.