### PR TITLE
Added selected conversion of columns to string when computing metadata

### DIFF
--- a/ludwig/features/bag_feature.py
+++ b/ludwig/features/bag_feature.py
@@ -43,6 +43,7 @@ class BagFeatureMixin(object):
 
     @staticmethod
     def cast_column(feature, dataset_df, backend):
+        dataset_df[feature[COLUMN]] = dataset_df[feature[COLUMN]].astype(str)
         return dataset_df
 
     @staticmethod
@@ -87,7 +88,7 @@ class BagFeatureMixin(object):
             backend
     ):
         proc_df[feature[PROC_COLUMN]] = BagFeatureMixin.feature_data(
-            input_df[feature[COLUMN]].astype(str),
+            input_df[feature[COLUMN]],
             metadata[feature[NAME]],
             preprocessing_parameters,
             backend

--- a/ludwig/features/bag_feature.py
+++ b/ludwig/features/bag_feature.py
@@ -43,11 +43,11 @@ class BagFeatureMixin(object):
 
     @staticmethod
     def cast_column(feature, dataset_df, backend):
-        dataset_df[feature[COLUMN]] = dataset_df[feature[COLUMN]].astype(str)
         return dataset_df
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters, backend):
+        column = column.astype(str)
         idx2str, str2idx, str2freq, max_size, _, _, _ = create_vocabulary(
             column,
             preprocessing_parameters['tokenizer'],
@@ -88,7 +88,7 @@ class BagFeatureMixin(object):
             backend
     ):
         proc_df[feature[PROC_COLUMN]] = BagFeatureMixin.feature_data(
-            input_df[feature[COLUMN]],
+            input_df[feature[COLUMN]].astype(str),
             metadata[feature[NAME]],
             preprocessing_parameters,
             backend

--- a/ludwig/features/category_feature.py
+++ b/ludwig/features/category_feature.py
@@ -55,11 +55,11 @@ class CategoryFeatureMixin(object):
 
     @staticmethod
     def cast_column(feature, dataset_df, backend):
-        dataset_df[feature[COLUMN]] = dataset_df[feature[COLUMN]].astype(str)
         return dataset_df
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters, backend):
+        column = column.astype(str)
         idx2str, str2idx, str2freq, _, _, _, _ = create_vocabulary(
             column, 'stripped',
             num_most_frequent=preprocessing_parameters['most_common'],
@@ -94,7 +94,7 @@ class CategoryFeatureMixin(object):
             backend
     ):
         proc_df[feature[PROC_COLUMN]] = CategoryFeatureMixin.feature_data(
-            input_df[feature[COLUMN]],
+            input_df[feature[COLUMN]].astype(str),
             metadata[feature[NAME]],
         )
         return proc_df

--- a/ludwig/features/category_feature.py
+++ b/ludwig/features/category_feature.py
@@ -55,6 +55,7 @@ class CategoryFeatureMixin(object):
 
     @staticmethod
     def cast_column(feature, dataset_df, backend):
+        dataset_df[feature[COLUMN]] = dataset_df[feature[COLUMN]].astype(str)
         return dataset_df
 
     @staticmethod
@@ -93,7 +94,7 @@ class CategoryFeatureMixin(object):
             backend
     ):
         proc_df[feature[PROC_COLUMN]] = CategoryFeatureMixin.feature_data(
-            input_df[feature[COLUMN]].astype(str),
+            input_df[feature[COLUMN]],
             metadata[feature[NAME]],
         )
         return proc_df

--- a/ludwig/features/sequence_feature.py
+++ b/ludwig/features/sequence_feature.py
@@ -69,11 +69,11 @@ class SequenceFeatureMixin(object):
 
     @staticmethod
     def cast_column(feature, dataset_df, backend):
-        dataset_df[feature[COLUMN]] = dataset_df[feature[COLUMN]].astype(str)
         return dataset_df
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters, backend):
+        column = column.astype(str)
         idx2str, str2idx, str2freq, max_length, _, _, _ = create_vocabulary(
             column, preprocessing_parameters['tokenizer'],
             lowercase=preprocessing_parameters['lowercase'],
@@ -123,7 +123,7 @@ class SequenceFeatureMixin(object):
             backend
     ):
         sequence_data = SequenceInputFeature.feature_data(
-            input_df[feature[COLUMN]],
+            input_df[feature[COLUMN]].astype(str),
             metadata[feature[NAME]], preprocessing_parameters,
             backend
         )

--- a/ludwig/features/sequence_feature.py
+++ b/ludwig/features/sequence_feature.py
@@ -69,6 +69,7 @@ class SequenceFeatureMixin(object):
 
     @staticmethod
     def cast_column(feature, dataset_df, backend):
+        dataset_df[feature[COLUMN]] = dataset_df[feature[COLUMN]].astype(str)
         return dataset_df
 
     @staticmethod
@@ -122,7 +123,7 @@ class SequenceFeatureMixin(object):
             backend
     ):
         sequence_data = SequenceInputFeature.feature_data(
-            input_df[feature[COLUMN]].astype(str),
+            input_df[feature[COLUMN]],
             metadata[feature[NAME]], preprocessing_parameters,
             backend
         )

--- a/ludwig/features/set_feature.py
+++ b/ludwig/features/set_feature.py
@@ -60,7 +60,6 @@ class SetFeatureMixin(object):
             lowercase=preprocessing_parameters['lowercase'],
             processor=backend.df_engine
         )
-        print(str2idx)
         return {
             'idx2str': idx2str,
             'str2idx': str2idx,

--- a/ludwig/features/set_feature.py
+++ b/ludwig/features/set_feature.py
@@ -48,11 +48,11 @@ class SetFeatureMixin(object):
 
     @staticmethod
     def cast_column(feature, dataset_df, backend):
-        dataset_df[feature[COLUMN]] = dataset_df[feature[COLUMN]].astype(str)
         return dataset_df
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters, backend):
+        column = column.astype(str)
         idx2str, str2idx, str2freq, max_size, _, _, _ = create_vocabulary(
             column,
             preprocessing_parameters['tokenizer'],
@@ -60,6 +60,7 @@ class SetFeatureMixin(object):
             lowercase=preprocessing_parameters['lowercase'],
             processor=backend.df_engine
         )
+        print(str2idx)
         return {
             'idx2str': idx2str,
             'str2idx': str2idx,
@@ -93,7 +94,7 @@ class SetFeatureMixin(object):
             backend
     ):
         proc_df[feature[PROC_COLUMN]] = SetFeatureMixin.feature_data(
-            input_df[feature[COLUMN]],
+            input_df[feature[COLUMN]].astype(str),
             metadata[feature[NAME]],
             preprocessing_parameters,
             backend

--- a/ludwig/features/set_feature.py
+++ b/ludwig/features/set_feature.py
@@ -48,6 +48,7 @@ class SetFeatureMixin(object):
 
     @staticmethod
     def cast_column(feature, dataset_df, backend):
+        dataset_df[feature[COLUMN]] = dataset_df[feature[COLUMN]].astype(str)
         return dataset_df
 
     @staticmethod
@@ -92,7 +93,7 @@ class SetFeatureMixin(object):
             backend
     ):
         proc_df[feature[PROC_COLUMN]] = SetFeatureMixin.feature_data(
-            input_df[feature[COLUMN]].astype(str),
+            input_df[feature[COLUMN]],
             metadata[feature[NAME]],
             preprocessing_parameters,
             backend

--- a/ludwig/features/text_feature.py
+++ b/ludwig/features/text_feature.py
@@ -59,7 +59,6 @@ class TextFeatureMixin(object):
 
     @staticmethod
     def cast_column(feature, dataset_df, backend):
-        dataset_df[feature[COLUMN]] = dataset_df[feature[COLUMN]].astype(str)
         return dataset_df
 
     @staticmethod
@@ -122,6 +121,7 @@ class TextFeatureMixin(object):
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters, backend):
+        column = column.astype(str)
         tf_meta = TextFeatureMixin.feature_meta(
             column, preprocessing_parameters, backend
         )
@@ -217,7 +217,7 @@ class TextFeatureMixin(object):
             backend
     ):
         chars_data, words_data = TextFeatureMixin.feature_data(
-            input_df[feature[COLUMN]],
+            input_df[feature[COLUMN]].astype(str),
             metadata[feature[NAME]],
             preprocessing_parameters,
             backend

--- a/ludwig/features/text_feature.py
+++ b/ludwig/features/text_feature.py
@@ -59,6 +59,7 @@ class TextFeatureMixin(object):
 
     @staticmethod
     def cast_column(feature, dataset_df, backend):
+        dataset_df[feature[COLUMN]] = dataset_df[feature[COLUMN]].astype(str)
         return dataset_df
 
     @staticmethod
@@ -216,7 +217,7 @@ class TextFeatureMixin(object):
             backend
     ):
         chars_data, words_data = TextFeatureMixin.feature_data(
-            input_df[feature[COLUMN]].astype(str),
+            input_df[feature[COLUMN]],
             metadata[feature[NAME]],
             preprocessing_parameters,
             backend

--- a/ludwig/features/timeseries_feature.py
+++ b/ludwig/features/timeseries_feature.py
@@ -44,11 +44,11 @@ class TimeseriesFeatureMixin(object):
 
     @staticmethod
     def cast_column(feature, dataset_df, backend):
-        dataset_df[feature[COLUMN]] = dataset_df[feature[COLUMN]].astype(str)
         return dataset_df
 
     @staticmethod
     def get_feature_meta(column, preprocessing_parameters, backend):
+        column = column.astype(str)
         tokenizer = get_from_registry(
             preprocessing_parameters['tokenizer'],
             tokenizer_registry
@@ -130,7 +130,7 @@ class TimeseriesFeatureMixin(object):
             backend
     ):
         proc_df[feature[PROC_COLUMN]] = TimeseriesFeatureMixin.feature_data(
-            input_df[feature[COLUMN]],
+            input_df[feature[COLUMN]].astype(str),
             metadata[feature[NAME]],
             preprocessing_parameters,
             backend

--- a/ludwig/features/timeseries_feature.py
+++ b/ludwig/features/timeseries_feature.py
@@ -44,6 +44,7 @@ class TimeseriesFeatureMixin(object):
 
     @staticmethod
     def cast_column(feature, dataset_df, backend):
+        dataset_df[feature[COLUMN]] = dataset_df[feature[COLUMN]].astype(str)
         return dataset_df
 
     @staticmethod
@@ -129,7 +130,7 @@ class TimeseriesFeatureMixin(object):
             backend
     ):
         proc_df[feature[PROC_COLUMN]] = TimeseriesFeatureMixin.feature_data(
-            input_df[feature[COLUMN]].astype(str),
+            input_df[feature[COLUMN]],
             metadata[feature[NAME]],
             preprocessing_parameters,
             backend

--- a/tests/integration_tests/test_simple_features.py
+++ b/tests/integration_tests/test_simple_features.py
@@ -14,11 +14,15 @@
 # limitations under the License.
 # ==============================================================================
 import logging
+import os
 import shutil
 
+import pandas as pd
 import pytest
 
+from ludwig.constants import NAME
 from ludwig.experiment import experiment_cli
+
 from tests.integration_tests.utils import binary_feature, sequence_feature, \
     set_feature, text_feature, vector_feature
 from tests.integration_tests.utils import category_feature
@@ -181,3 +185,21 @@ def test_feature_multiple_outputs(input_test_feature, output_test_feature,
                              csv_filename, 1001)
 
     run_experiment(input_test_feature, output_test_feature, dataset=rel_path)
+
+
+def test_category_int_dtype(tmpdir):
+    feature = category_feature()
+    input_features = [feature]
+    output_features = [binary_feature()]
+
+    csv_fname = generate_data(input_features, output_features,
+                              os.path.join(tmpdir, 'dataset.csv'))
+    df = pd.read_csv(csv_fname)
+
+    distinct_values = df[feature[NAME]].drop_duplicates().values
+    value_map = {v: idx for idx, v in enumerate(distinct_values)}
+    df[feature[NAME]] = df[feature[NAME]].map(
+        lambda x: value_map[x]
+    )
+
+    run_experiment(input_features, output_features, dataset=df)


### PR DESCRIPTION
Fixes #1040.

Note that we cannot do this in `cast_column` due to https://github.com/pandas-dev/pandas/issues/25353.  If that is ever resolved, then we could simplify this by adding the conversion there.