### PR TITLE
Added bool2str postprocessing for binary features so prediction vocab matches inputs

### DIFF
--- a/ludwig/data/postprocessing.py
+++ b/ludwig/data/postprocessing.py
@@ -85,7 +85,12 @@ def convert_to_df(
                             class_name = training_set_metadata[of_name][
                                 'idx2str'][i]
                         elif output_feature.type == BINARY:
-                            class_name = 'True' if i == 1 else 'False'
+                            if (of_name in training_set_metadata and
+                                    'bool2str' in training_set_metadata[of_name]):
+                                class_name = training_set_metadata[of_name][
+                                    'bool2str'][i]
+                            else:
+                                class_name = 'True' if i == 1 else 'False'
                         else:
                             class_name = str(i)
                         data_for_df[

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -1087,7 +1087,7 @@ def build_metadata(dataset_df, features, global_preprocessing_parameters, backen
             ).get_feature_meta
 
             metadata[feature[NAME]] = get_feature_meta(
-                dataset_df[feature[NAME]].astype(str),
+                dataset_df[feature[NAME]],
                 preprocessing_parameters,
                 backend
             )

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -1086,8 +1086,12 @@ def build_metadata(dataset_df, features, global_preprocessing_parameters, backen
                 base_type_registry
             ).get_feature_meta
 
+            column = dataset_df[feature[NAME]]
+            if column.dtype == object:
+                column = column.astype(str)
+
             metadata[feature[NAME]] = get_feature_meta(
-                dataset_df[feature[NAME]],
+                column,
                 preprocessing_parameters,
                 backend
             )

--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -58,7 +58,7 @@ class BinaryFeatureMixin(object):
         if len(distinct_values) > 2:
             raise ValueError(
                 f'Binary feature column expects 2 distinct values, '
-                f'found {distinct_values.values.tolist()}'
+                f'found: {distinct_values.values.tolist()}'
             )
 
         str2bool = {v: strings_utils.str2bool(v) for v in distinct_values}
@@ -80,7 +80,7 @@ class BinaryFeatureMixin(object):
     ):
         column = input_df[feature[COLUMN]]
         if column.dtype == object:
-            str2bool = metadata['str2bool']
+            str2bool = metadata[feature[NAME]]['str2bool']
             column = column.map(lambda x: str2bool[x])
         proc_df[feature[PROC_COLUMN]] = column.astype(np.bool_).values
         return proc_df

--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -79,9 +79,15 @@ class BinaryFeatureMixin(object):
             backend
     ):
         column = input_df[feature[COLUMN]]
+
+        metadata = metadata[feature[NAME]]
         if column.dtype == object:
-            str2bool = metadata[feature[NAME]]['str2bool']
-            column = column.map(lambda x: str2bool[x])
+            if 'str2bool' in metadata:
+                column = column.map(lambda x: metadata['str2bool'][x])
+            else:
+                # No predefined mapping from string to bool, so compute it directly
+                column = column.map(strings_utils.str2bool)
+
         proc_df[feature[PROC_COLUMN]] = column.astype(np.bool_).values
         return proc_df
 

--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -62,7 +62,7 @@ class BinaryFeatureMixin(object):
             )
 
         str2bool = {v: strings_utils.str2bool(v) for v in distinct_values}
-        bool2str = {b: v for v, b in str2bool.items()}
+        bool2str = [k for k, v in sorted(str2bool.items(), key=lambda item: item[1])]
 
         return {
             'str2bool': str2bool,

--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -80,8 +80,8 @@ class BinaryFeatureMixin(object):
     ):
         column = input_df[feature[COLUMN]]
 
-        metadata = metadata[feature[NAME]]
         if column.dtype == object:
+            metadata = metadata[feature[NAME]]
             if 'str2bool' in metadata:
                 column = column.map(lambda x: metadata['str2bool'][x])
             else:

--- a/ludwig/utils/strings_utils.py
+++ b/ludwig/utils/strings_utils.py
@@ -36,6 +36,8 @@ SPACE_PUNCTUATION_REGEX = re.compile(r'\w+|[^\w\s]')
 COMMA_REGEX = re.compile(r'\s*,\s*')
 UNDERSCORE_REGEX = re.compile(r'\s*_\s*')
 
+BOOL_TRUE_STRS = {'yes', 'y', 'true', 't', '1'}
+
 
 def make_safe_filename(s):
     def safe_char(c):
@@ -53,7 +55,7 @@ def strip_accents(s):
 
 
 def str2bool(v):
-    return str(v).lower() in ('yes', 'true', 't', '1')
+    return str(v).lower() in BOOL_TRUE_STRS
 
 
 def match_replace(string_to_match, list_regex):

--- a/tests/integration_tests/test_postprocessing.py
+++ b/tests/integration_tests/test_postprocessing.py
@@ -48,6 +48,7 @@ def test_binary_predictions(tmpdir, distinct_values):
     )
     data_df = pd.read_csv(data_csv_path)
 
+    # Optionally convert bool values to strings, e.g., {'Yes', 'No'}
     false_value, true_value = distinct_values
     data_df[feature[NAME]] = data_df[feature[NAME]].map(
         lambda x: true_value if x else false_value
@@ -64,10 +65,8 @@ def test_binary_predictions(tmpdir, distinct_values):
         output_directory=os.path.join(tmpdir, 'output'),
     )
 
+    # Check that metadata JSON saves and loads correctly
     ludwig_model = LudwigModel.load(os.path.join(output_directory, 'model'))
-
-    # with open(os.path.join(output_directory, 'model/training_set_metadata.json'), 'r') as f:
-    #     print(f.read())
 
     # Produce an even mix of True and False predictions, as the model may be biased towards
     # one direction without training

--- a/tests/integration_tests/test_postprocessing.py
+++ b/tests/integration_tests/test_postprocessing.py
@@ -59,10 +59,15 @@ def test_binary_predictions(tmpdir, distinct_values):
         'training': {'epochs': 1}
     }
     ludwig_model = LudwigModel(config)
-    ludwig_model.train(
+    _, _, output_directory = ludwig_model.train(
         dataset=data_df,
         output_directory=os.path.join(tmpdir, 'output'),
     )
+
+    ludwig_model = LudwigModel.load(os.path.join(output_directory, 'model'))
+
+    # with open(os.path.join(output_directory, 'model/training_set_metadata.json'), 'r') as f:
+    #     print(f.read())
 
     # Produce an even mix of True and False predictions, as the model may be biased towards
     # one direction without training


### PR DESCRIPTION
This PR makes it so that when the user has input data like: `{'binary_feature': ['Yes', 'Yes', 'No']}`, the prediction vocabulary will match the input. So instead of getting outputs like `True` and `False`, we will map them back to `Yes` and `No`.