### PR TITLE
FIX: fail in reading xls/xlsx data sources

### DIFF
--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -136,7 +136,12 @@ def read_jsonl(data_fp, df_lib):
 
 
 def read_excel(data_fp, df_lib):
-    return df_lib.read_excel(data_fp)
+    fp_split = os.path.splitext(data_fp)
+    if fp_split[1] == '.xls':
+        excel_engine = 'xlrd'
+    else:
+        excel_engine = 'openpyxl'
+    return df_lib.read_excel(data_fp, engine=excel_engine)
 
 
 def read_parquet(data_fp, df_lib):

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ requests
 
 # new data format support
 xlwt            # excel
-xlrd<2          # excel
+xlrd            # excel
 openpyxl        # excel
 pyarrow         # parquet
 lxml            # html

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -435,7 +435,7 @@ def test_experiment_image_dataset(
 
 
 DATA_FORMATS_TO_TEST = [
-    'csv', 'df', 'dict', 'excel', 'feather', 'fwf', 'hdf5', 'html',
+    'csv', 'df', 'dict', 'excel', 'excel_xls', 'feather', 'fwf', 'hdf5', 'html',
     'json', 'jsonl', 'parquet', 'pickle', 'stata', 'tsv'
 ]
 @pytest.mark.parametrize('data_format', DATA_FORMATS_TO_TEST)

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -540,6 +540,13 @@ def create_data_set_to_use(data_format, raw_data):
             index=False
         )
 
+    elif data_format == 'excel_xls':
+        dataset_to_use = replace_file_extension(raw_data, 'xls')
+        pd.read_csv(raw_data).to_excel(
+            dataset_to_use,
+            index=False
+        )
+
     elif data_format == 'feather':
         dataset_to_use = replace_file_extension(raw_data, 'feather')
         pd.read_csv(raw_data).to_feather(


### PR DESCRIPTION
# Code Pull Requests

Fix #1055 

Dependent package `xlrd` changed the excel formats it supports.  This PR resolves the errors caused by that change.  Other changes in this PR
* update to unit test to test reading both `.xls` and `.xlsx` file formats
* update `requirements.txt` to remove pinning of `xlrd` package.